### PR TITLE
Windows: single source of truth for the credits purchase URL

### DIFF
--- a/app/windows/HyperWhisper/Services/LicenseManager.cs
+++ b/app/windows/HyperWhisper/Services/LicenseManager.cs
@@ -339,6 +339,19 @@ public sealed class LicenseManager : INotifyPropertyChanged
         return (DeviceIdService.Instance.GetDeviceId(), false);
     }
 
+    /// <summary>
+    /// Builds the identifier-aware credits purchase URL — the same `/credits`
+    /// destination as <see cref="OpenPurchasePage()"/>, tagged with the caller's
+    /// license key (licensed) or device ID (guest) so the buy is attributed to the
+    /// right wallet. Single source of truth for the credits URL.
+    /// </summary>
+    public string GetCreditsPurchaseUrl()
+    {
+        var (identifier, isLicensed) = GetTranscriptionIdentifier();
+        var paramName = isLicensed ? "license_key" : "device_id";
+        return $"{PurchaseUrl}?{paramName}={Uri.EscapeDataString(identifier)}";
+    }
+
     // =========================================================================
     // EXTERNAL LINKS
     // =========================================================================

--- a/app/windows/HyperWhisper/Views/Pages/Settings/CloudAccountSettingsPage.xaml.cs
+++ b/app/windows/HyperWhisper/Views/Pages/Settings/CloudAccountSettingsPage.xaml.cs
@@ -321,11 +321,9 @@ public partial class CloudAccountSettingsPage : Page
 
     private void CreditsAddCredits_Click(object sender, RoutedEventArgs e)
     {
-        var (identifier, isLicensed) = LicenseManager.Instance.GetTranscriptionIdentifier();
-        var paramName = isLicensed ? "license_key" : "device_id";
-        var url = $"https://www.hyperwhisper.com/credits?{paramName}={Uri.EscapeDataString(identifier)}";
+        var url = LicenseManager.Instance.GetCreditsPurchaseUrl();
 
-        LoggingService.Info($"CloudAccountSettingsPage: Opening credits purchase page (licensed: {isLicensed})");
+        LoggingService.Info("CloudAccountSettingsPage: Opening credits purchase page");
 
         try
         {


### PR DESCRIPTION
Follow-up cleanup from the code review of the unified HyperWhisper Cloud panel (#14).

## Problem
`CreditsAddCredits_Click` hardcoded `https://www.hyperwhisper.com/credits` while `LicenseManager.PurchaseUrl` already held the canonical value — two sources of truth. A future domain/path change (exactly the `/checkout` → `/credits` move that PR made) would update the constant but silently leave the Purchase/Get-Credits CTA pointing at the old URL.

## Fix
Add `LicenseManager.GetCreditsPurchaseUrl()` — one identifier-aware builder derived from `PurchaseUrl` — and route the handler through it, dropping the duplicated base URL and the `license_key`/`device_id` param logic. Behavior-identical.

⚠️ WPF/.NET 10 is Windows-only — not build-verified on the macOS box. Straight method-extraction + call-site swap, so risk is low; the real gate is a Windows/CI `dotnet build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)