### PR TITLE
chore(nextjs): skip Vercel builds when only non-nextjs paths change

### DIFF
--- a/nextjs/vercel.json
+++ b/nextjs/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./ ../shared-types/",
   "buildCommand": "npm run db:migrate && npm run validate-appcast && npm run build",
   "installCommand": "npm install",
   "framework": "nextjs",


### PR DESCRIPTION
Now that `main` is shared across `nextjs`, the native apps, and the vendored Fly backend, every commit to `main` triggered a Vercel build even when `nextjs/` didn't change. This adds a `vercel.json` `ignoreCommand` so Vercel only builds when the site's own inputs change.

```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD ./ ../shared-types/"
```

- Vercel runs the command from the project Root Directory (`nextjs/`). Exit 0 → skip build; exit 1 → build.
- `git diff --quiet` exits 0 when the given paths are unchanged (skip) and 1 when they changed (build).
- Watches **`nextjs/`** plus **`../shared-types/`** — the latter is a build-time input via the `@shared-types/*` tsconfig path alias, so a change there must still rebuild.
- Mirrors the `paths:` filter just added to `cloud-deploy-prod.yml` for Fly.

The commit landing this change is itself under `nextjs/`, so it builds; skipping kicks in for subsequent non-`nextjs` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JerjY5Y8CHg9t4X3VGLaqc