### PR TITLE
chore(skills): track localisation-syncer skill in-repo

### DIFF
--- a/.claude/skills/localisation-syncer/SKILL.md
+++ b/.claude/skills/localisation-syncer/SKILL.md
@@ -1,0 +1,452 @@
+---
+name: localisation-syncer
+description: Keep localization files in sync across platforms (macOS, Windows, Next.js website). Compares translations against the source-of-truth for each platform, identifies missing/extra keys, adds native translations, and finds unused keys in the base files.
+context: fork
+model: sonnet
+allowed-tools:
+    - Bash
+    - Read
+    - Edit
+    - Write
+    - Glob
+    - Grep
+---
+
+# Localization Syncer
+
+Keep localization files aligned with their source-of-truth, update translations in a native voice, and prune keys that are no longer referenced in the app code.
+
+## Step 1: Ask What the User Wants to Do
+
+Ask **intent first, then platform**. Use the AskUserQuestion tool for each.
+
+### 1a. Intent
+
+- **Sync missing translations** — a key exists in the base file but some locales don't have it. The `compare_*.py` scripts find them; you add native translations to every locale that's short.
+- **Add new translations for new keys** — you just added a key to the base file and need every locale populated. Same flow as "sync missing" but driven by a known new key.
+- **Find & remove unused keys** — keys exist in the base + locales but no longer appear in the app source. Run `find_unused_keys.py`, review, then `remove_keys.py` to strip them from all 40 files at once.
+
+### 1b. Platform (multiSelect)
+
+- **macOS** — `Localizable.strings` files in `app/macos/hyperwhisper/Localizations/`
+- **Windows** — `.resx` XML files in `app/windows/HyperWhisper/Resources/`
+- **Next.js Website** — JSON message files in `nextjs/messages/`
+
+The rest of this doc has one section per platform with sync workflows, plus a cross-platform "Remove Unused Keys" workflow further down. Jump to the section that matches the user's intent + platform choice.
+
+---
+
+## MANDATORY: Verification Gate Before Reporting Success
+
+**Your success summary MUST be derived from command output you actually ran and quoted in this run — never from your memory of what you intended to write.** This gate is not optional and applies to every platform.
+
+> A previous run reported *"inserted native translations into all 39 locale files… the compare script confirms 0 missing entries"* — but `git status` showed **only the Base file changed**, every locale file was untouched, and the compare script had never been run. The batch `for` loop had silently failed to persist, yet the summary was written from intent. The user had to redo the entire sync by hand. **This must never happen again.**
+
+Before you claim a sync/add is done, run BOTH commands below and **paste their raw output into your summary**:
+
+1. **Prove which files actually changed on disk** (run from repo root):
+   ```bash
+   # macOS:   git status --short app/macos/hyperwhisper/Localizations/
+   # Windows: git status --short app/windows/HyperWhisper/Resources/
+   # Next.js: git status --short nextjs/messages/
+   ```
+   For an add/sync you MUST see a modified (`M`) entry for **every** locale file you claim to have touched. If only one — or a handful — show up, your writes did **not** land. STOP and fix before reporting anything.
+
+2. **Count each added/changed key across ALL target files** — expected count = number of locales **including base** (40 for macOS/Windows):
+   ```bash
+   # macOS example:   grep -rl '"new.key.name"'  app/macos/hyperwhisper/Localizations/ | wc -l   # expect 40
+   # Windows example: grep -rl 'name="NewKey"'    app/windows/HyperWhisper/Resources/ | wc -l    # expect 40
+   ```
+   Then re-run the platform `compare_*.py` script and **quote its actual "0 missing" output** — do not paraphrase it.
+
+### Pass / Fail rule (no middle ground)
+
+- **PASS** only if all three hold AND you quoted them: `git status` shows every claimed file modified, the per-key count equals the locale count, and `compare_*.py` reports 0 missing.
+- **FAIL** otherwise: report **FAILURE**, list the exact files still missing the key (`grep -rL '"key"' <dir>`), and do NOT claim the sync is complete.
+
+### Do NOT (anti-patterns that caused the past failure)
+
+- Do NOT report "added to all N locales" from memory without running `git status` and the grep count this run.
+- Do NOT claim "compare script confirms 0 missing" without pasting the script's real output.
+- Do NOT trust that a batch Python `for` loop worked because it printed `OK:` lines — a heredoc can be sandboxed, skipped, or fail to persist. On-disk `git status` is the only proof a write landed.
+
+---
+
+## Platform: macOS
+
+### Source of Truth
+`app/macos/hyperwhisper/Localizations/Base.lproj/Localizable.strings` (English)
+
+### Locale Files
+**IMPORTANT: There are 39 locale files. You MUST sync ALL of them, not just a subset.**
+
+Discover all locale files dynamically:
+```bash
+ls app/macos/hyperwhisper/Localizations/*.lproj/Localizable.strings
+```
+
+This will return all non-Base locale directories (ar, bg, ca, cs, da, de, el, es, et, fi, fr, he, hi, hr, hu, id, is, it, ja, ko, lt, lv, ms, nb, nl, pl, pt, ro, ru, sk, sl, sr, sv, th, tr, uk, vi, zh-Hans, zh-Hant).
+
+### CRITICAL: File Encoding Rules
+
+**macOS `.strings` files are extremely sensitive to encoding and line endings.**
+
+1. **CRLF Line Endings Required**: All `.strings` files use Windows-style CRLF (`\r\n`) line endings. The `plutil` validator and Xcode's `builtin-copyStrings` will fail with "Unexpected character / at line 1" if this is changed.
+
+2. **NEVER use the Edit tool** on `.strings` files - it converts CRLF to LF and corrupts the file.
+
+3. **NEVER rewrite entire files** - This risks encoding corruption.
+
+4. **Always validate after changes**:
+   ```bash
+   plutil -lint path/to/Localizable.strings
+   ```
+
+5. **Check line endings**:
+   ```bash
+   file path/to/Localizable.strings
+   # Should show: "with CRLF line terminators"
+   ```
+
+### Workflow
+
+#### 1. Find Missing Keys
+
+The compare script auto-discovers all 39 non-Base locale files:
+
+```bash
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/macos/compare_localizable.py
+```
+
+#### 2. Get English Values for Missing Keys
+
+```bash
+cd $(git rev-parse --show-toplevel)/app/macos/hyperwhisper/Localizations
+grep '^"missing.key.name"' Base.lproj/Localizable.strings
+```
+
+#### 3. Add Translations to ALL 39 Locales
+
+**IMPORTANT: You must insert translations into ALL locale files that are missing keys, not just a subset.**
+
+Use this batch Python pattern that inserts a key into all locales at once, preserving CRLF encoding. Build a `translations` dict mapping each locale code to its native translation, then insert after a nearby existing key:
+
+```python
+python3 << 'PYEOF'
+import os
+
+translations = {
+    "ar": "Arabic translation",
+    "bg": "Bulgarian translation",
+    # ... ALL 39 locales ...
+    "zh-Hant": "Traditional Chinese translation",
+}
+
+base_dir = "app/macos/hyperwhisper/Localizations"  # relative to repo root — run this from the repo root
+marker = b'"existing.nearby.key"'
+
+for locale, value in translations.items():
+    filepath = os.path.join(base_dir, f"{locale}.lproj", "Localizable.strings")
+    if not os.path.exists(filepath):
+        print(f"SKIP (not found): {filepath}")
+        continue
+    with open(filepath, 'rb') as f:
+        content = f.read()
+    if b'"new.key.name"' in content:
+        print(f"SKIP (already exists): {locale}")
+        continue
+    idx = content.find(marker)
+    if idx == -1:
+        print(f"SKIP (marker not found): {locale}")
+        continue
+    end_line = content.find(b'\r\n', idx)
+    if end_line == -1:
+        end_line = content.find(b'\n', idx)
+        end_line = end_line + 1 if end_line != -1 else len(content)
+    else:
+        end_line += 2
+    insert_text = f'"new.key.name" = "{value}";\r\n'.encode('utf-8')
+    new_content = content[:end_line] + insert_text + content[end_line:]
+    with open(filepath, 'wb') as f:
+        f.write(new_content)
+    print(f"OK: {locale} -> {value}")
+print("\nDone!")
+PYEOF
+```
+
+For multiple missing keys, repeat the pattern for each key (or nest the key loop inside the locale loop).
+
+Alternatively, for a single locale file, use the insert script:
+```bash
+python3 .claude/skills/localisation-syncer/scripts/macos/insert_translation.py \
+    --file app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings \
+    --after "existing.key.name" \
+    --key "new.key.name" \
+    --value "翻译文本"
+```
+
+#### 4. Validate ALL Files and Re-check
+
+```bash
+# Validate all locale files
+for f in $(git rev-parse --show-toplevel)/app/macos/hyperwhisper/Localizations/*.lproj/Localizable.strings; do
+    result=$(plutil -lint "$f" 2>&1)
+    if ! echo "$result" | grep -q "OK"; then echo "FAIL: $f - $result"; fi
+done
+
+# Verify no locales are missing the key
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/macos/compare_localizable.py
+```
+
+**Then apply the [MANDATORY Verification Gate](#mandatory-verification-gate-before-reporting-success) — quote `git status --short` and the per-key grep count before reporting success.**
+
+---
+
+## Platform: Windows
+
+### Source of Truth
+`app/windows/HyperWhisper/Resources/Strings.resx` (English)
+
+### Locale Files
+**IMPORTANT: There are 39 locale files. You MUST sync ALL of them, not just a subset.**
+
+Discover all locale files dynamically:
+```bash
+ls app/windows/HyperWhisper/Resources/Strings.*.resx
+```
+
+This will return all locale files (ar, bg, ca, cs, da, de, el, es, et, fi, fr, he, hi, hr, hu, id, is, it, ja, ko, lt, lv, ms, nb, nl, pl, pt, ro, ru, sk, sl, sr, sv, th, tr, uk, vi, zh-Hans, zh-Hant).
+
+### File Format
+Windows `.resx` files are XML. Each translatable string is a `<data>` element:
+```xml
+<data name="KeyName" xml:space="preserve">
+  <value>English text</value>
+</data>
+```
+
+### Workflow
+
+#### 1. Find Missing Keys
+
+```bash
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/windows/compare_resx.py
+```
+
+#### 2. Get English Values for Missing Keys
+
+Read the base `Strings.resx` file and find the `<data>` elements for missing keys.
+
+#### 3. Add Translations
+
+**IMPORTANT: You MUST add translations to ALL locale files that are missing keys, not just a subset. The compare script will show issues for every locale file — fix them all.**
+
+Use the Edit tool to add missing `<data>` elements to the locale `.resx` files. Place them in the same order as the base file. The XML format is straightforward and safe to edit directly (no CRLF sensitivity like macOS `.strings`).
+
+To be efficient with many locale files, batch similar edits together and process all files in parallel where possible.
+
+Example insertion:
+```xml
+<data name="NewKey" xml:space="preserve">
+  <value>Translated text</value>
+</data>
+```
+
+#### 4. Re-check
+
+```bash
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/windows/compare_resx.py
+```
+
+**Then apply the [MANDATORY Verification Gate](#mandatory-verification-gate-before-reporting-success) — quote `git status --short` and the per-key grep count before reporting success.**
+
+---
+
+## Platform: Next.js Website
+
+### Source of Truth
+`nextjs/messages/en.json` (English)
+
+### Locale Files
+All other JSON files in `nextjs/messages/` (40+ locales: ar, bg, ca, cs, da, de, el, es, et, fi, fr, he, hi, hr, hu, id, is, it, ja, ko, lt, lv, ms, nb, nl, pl, pt, ro, ru, sk, sl, sr, sv, th, tr, uk, vi, zh, zh-Hant).
+
+### File Format
+Nested JSON objects using next-intl conventions. Keys are dot-separated via nesting:
+```json
+{
+  "section": {
+    "key": "Translated value"
+  }
+}
+```
+
+### CRITICAL: JSON Syntax Rules
+
+**Never use curly quotes in JSON strings.** They break JSON parsing.
+
+| Bad | Good |
+|-----|------|
+| `"下载"` (curly quotes) | `「下载」` (corner brackets) |
+| `"text"` | `「text」` or `'text'` |
+
+Use corner brackets `「」` for Chinese/Japanese or straight quotes `'` for other languages.
+
+### Workflow
+
+#### 1. Find Missing Keys
+
+Check all locales at once:
+
+```bash
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/nextjs/compare_messages.py
+```
+
+Or check specific locales:
+
+```bash
+python3 .claude/skills/localisation-syncer/scripts/nextjs/compare_messages.py --langs nextjs/messages/ja.json nextjs/messages/es.json
+```
+
+#### 2. Add Translations
+
+Use the Edit tool to add missing keys to locale JSON files. Match the nesting structure from `en.json`.
+
+#### 3. Validate JSON and Re-check
+
+```bash
+cd $(git rev-parse --show-toplevel)
+# Validate all JSON files parse correctly
+for f in nextjs/messages/*.json; do python3 -m json.tool "$f" > /dev/null && echo "OK: $f" || echo "FAIL: $f"; done
+
+# Re-run comparison to verify
+python3 .claude/skills/localisation-syncer/scripts/nextjs/compare_messages.py
+```
+
+**Then apply the [MANDATORY Verification Gate](#mandatory-verification-gate-before-reporting-success) — quote `git status --short` and the per-key grep count before reporting success.**
+
+---
+
+## Workflow: Remove Unused Keys (macOS & Windows)
+
+Use this flow when the user says "find unused translations", "prune unused keys", "clean up localizations", or similar.
+
+The flow has three stages: **find → curate → remove**. Never skip curation — the `find` script is conservative but not infallible.
+
+### Stage 1 — Find
+
+Each `find_unused_keys.py` classifies every base-file key into one of three buckets:
+
+- **Used** — the key appears as a literal string (`"key.name"`) somewhere in the source tree.
+- **Maybe-used (dyn)** — the key wasn't found literally, but its prefix matches a string-interpolation site (Swift `"prefix.\(x)"` or C# `$"prefix.{x}"`). The key might be assembled at runtime.
+- **Definitely unused** — no literal match and no dynamic prefix match. Safest removal candidates.
+
+**macOS.** Scans `.swift` under `app/macos/hyperwhisper/`, skipping `Libraries/`, `Pods/`, `.build/`, `build/`, `DerivedData/`.
+
+```bash
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/macos/find_unused_keys.py --json /tmp/mac_unused.json
+```
+
+**Windows.** Scans `.cs` and `.xaml` under `app/windows/HyperWhisper/`, skipping `bin/`, `obj/`, `.vs/`, `packages/`, `Migrations/`, `*.Designer.cs`, `*.g.cs`. Recognises both `Loc.S("key")` (C#) and `{loc:Loc key}` (XAML).
+
+```bash
+cd $(git rev-parse --show-toplevel)
+python3 .claude/skills/localisation-syncer/scripts/windows/find_unused_keys.py --json /tmp/win_unused.json
+```
+
+### Stage 2 — Curate
+
+Extract the `definitely-unused` list into a plain-text file, one key per line:
+
+```bash
+python3 -c "import json,sys; [print(k) for k in json.load(open(sys.argv[1]))['unused']]" /tmp/mac_unused.json > /tmp/mac_to_remove.txt
+python3 -c "import json,sys; [print(k) for k in json.load(open(sys.argv[1]))['unused']]" /tmp/win_unused.json > /tmp/win_to_remove.txt
+```
+
+**Show the list to the user via AskUserQuestion and get explicit confirmation.** Spot-check any suspicious-looking keys with `grep` first (e.g. constants that might be assembled from an enum or referenced from a nib/xib/xaml resource dictionary). Let the user strike out any keys they want to keep — edit the `.txt` file accordingly. The file accepts `#` comments and blank lines, so the user can annotate freely.
+
+### Stage 3 — Remove
+
+The `remove_keys.py` scripts take the curated key list and strip each key from the base file **and every locale file** in one pass. Both scripts support `--dry-run` so you can preview the touch count before committing.
+
+**macOS.** Binary-mode edits that preserve the file's CRLF line endings, validated with `plutil -lint` afterwards:
+
+```bash
+# Preview:
+python3 .claude/skills/localisation-syncer/scripts/macos/remove_keys.py \
+    --keys-file /tmp/mac_to_remove.txt --dry-run
+
+# Commit:
+python3 .claude/skills/localisation-syncer/scripts/macos/remove_keys.py \
+    --keys-file /tmp/mac_to_remove.txt
+```
+
+**Windows.** String-based block removal that preserves the file's indentation and XSD header verbatim, validated by parsing afterwards:
+
+```bash
+python3 .claude/skills/localisation-syncer/scripts/windows/remove_keys.py \
+    --keys-file /tmp/win_to_remove.txt --dry-run
+
+python3 .claude/skills/localisation-syncer/scripts/windows/remove_keys.py \
+    --keys-file /tmp/win_to_remove.txt
+```
+
+Both scripts print a per-locale removal count. Expect `N` (the curated list size) keys removed from all 40 files — if a file is short, the base/locale pair was already out of sync and you should re-run `compare_*.py` to investigate.
+
+### Stage 4 — Verify
+
+```bash
+# macOS: confirm no locale drifted out of sync
+python3 .claude/skills/localisation-syncer/scripts/macos/compare_localizable.py
+
+# Windows: same
+python3 .claude/skills/localisation-syncer/scripts/windows/compare_resx.py
+```
+
+Total issues should be 0. If not, a removal mismatch leaked a key in one locale — investigate before committing.
+
+---
+
+## Translation Requirements (All Platforms)
+
+- Preserve all format tokens (`%@`, `%d`, `%0.2f`, `{variable}`) and spacing.
+- Preserve ellipses and punctuation (`…`, `...`, `:`) exactly as intended.
+- Preserve newlines and list formatting (`\n`, bullets) without reflow.
+- Keep product names and model names unchanged unless already localized in that locale file.
+- Prefer native, natural UI phrasing over literal translation.
+
+## Troubleshooting
+
+### macOS: "Unexpected character / at line 1" Error
+
+This means the file encoding was corrupted. To fix:
+
+1. Check if there's a good version in git:
+   ```bash
+   git log --oneline -5 -- path/to/Localizable.strings
+   git show <commit>:path/to/Localizable.strings > path/to/Localizable.strings
+   plutil -lint path/to/Localizable.strings
+   ```
+
+2. If the file validates, carefully re-add your translations using the binary Python method above.
+
+### macOS: Line Ending Issues
+
+If `file` command shows LF instead of CRLF:
+```bash
+# DO NOT use perl or sed to convert - they may corrupt encoding
+# Instead, restore from git and re-apply changes
+```
+
+## Notes
+
+- Do not rename keys on any platform.
+- Do not delete existing translations unless explicitly requested.
+- Do not use the Edit tool on macOS .strings files.
+- Do not sort or reorder macOS .strings files - this risks corruption.
+- If a locale file is missing entirely, copy the source-of-truth and translate in place.

--- a/.claude/skills/localisation-syncer/scripts/macos/compare_localizable.py
+++ b/.claude/skills/localisation-syncer/scripts/macos/compare_localizable.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+KEY_RE = re.compile(r'^\s*"([^"]+)"\s*=')
+
+
+def parse_keys(path: Path) -> list[str]:
+    keys: list[str] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            match = KEY_RE.match(line)
+            if match:
+                keys.append(match.group(1))
+    return keys
+
+
+def report(label: str, base_keys: list[str], other_keys: list[str]) -> int:
+    base_set = set(base_keys)
+    other_set = set(other_keys)
+    missing = sorted(base_set - other_set)
+    extra = sorted(other_set - base_set)
+
+    print(f"\n[{label}]")
+    print(f"- Base keys: {len(base_set)}")
+    print(f"- {label} keys: {len(other_set)}")
+
+    dupes = [k for k in other_keys if other_keys.count(k) > 1]
+    if dupes:
+        unique_dupes = sorted(set(dupes))
+        print(f"- Duplicate keys: {len(unique_dupes)}")
+        for key in unique_dupes:
+            print(f"  - {key}")
+    else:
+        print("- Duplicate keys: 0")
+
+    if missing:
+        print(f"- Missing keys: {len(missing)}")
+        for key in missing:
+            print(f"  - {key}")
+    else:
+        print("- Missing keys: 0")
+
+    if extra:
+        print(f"- Extra keys: {len(extra)}")
+        for key in extra:
+            print(f"  - {key}")
+    else:
+        print("- Extra keys: 0")
+
+    return len(missing) + len(extra)
+
+
+def discover_locale_files(base_path: Path) -> list[Path]:
+    """Auto-discover all non-Base locale files in the Localizations directory."""
+    loc_dir = base_path.parent.parent  # Go from Base.lproj/ up to Localizations/
+    locale_files = sorted(
+        p
+        for p in loc_dir.glob("*.lproj/Localizable.strings")
+        if p.parent.name != "Base.lproj"
+    )
+    return locale_files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare Localizable.strings keys against Base.lproj"
+    )
+    parser.add_argument(
+        "--base",
+        default="app/macos/hyperwhisper/Localizations/Base.lproj/Localizable.strings",
+    )
+    parser.add_argument(
+        "--langs",
+        nargs="*",
+        help="Locale files to check (default: auto-discover all non-Base locales)",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    base_keys = parse_keys(base_path)
+
+    if not base_keys:
+        print(f"No keys found in base file: {base_path}")
+        return 1
+
+    # Auto-discover all locale files if none specified
+    if args.langs:
+        lang_paths = [Path(p) for p in args.langs]
+    else:
+        lang_paths = discover_locale_files(base_path)
+        if not lang_paths:
+            print("No locale files found!")
+            return 1
+        print(f"Discovered {len(lang_paths)} locale files")
+
+    total_issues = 0
+    for lang_path in lang_paths:
+        label = lang_path.parent.name
+        if not lang_path.exists():
+            print(f"\n[{label}]\n- Missing file: {lang_path}")
+            total_issues += 1
+            continue
+        other_keys = parse_keys(lang_path)
+        total_issues += report(label, base_keys, other_keys)
+
+    print(f"\nTotal issues: {total_issues}")
+    return 0 if total_issues == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/localisation-syncer/scripts/macos/find_unused_keys.py
+++ b/.claude/skills/localisation-syncer/scripts/macos/find_unused_keys.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Find localization keys in the macOS Base.lproj/Localizable.strings that are
+not referenced anywhere in the Swift source tree.
+
+Scans app/macos/hyperwhisper/ for .swift files (excluding Libraries/, which
+contains third-party code like Sentry). For each key, looks for the literal
+string "key.name" in any .swift file. Also identifies keys whose prefix
+matches a string-interpolation site like "foo.bar.\\(mode)" — those are
+flagged as "maybe-used" since they may be assembled at runtime.
+
+Usage:
+    python3 find_unused_keys.py
+    python3 find_unused_keys.py --source-root app/macos/hyperwhisper
+    python3 find_unused_keys.py --json out.json
+
+Exit codes:
+    0 — no definitely-unused keys found
+    2 — definitely-unused keys present (review the report)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+KEY_RE = re.compile(r'^\s*"([^"]+)"\s*=')
+# Matches a string literal that contains interpolation, capturing the
+# static prefix up to the first `\(`. Example: "settings.mode.\(x)" -> "settings.mode."
+INTERP_RE = re.compile(r'"([^"\\]*?)\\\(')
+
+EXCLUDE_DIRS = {"Libraries", "Pods", ".build", "build", "DerivedData"}
+
+
+def parse_keys(path: Path) -> list[str]:
+    keys: list[str] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            m = KEY_RE.match(line)
+            if m:
+                keys.append(m.group(1))
+    return keys
+
+
+def iter_swift_files(root: Path):
+    for p in root.rglob("*.swift"):
+        # Skip excluded directories anywhere in the path
+        if any(part in EXCLUDE_DIRS for part in p.parts):
+            continue
+        yield p
+
+
+def load_sources(root: Path) -> tuple[str, list[str]]:
+    """Return (concatenated-source, list-of-interpolation-prefixes)."""
+    chunks: list[str] = []
+    interp_prefixes: set[str] = set()
+    for path in iter_swift_files(root):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        chunks.append(text)
+        for m in INTERP_RE.finditer(text):
+            prefix = m.group(1)
+            if prefix:
+                interp_prefixes.add(prefix)
+    return "\n".join(chunks), sorted(interp_prefixes)
+
+
+def classify(
+    keys: list[str], haystack: str, interp_prefixes: list[str]
+) -> tuple[list[str], list[tuple[str, str]], list[str]]:
+    used: list[str] = []
+    maybe: list[tuple[str, str]] = []  # (key, matching-prefix)
+    unused: list[str] = []
+
+    for key in keys:
+        literal = f'"{key}"'
+        if literal in haystack:
+            used.append(key)
+            continue
+        match_prefix = None
+        for prefix in interp_prefixes:
+            if key.startswith(prefix):
+                match_prefix = prefix
+                break
+        if match_prefix is not None:
+            maybe.append((key, match_prefix))
+        else:
+            unused.append(key)
+
+    return used, maybe, unused
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find unused localization keys in macOS Base.lproj"
+    )
+    parser.add_argument(
+        "--base",
+        default="app/macos/hyperwhisper/Localizations/Base.lproj/Localizable.strings",
+    )
+    parser.add_argument(
+        "--source-root",
+        default="app/macos/hyperwhisper",
+        help="Root directory to scan for .swift files",
+    )
+    parser.add_argument(
+        "--json",
+        default=None,
+        help="Write the full report as JSON to this path",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    src_root = Path(args.source_root)
+
+    if not base_path.exists():
+        print(f"ERROR: Base file not found: {base_path}")
+        return 1
+    if not src_root.exists():
+        print(f"ERROR: Source root not found: {src_root}")
+        return 1
+
+    keys = parse_keys(base_path)
+    if not keys:
+        print(f"No keys found in base file: {base_path}")
+        return 1
+
+    print(f"Base file: {base_path} ({len(keys)} keys)")
+    print(f"Scanning: {src_root}")
+
+    haystack, interp_prefixes = load_sources(src_root)
+    print(f"Found {len(interp_prefixes)} string-interpolation prefixes")
+
+    used, maybe, unused = classify(keys, haystack, interp_prefixes)
+
+    print()
+    print(f"Used:              {len(used)}")
+    print(f"Maybe-used (dyn):  {len(maybe)}")
+    print(f"Definitely unused: {len(unused)}")
+
+    if maybe:
+        print("\n[maybe-unused — matches an interpolation prefix]")
+        for key, prefix in maybe:
+            print(f'  - {key}   (prefix "{prefix}")')
+
+    if unused:
+        print("\n[definitely-unused — no literal match in source]")
+        for key in unused:
+            print(f"  - {key}")
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    "base": str(base_path),
+                    "source_root": str(src_root),
+                    "total": len(keys),
+                    "used": used,
+                    "maybe_unused": [
+                        {"key": k, "prefix": p} for k, p in maybe
+                    ],
+                    "unused": unused,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        print(f"\nJSON report written to {args.json}")
+
+    return 0 if not unused else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/localisation-syncer/scripts/macos/insert_translation.py
+++ b/.claude/skills/localisation-syncer/scripts/macos/insert_translation.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Safely insert translations into macOS Localizable.strings files.
+
+This script preserves CRLF line endings and UTF-8 encoding, which are
+critical for plutil validation and Xcode builds.
+
+Usage:
+    # Single key insertion
+    python3 insert_translation.py \
+        --file path/to/Localizable.strings \
+        --after "existing.key" \
+        --key "new.key" \
+        --value "translated value"
+
+    # Batch insertion from JSON
+    python3 insert_translation.py \
+        --file path/to/Localizable.strings \
+        --batch translations.json
+
+    # With comment/section header
+    python3 insert_translation.py \
+        --file path/to/Localizable.strings \
+        --after "existing.key" \
+        --key "new.key" \
+        --value "translated value" \
+        --comment "// New Section Header"
+
+JSON batch file format:
+{
+    "after": "existing.key",
+    "translations": [
+        {"key": "new.key1", "value": "value1"},
+        {"key": "new.key2", "value": "value2", "comment": "// Optional comment"}
+    ]
+}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def validate_file(path: Path) -> bool:
+    """Validate .strings file using plutil."""
+    result = subprocess.run(
+        ["plutil", "-lint", str(path)],
+        capture_output=True,
+        text=True
+    )
+    return result.returncode == 0
+
+
+def find_line_end(content: bytes, start: int) -> int:
+    """Find the end of a line (after CRLF or LF)."""
+    crlf = content.find(b'\r\n', start)
+    lf = content.find(b'\n', start)
+
+    if crlf != -1 and (lf == -1 or crlf < lf):
+        return crlf + 2  # Include CRLF
+    elif lf != -1:
+        return lf + 1  # Include LF
+    return len(content)
+
+
+def detect_line_ending(content: bytes) -> bytes:
+    """Detect the line ending style used in the file."""
+    if b'\r\n' in content:
+        return b'\r\n'
+    return b'\n'
+
+
+def escape_for_strings(value: str) -> str:
+    """Escape special characters for .strings file format."""
+    # Escape backslashes first, then quotes
+    value = value.replace('\\', '\\\\')
+    value = value.replace('"', '\\"')
+    return value
+
+
+def insert_translation(
+    file_path: Path,
+    after_key: str,
+    key: str,
+    value: str,
+    comment: str | None = None
+) -> bool:
+    """
+    Insert a translation after a specified key.
+
+    Args:
+        file_path: Path to the .strings file
+        after_key: Key to insert after
+        key: New key to insert
+        value: Translated value
+        comment: Optional comment line to add before the key
+
+    Returns:
+        True if successful, False otherwise
+    """
+    # Read in binary to preserve exact bytes
+    with open(file_path, 'rb') as f:
+        content = f.read()
+
+    # Detect line ending style
+    nl = detect_line_ending(content)
+
+    # Find the marker key
+    marker = f'"{after_key}" = '.encode('utf-8')
+    idx = content.find(marker)
+
+    if idx == -1:
+        print(f"Error: Key '{after_key}' not found in {file_path}", file=sys.stderr)
+        return False
+
+    # Find end of that line
+    end_line = find_line_end(content, idx)
+
+    # Build the insertion text
+    escaped_value = escape_for_strings(value)
+    insert_parts = []
+
+    if comment:
+        insert_parts.append(comment.encode('utf-8'))
+
+    insert_parts.append(f'"{key}" = "{escaped_value}";'.encode('utf-8'))
+
+    insert_text = nl + nl.join(insert_parts)
+
+    # Insert after the marker line
+    new_content = content[:end_line] + insert_text + content[end_line:]
+
+    # Write back in binary
+    with open(file_path, 'wb') as f:
+        f.write(new_content)
+
+    return True
+
+
+def batch_insert(file_path: Path, batch_file: Path) -> bool:
+    """
+    Insert multiple translations from a JSON batch file.
+
+    Args:
+        file_path: Path to the .strings file
+        batch_file: Path to JSON file with translations
+
+    Returns:
+        True if all insertions successful, False otherwise
+    """
+    with open(batch_file, 'r', encoding='utf-8') as f:
+        batch = json.load(f)
+
+    after_key = batch.get('after')
+    translations = batch.get('translations', [])
+
+    if not after_key:
+        print("Error: 'after' key is required in batch file", file=sys.stderr)
+        return False
+
+    if not translations:
+        print("Error: 'translations' array is empty", file=sys.stderr)
+        return False
+
+    # Insert in reverse order so positions stay valid
+    for item in reversed(translations):
+        key = item.get('key')
+        value = item.get('value')
+        comment = item.get('comment')
+
+        if not key or not value:
+            print(f"Error: Missing key or value in translation item", file=sys.stderr)
+            return False
+
+        if not insert_translation(file_path, after_key, key, value, comment):
+            return False
+
+        print(f"  Inserted: {key}")
+
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Safely insert translations into macOS Localizable.strings files"
+    )
+    parser.add_argument(
+        "--file", "-f",
+        required=True,
+        help="Path to the Localizable.strings file"
+    )
+    parser.add_argument(
+        "--after", "-a",
+        help="Key to insert after (required for single insertion)"
+    )
+    parser.add_argument(
+        "--key", "-k",
+        help="New key to insert"
+    )
+    parser.add_argument(
+        "--value", "-v",
+        help="Translated value"
+    )
+    parser.add_argument(
+        "--comment", "-c",
+        help="Optional comment line to add before the key"
+    )
+    parser.add_argument(
+        "--batch", "-b",
+        help="Path to JSON file for batch insertion"
+    )
+    parser.add_argument(
+        "--validate-only",
+        action="store_true",
+        help="Only validate the file, don't modify"
+    )
+
+    args = parser.parse_args()
+    file_path = Path(args.file)
+
+    if not file_path.exists():
+        print(f"Error: File not found: {file_path}", file=sys.stderr)
+        return 1
+
+    # Validate-only mode
+    if args.validate_only:
+        if validate_file(file_path):
+            print(f"OK: {file_path}")
+            return 0
+        else:
+            print(f"INVALID: {file_path}", file=sys.stderr)
+            return 1
+
+    # Validate before modification
+    if not validate_file(file_path):
+        print(f"Error: File is already invalid: {file_path}", file=sys.stderr)
+        print("Restore from git before attempting modifications.", file=sys.stderr)
+        return 1
+
+    # Batch mode
+    if args.batch:
+        batch_path = Path(args.batch)
+        if not batch_path.exists():
+            print(f"Error: Batch file not found: {batch_path}", file=sys.stderr)
+            return 1
+
+        print(f"Batch inserting translations into {file_path}...")
+        if not batch_insert(file_path, batch_path):
+            return 1
+
+    # Single insertion mode
+    elif args.after and args.key and args.value:
+        print(f"Inserting '{args.key}' into {file_path}...")
+        if not insert_translation(
+            file_path,
+            args.after,
+            args.key,
+            args.value,
+            args.comment
+        ):
+            return 1
+        print(f"  Inserted: {args.key}")
+
+    else:
+        print("Error: Provide either --batch or (--after, --key, --value)", file=sys.stderr)
+        parser.print_help()
+        return 1
+
+    # Validate after modification
+    if validate_file(file_path):
+        print(f"Validation: OK")
+        return 0
+    else:
+        print(f"Validation: FAILED - file may be corrupted!", file=sys.stderr)
+        print("Consider restoring from git.", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/localisation-syncer/scripts/macos/remove_keys.py
+++ b/.claude/skills/localisation-syncer/scripts/macos/remove_keys.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""
+Remove a set of localization keys from the macOS Base.lproj/Localizable.strings
+and every non-Base locale file.
+
+.strings files are CRLF-sensitive and Xcode will refuse to copy them if line
+endings get mangled, so this script works in binary mode — it finds each key's
+line, snips it along with its line terminator, and leaves the rest of the file
+byte-identical.
+
+Input: a list of keys, either inline (--keys foo.bar baz.qux) or one-per-line
+in a file (--keys-file /tmp/to_remove.txt). Blank lines and lines starting
+with `#` are ignored.
+
+Usage:
+    python3 remove_keys.py --keys-file /tmp/to_remove.txt
+    python3 remove_keys.py --keys content.placeholder common.save
+    python3 remove_keys.py --keys-file /tmp/to_remove.txt --dry-run
+
+Validates every touched file with `plutil -lint` afterwards. Exits non-zero
+if any file fails validation.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def read_keys(keys_file: Path | None, keys_inline: list[str] | None) -> list[str]:
+    keys: list[str] = []
+    if keys_file is not None:
+        for raw in keys_file.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            keys.append(line)
+    if keys_inline:
+        keys.extend(keys_inline)
+    # Preserve order, dedupe
+    seen = set()
+    unique = []
+    for k in keys:
+        if k not in seen:
+            seen.add(k)
+            unique.append(k)
+    return unique
+
+
+def remove_keys_from_file(path: Path, keys: list[str], dry_run: bool) -> int:
+    """Return number of keys removed from this file."""
+    with path.open("rb") as f:
+        content = f.read()
+
+    removed = 0
+    for key in keys:
+        # Match the whole line starting at a newline (or file start) through
+        # its line terminator. The key is stored as "key.name".
+        # Regex is applied to bytes to preserve encoding.
+        escaped = re.escape(key).encode("utf-8")
+        # Line pattern: start-of-line, optional whitespace, "key", optional
+        # whitespace, =, anything up to the line terminator (CRLF or LF),
+        # consuming the terminator.
+        pattern = re.compile(
+            rb"(?m)^[ \t]*\"" + escaped + rb"\"[ \t]*=[^\r\n]*(?:\r\n|\n|\r)"
+        )
+        new_content, count = pattern.subn(b"", content)
+        if count:
+            removed += count
+            content = new_content
+
+    if removed and not dry_run:
+        with path.open("wb") as f:
+            f.write(content)
+
+    return removed
+
+
+def discover_locale_files(base: Path) -> list[Path]:
+    """Return Base.lproj first, then every other *.lproj/Localizable.strings."""
+    loc_dir = base.parent.parent  # Base.lproj/ -> Localizations/
+    others = sorted(
+        p for p in loc_dir.glob("*.lproj/Localizable.strings") if p != base
+    )
+    return [base] + others
+
+
+def validate_plutil(paths: list[Path]) -> list[Path]:
+    bad: list[Path] = []
+    for p in paths:
+        try:
+            result = subprocess.run(
+                ["plutil", "-lint", str(p)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except FileNotFoundError:
+            print("WARNING: plutil not available; skipping validation")
+            return []
+        if result.returncode != 0 or "OK" not in result.stdout:
+            bad.append(p)
+            print(f"FAIL: {p}\n  {result.stdout.strip()}\n  {result.stderr.strip()}")
+    return bad
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Remove localization keys from macOS Base + all locale files"
+    )
+    parser.add_argument(
+        "--base",
+        default="app/macos/hyperwhisper/Localizations/Base.lproj/Localizable.strings",
+    )
+    parser.add_argument("--keys-file", type=Path, default=None)
+    parser.add_argument("--keys", nargs="*", default=None)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be removed without writing any files",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    if not base_path.exists():
+        print(f"ERROR: Base file not found: {base_path}")
+        return 1
+
+    keys = read_keys(args.keys_file, args.keys)
+    if not keys:
+        print("ERROR: no keys specified. Use --keys-file or --keys.")
+        return 1
+
+    paths = discover_locale_files(base_path)
+    print(f"Removing {len(keys)} key(s) from {len(paths)} file(s)")
+    if args.dry_run:
+        print("(dry run — no files will be written)")
+
+    total_removed = 0
+    touched: list[Path] = []
+    for p in paths:
+        count = remove_keys_from_file(p, keys, dry_run=args.dry_run)
+        if count:
+            touched.append(p)
+            total_removed += count
+            print(f"  {p.parent.name}: -{count}")
+
+    print(f"\nRemoved {total_removed} line(s) across {len(touched)} file(s)")
+
+    if args.dry_run or not touched:
+        return 0
+
+    print("\nValidating with plutil...")
+    bad = validate_plutil(touched)
+    if bad:
+        print(f"\n{len(bad)} file(s) failed plutil validation — inspect before committing")
+        return 2
+    print("All touched files pass plutil -lint")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/localisation-syncer/scripts/nextjs/compare_messages.py
+++ b/.claude/skills/localisation-syncer/scripts/nextjs/compare_messages.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Compare Next.js i18n JSON message files against the English source of truth.
+
+Identifies missing keys, extra keys, and JSON parse errors in each locale.
+Supports nested JSON structures (flattens to dot-separated paths).
+
+Usage:
+    python3 compare_messages.py
+    python3 compare_messages.py --base nextjs/messages/en.json
+    python3 compare_messages.py --base nextjs/messages/en.json --langs nextjs/messages/ja.json
+    python3 compare_messages.py --base nextjs/messages/en.json --all
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def flatten_keys(d: dict, prefix: str = "") -> set[str]:
+    """Recursively flatten nested dict keys into dot-separated paths."""
+    keys: set[str] = set()
+    for k, v in d.items():
+        key = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            keys.update(flatten_keys(v, key))
+        else:
+            keys.add(key)
+    return keys
+
+
+def parse_json_keys(path: Path) -> set[str] | None:
+    """Parse a JSON file and return flattened keys, or None on error."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return flatten_keys(data)
+    except json.JSONDecodeError as e:
+        print(f"  ERROR: Invalid JSON in {path}: {e}")
+        return None
+    except Exception as e:
+        print(f"  ERROR: Failed to read {path}: {e}")
+        return None
+
+
+def report(label: str, base_keys: set[str], other_keys: set[str]) -> int:
+    missing = sorted(base_keys - other_keys)
+    extra = sorted(other_keys - base_keys)
+
+    print(f"\n[{label}]")
+    print(f"- Base keys: {len(base_keys)}")
+    print(f"- {label} keys: {len(other_keys)}")
+
+    if missing:
+        print(f"- Missing keys: {len(missing)}")
+        for key in missing:
+            print(f"  - {key}")
+    else:
+        print("- Missing keys: 0")
+
+    if extra:
+        print(f"- Extra keys: {len(extra)}")
+        for key in extra:
+            print(f"  - {key}")
+    else:
+        print("- Extra keys: 0")
+
+    return len(missing) + len(extra)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare Next.js i18n JSON message files against English"
+    )
+    parser.add_argument(
+        "--base",
+        default="nextjs/messages/en.json",
+    )
+    parser.add_argument(
+        "--langs",
+        nargs="*",
+        help="Specific locale files to check (default: all non-en JSON files)",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Check all locale files in the messages directory",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    if not base_path.exists():
+        print(f"ERROR: Base file not found: {base_path}")
+        return 1
+
+    base_keys = parse_json_keys(base_path)
+    if base_keys is None or not base_keys:
+        print(f"No keys found in base file: {base_path}")
+        return 1
+
+    print(f"Base: {base_path} ({len(base_keys)} keys)")
+
+    # Determine which locale files to check
+    if args.langs:
+        lang_paths = [Path(p) for p in args.langs]
+    else:
+        # Auto-discover all non-en JSON files in the same directory
+        messages_dir = base_path.parent
+        lang_paths = sorted(
+            p for p in messages_dir.glob("*.json")
+            if p.name != base_path.name and p.name != "CLAUDE.md"
+        )
+
+    if not lang_paths:
+        print("No locale files found to compare.")
+        return 0
+
+    total_issues = 0
+    synced_count = 0
+    error_count = 0
+
+    for lang_path in lang_paths:
+        label = lang_path.stem  # e.g., "ja", "zh-Hant"
+        if not lang_path.exists():
+            print(f"\n[{label}]\n- Missing file: {lang_path}")
+            total_issues += 1
+            error_count += 1
+            continue
+
+        other_keys = parse_json_keys(lang_path)
+        if other_keys is None:
+            total_issues += 1
+            error_count += 1
+            continue
+
+        issues = report(label, base_keys, other_keys)
+        total_issues += issues
+        if issues == 0:
+            synced_count += 1
+
+    print(f"\n{'=' * 40}")
+    print(f"Total locales checked: {len(lang_paths)}")
+    print(f"In sync: {synced_count}")
+    print(f"With issues: {len(lang_paths) - synced_count - error_count}")
+    if error_count:
+        print(f"Errors: {error_count}")
+    print(f"Total issues: {total_issues}")
+    return 0 if total_issues == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/localisation-syncer/scripts/windows/compare_resx.py
+++ b/.claude/skills/localisation-syncer/scripts/windows/compare_resx.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Compare Windows .resx localization files against the base English file.
+
+Identifies missing keys, extra keys, and duplicate keys in each locale.
+
+Usage:
+    python3 compare_resx.py
+    python3 compare_resx.py --base path/to/Strings.resx --langs path/to/Strings.ja.resx
+"""
+from __future__ import annotations
+
+import argparse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_resx_keys(path: Path) -> list[str]:
+    """Extract all data keys from a .resx file, preserving order and duplicates."""
+    keys: list[str] = []
+    try:
+        tree = ET.parse(path)
+        root = tree.getroot()
+        for data in root.findall("data"):
+            name = data.get("name")
+            if name:
+                keys.append(name)
+    except ET.ParseError as e:
+        print(f"  ERROR: Failed to parse {path}: {e}")
+    return keys
+
+
+def report(label: str, base_keys: list[str], other_keys: list[str]) -> int:
+    base_set = set(base_keys)
+    other_set = set(other_keys)
+    missing = sorted(base_set - other_set)
+    extra = sorted(other_set - base_set)
+
+    print(f"\n[{label}]")
+    print(f"- Base keys: {len(base_set)}")
+    print(f"- {label} keys: {len(other_set)}")
+
+    dupes = [k for k in other_keys if other_keys.count(k) > 1]
+    if dupes:
+        unique_dupes = sorted(set(dupes))
+        print(f"- Duplicate keys: {len(unique_dupes)}")
+        for key in unique_dupes:
+            print(f"  - {key}")
+    else:
+        print("- Duplicate keys: 0")
+
+    if missing:
+        print(f"- Missing keys: {len(missing)}")
+        for key in missing:
+            print(f"  - {key}")
+    else:
+        print("- Missing keys: 0")
+
+    if extra:
+        print(f"- Extra keys: {len(extra)}")
+        for key in extra:
+            print(f"  - {key}")
+    else:
+        print("- Extra keys: 0")
+
+    return len(missing) + len(extra)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compare Windows .resx localization files against the base"
+    )
+    parser.add_argument(
+        "--base",
+        default="app/windows/HyperWhisper/Resources/Strings.resx",
+    )
+    parser.add_argument(
+        "--langs",
+        nargs="*",
+        default=None,
+        help="Locale files to check. If omitted, auto-discovers all Strings.*.resx files.",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    if not base_path.exists():
+        print(f"ERROR: Base file not found: {base_path}")
+        return 1
+
+    base_keys = parse_resx_keys(base_path)
+    if not base_keys:
+        print(f"No keys found in base file: {base_path}")
+        return 1
+
+    # Auto-discover all locale files if none specified
+    lang_paths = args.langs
+    if lang_paths is None:
+        resource_dir = base_path.parent
+        lang_paths = sorted(
+            str(p) for p in resource_dir.glob("Strings.*.resx")
+        )
+        if not lang_paths:
+            print(f"No locale files found in {resource_dir}")
+            return 1
+
+    print(f"Base: {base_path} ({len(set(base_keys))} keys)")
+    print(f"Checking {len(lang_paths)} locale file(s)")
+
+    total_issues = 0
+    for lang_path_str in lang_paths:
+        lang_path = Path(lang_path_str)
+        # Extract locale from filename: Strings.ja.resx -> ja
+        label = lang_path.stem.replace("Strings.", "").replace("Strings", "base")
+        if not lang_path.exists():
+            print(f"\n[{label}]\n- Missing file: {lang_path}")
+            total_issues += 1
+            continue
+        other_keys = parse_resx_keys(lang_path)
+        total_issues += report(label, base_keys, other_keys)
+
+    print(f"\nTotal issues: {total_issues}")
+    return 0 if total_issues == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/localisation-syncer/scripts/windows/find_unused_keys.py
+++ b/.claude/skills/localisation-syncer/scripts/windows/find_unused_keys.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Find localization keys in the Windows base Strings.resx that are not
+referenced anywhere in the source tree.
+
+HyperWhisper Windows uses a `Loc` helper (Localization/Loc.cs) that looks
+up strings by their literal dotted key at runtime:
+    C#:   Loc.S("sidebar.home")
+    XAML: {loc:Loc sidebar.home}
+
+So we scan every .cs / .xaml under app/windows/HyperWhisper/ and look for
+each key in two forms:
+    1. As a double-quoted literal:  "sidebar.home"
+    2. As a bare XAML token after  `loc:Loc ` / `Loc `:  sidebar.home
+
+Keys whose prefix matches a C# interpolated string of the form $"foo.{x}"
+are flagged "maybe-used" rather than unused.
+
+Usage:
+    python3 find_unused_keys.py
+    python3 find_unused_keys.py --source-root app/windows/HyperWhisper
+    python3 find_unused_keys.py --json out.json
+
+Exit codes:
+    0 — no definitely-unused keys found
+    2 — definitely-unused keys present (review the report)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# $"prefix.{arg}" or $"prefix.{arg}.suffix"
+CSHARP_INTERP_RE = re.compile(r'\$"([^"{}\\]*?)\{')
+# {loc:Loc key.name} or {loc:Loc key.name, ...}
+XAML_LOC_RE = re.compile(r"\{(?:loc:)?Loc\s+([^\s,}]+)")
+
+EXCLUDE_DIRS = {"bin", "obj", ".vs", "packages", "Migrations"}
+
+
+def parse_resx_keys(path: Path) -> list[str]:
+    keys: list[str] = []
+    tree = ET.parse(path)
+    root = tree.getroot()
+    for data in root.findall("data"):
+        name = data.get("name")
+        if name:
+            keys.append(name)
+    return keys
+
+
+def iter_source_files(root: Path):
+    for pattern in ("*.cs", "*.xaml"):
+        for p in root.rglob(pattern):
+            if any(part in EXCLUDE_DIRS for part in p.parts):
+                continue
+            # Skip auto-generated designer files — they only reflect the resx,
+            # not actual usage.
+            if p.name.endswith(".Designer.cs") or p.name.endswith(".g.cs"):
+                continue
+            yield p
+
+
+def load_sources(root: Path):
+    chunks: list[str] = []
+    interp_prefixes: set[str] = set()
+    xaml_loc_keys: set[str] = set()
+
+    for path in iter_source_files(root):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        chunks.append(text)
+        if path.suffix == ".cs":
+            for m in CSHARP_INTERP_RE.finditer(text):
+                prefix = m.group(1)
+                if prefix:
+                    interp_prefixes.add(prefix)
+        elif path.suffix == ".xaml":
+            for m in XAML_LOC_RE.finditer(text):
+                xaml_loc_keys.add(m.group(1).strip())
+
+    return "\n".join(chunks), sorted(interp_prefixes), xaml_loc_keys
+
+
+def classify(
+    keys: list[str],
+    haystack: str,
+    interp_prefixes: list[str],
+    xaml_loc_keys: set[str],
+):
+    used: list[str] = []
+    maybe: list[tuple[str, str]] = []
+    unused: list[str] = []
+
+    for key in keys:
+        if f'"{key}"' in haystack or key in xaml_loc_keys:
+            used.append(key)
+            continue
+        match_prefix = None
+        for prefix in interp_prefixes:
+            if key.startswith(prefix):
+                match_prefix = prefix
+                break
+        if match_prefix is not None:
+            maybe.append((key, match_prefix))
+        else:
+            unused.append(key)
+
+    return used, maybe, unused
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find unused localization keys in Windows Strings.resx"
+    )
+    parser.add_argument(
+        "--base",
+        default="app/windows/HyperWhisper/Resources/Strings.resx",
+    )
+    parser.add_argument(
+        "--source-root",
+        default="app/windows/HyperWhisper",
+        help="Root directory to scan for .cs and .xaml files",
+    )
+    parser.add_argument(
+        "--json",
+        default=None,
+        help="Write the full report as JSON to this path",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    src_root = Path(args.source_root)
+
+    if not base_path.exists():
+        print(f"ERROR: Base file not found: {base_path}")
+        return 1
+    if not src_root.exists():
+        print(f"ERROR: Source root not found: {src_root}")
+        return 1
+
+    keys = parse_resx_keys(base_path)
+    if not keys:
+        print(f"No keys found in base file: {base_path}")
+        return 1
+
+    print(f"Base file: {base_path} ({len(keys)} keys)")
+    print(f"Scanning: {src_root}")
+
+    haystack, interp_prefixes, xaml_loc_keys = load_sources(src_root)
+    print(
+        f"Found {len(interp_prefixes)} C# interp prefixes, "
+        f"{len(xaml_loc_keys)} XAML {{loc:Loc ...}} references"
+    )
+
+    used, maybe, unused = classify(keys, haystack, interp_prefixes, xaml_loc_keys)
+
+    print()
+    print(f"Used:              {len(used)}")
+    print(f"Maybe-used (dyn):  {len(maybe)}")
+    print(f"Definitely unused: {len(unused)}")
+
+    if maybe:
+        print("\n[maybe-unused — matches a C# interpolation prefix]")
+        for key, prefix in maybe:
+            print(f'  - {key}   (prefix "{prefix}")')
+
+    if unused:
+        print("\n[definitely-unused — no literal match in source]")
+        for key in unused:
+            print(f"  - {key}")
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps(
+                {
+                    "base": str(base_path),
+                    "source_root": str(src_root),
+                    "total": len(keys),
+                    "used": used,
+                    "maybe_unused": [
+                        {"key": k, "prefix": p} for k, p in maybe
+                    ],
+                    "unused": unused,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        print(f"\nJSON report written to {args.json}")
+
+    return 0 if not unused else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/localisation-syncer/scripts/windows/remove_keys.py
+++ b/.claude/skills/localisation-syncer/scripts/windows/remove_keys.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Remove a set of localization keys from the Windows base Strings.resx and
+every Strings.<locale>.resx file.
+
+Each key is stored as a multi-line `<data name="KEY" xml:space="preserve">
+  <value>…</value>
+</data>` block. This script snips the whole block (including the trailing
+newline) in-place, leaving the rest of the file byte-identical. The parser
+is intentionally string-based rather than DOM-based so indentation, comments,
+the XSD header, and blank lines between blocks are preserved exactly.
+
+Input: a list of keys, either inline (--keys foo.bar baz.qux) or one-per-line
+in a file (--keys-file /tmp/to_remove.txt). Blank lines and lines starting
+with `#` are ignored.
+
+Usage:
+    python3 remove_keys.py --keys-file /tmp/to_remove.txt
+    python3 remove_keys.py --keys common.remove common.close
+    python3 remove_keys.py --keys-file /tmp/to_remove.txt --dry-run
+
+Validates every touched file with `xml.etree.ElementTree.parse` afterwards.
+Exits non-zero if any file fails to parse.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def read_keys(keys_file: Path | None, keys_inline: list[str] | None) -> list[str]:
+    keys: list[str] = []
+    if keys_file is not None:
+        for raw in keys_file.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            keys.append(line)
+    if keys_inline:
+        keys.extend(keys_inline)
+    seen = set()
+    unique = []
+    for k in keys:
+        if k not in seen:
+            seen.add(k)
+            unique.append(k)
+    return unique
+
+
+def remove_keys_from_file(path: Path, keys: list[str], dry_run: bool) -> int:
+    # Read and write in binary mode so CRLF line endings are preserved byte
+    # for byte — Python text mode applies universal-newlines translation
+    # (CRLF -> LF on read, LF-only on write), which would rewrite every line
+    # in the file and cause a massive spurious diff.
+    with path.open("rb") as f:
+        content = f.read()
+
+    removed = 0
+    for key in keys:
+        escaped = re.escape(key).encode("utf-8")
+        # Pattern: optional indent, <data name="KEY" ...>...</data>, trailing
+        # line terminator (CRLF, LF, or bare CR). The `.*?` under DOTALL may
+        # match across lines, but the non-greedy quantifier + the explicit
+        # </data> closer prevents it from devouring multiple blocks.
+        pattern = re.compile(
+            rb"[ \t]*<data\s+name=\"" + escaped + rb"\"[^>]*>.*?</data>[ \t]*(?:\r\n|\n|\r)",
+            re.DOTALL,
+        )
+        new_content, count = pattern.subn(b"", content)
+        if count:
+            removed += count
+            content = new_content
+
+    if removed and not dry_run:
+        with path.open("wb") as f:
+            f.write(content)
+    return removed
+
+
+def discover_locale_files(base: Path) -> list[Path]:
+    """Return base Strings.resx first, then every Strings.*.resx."""
+    res_dir = base.parent
+    others = sorted(p for p in res_dir.glob("Strings.*.resx") if p != base)
+    return [base] + others
+
+
+def validate_xml(paths: list[Path]) -> list[Path]:
+    bad: list[Path] = []
+    for p in paths:
+        try:
+            ET.parse(p)
+        except ET.ParseError as e:
+            bad.append(p)
+            print(f"FAIL: {p}\n  {e}")
+    return bad
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Remove localization keys from Windows Strings.resx + all locales"
+    )
+    parser.add_argument(
+        "--base",
+        default="app/windows/HyperWhisper/Resources/Strings.resx",
+    )
+    parser.add_argument("--keys-file", type=Path, default=None)
+    parser.add_argument("--keys", nargs="*", default=None)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would be removed without writing any files",
+    )
+    args = parser.parse_args()
+
+    base_path = Path(args.base)
+    if not base_path.exists():
+        print(f"ERROR: Base file not found: {base_path}")
+        return 1
+
+    keys = read_keys(args.keys_file, args.keys)
+    if not keys:
+        print("ERROR: no keys specified. Use --keys-file or --keys.")
+        return 1
+
+    paths = discover_locale_files(base_path)
+    print(f"Removing {len(keys)} key(s) from {len(paths)} file(s)")
+    if args.dry_run:
+        print("(dry run — no files will be written)")
+
+    total_removed = 0
+    touched: list[Path] = []
+    for p in paths:
+        count = remove_keys_from_file(p, keys, dry_run=args.dry_run)
+        if count:
+            touched.append(p)
+            total_removed += count
+            label = p.stem.replace("Strings.", "")
+            if label == "Strings":
+                label = "base"
+            print(f"  {label}: -{count}")
+
+    print(f"\nRemoved {total_removed} block(s) across {len(touched)} file(s)")
+
+    if args.dry_run or not touched:
+        return 0
+
+    print("\nValidating XML...")
+    bad = validate_xml(touched)
+    if bad:
+        print(f"\n{len(bad)} file(s) failed XML parsing — inspect before committing")
+        return 2
+    print("All touched files parse as valid XML")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,10 @@ notes/
 tasks/
 app/ios/
 # Local agent tooling & internal-only skills/worktrees — never part of the public repo
-.claude/
+# ...except .claude/skills/, which holds repo-shareable skills that ship with the project.
+.claude/*
+!.claude/skills/
+.claude/skills/**/.env
 .codex/
 .context/
 **/.vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **This is the PUBLIC, open-source repository** (`ray-amjad/hyperwhisper-app`, Apache-2.0, world-readable). Everything committed here is public forever.
 > - **Never** commit secrets, API keys, license keys, signing keys, customer data, personal paths/emails, or internal infra/business details. Secrets live in **Infisical only** (see the secrets note below) — it syncs to GitHub Actions / Vercel / Fly.
-> - Internal-only material stays **out**: `.claude/`, `.codex/`, `app/ios/`, `tasks/`, `notes/`, `plans/` are gitignored — keep them that way.
+> - Internal-only material stays **out**: `.claude/`, `.codex/`, `app/ios/`, `tasks/`, `notes/`, `plans/` are gitignored — keep them that way. **Exception:** `.claude/skills/` **is** tracked (repo-shareable skills ship with the project). Since it's public, treat everything under `.claude/skills/` like any other committed file: **no secrets, API keys, tokens, or personal paths** in a skill's `SKILL.md` or scripts. `.env` files inside skills stay gitignored — put secrets there (or in Infisical), never inline.
 > - HyperWhisper Cloud is the paid moat: entitlement is **enforced server-side**. Never add a client-side bypass, fake/test license key, or debug backdoor.
 
 HyperWhisper — macOS / Windows / iOS speech-to-text app with a Fly.io transcription backend, Next.js marketing site, and Mintlify docs.


### PR DESCRIPTION
Un-ignore `.claude/skills/` so repo-shareable Claude skills ship with the project, and add the **localisation-syncer** skill.

## What changed
- **`.gitignore`** — `.claude/` stays ignored, but `.claude/skills/` is now tracked. `.env` files inside skills remain ignored.
- **`.claude/skills/localisation-syncer/`** — skill that syncs localization files across macOS (`.strings`), Windows (`.resx`), and the Next.js site (`messages/*.json`), with compare/insert/remove scripts and a mandatory on-disk verification gate.
- **`AGENTS.md`** — documents the `.claude/skills/` exception and the rule that **no secrets/tokens/personal paths** may live in a skill (public repo); secrets go in gitignored `.env` or Infisical.

## Public-repo safety
- Personal absolute paths (`/Users/ray/...`) sanitised to `git rev-parse --show-toplevel` / repo-relative — verified no personal paths remain.
- Scripts contain no secrets; they use repo-relative defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)