### PR TITLE
chore(release): PR-merge release workflow + track macos-release skill

### DIFF
--- a/.claude/skills/macos-release/SKILL.md
+++ b/.claude/skills/macos-release/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: macos-release
+description: "macOS release workflow — generates user-facing release notes from git history, then triggers the macos-release.yml GitHub Action to build, sign, notarize, and publish. Use when the user wants to cut a new macOS version, bump the macOS version, release a specific version like '2.41.0', or generate/update the appcast."
+allowed-tools:
+    - Bash
+    - Read
+    - Edit
+    - Grep
+model: sonnet
+---
+
+# macOS Release Workflow
+
+Cutting a macOS release is a single GitHub Actions dispatch. The `macos-release.yml`
+workflow does all the heavy lifting; this skill's job is to feed it good inputs
+(version, build number, release notes) and watch it to completion.
+
+## When to Use This Skill
+
+- "release macOS", "new macOS version", "cut a macOS release"
+- "release 2.41.0" (or any version), "bump the macOS version"
+- "generate the appcast" / "update the appcast"
+
+## What the Workflow Does (so you don't have to)
+
+Everything below happens inside the Action — **do not do any of it by hand**:
+
+1. Bumps `MARKETING_VERSION` + `CURRENT_PROJECT_VERSION` in `project.pbxproj`
+2. Builds (`xcodebuild archive`), uploads dSYMs to Sentry
+3. Exports with Developer ID signing, creates a DMG
+4. Codesigns → notarizes → staples the DMG
+5. Sparkle Ed25519-signs the DMG
+6. Prepends a new entry to `nextjs/public/appcast.xml`
+7. Uploads the DMG to Cloudflare R2 (`builds.hyperwhisper.com`)
+8. Commits the version bump + appcast and lands them on `main` via an
+   auto-merged PR (the `main` ruleset requires PRs, so it can't push directly)
+9. Creates a published GitHub Release tagged `macos/vX.Y.Z` with the DMG attached
+
+You never bump the version, edit the appcast, or commit before dispatching.
+
+## Prerequisites
+
+- `gh` CLI authenticated (`gh auth status`)
+- On `main`, up to date (`git pull`)
+- No existing `macos/vX.Y.Z` tag for the target version
+- Secrets are already configured (see [references/setup-guide.md](references/setup-guide.md)) —
+  if the run fails on a missing-secret error, that guide explains what's needed.
+
+## Instructions
+
+### Step 1 — Version + build number
+
+```bash
+grep -E "MARKETING_VERSION|CURRENT_PROJECT_VERSION" app/macos/hyperwhisper.xcodeproj/project.pbxproj | head -4
+```
+
+- **Build number**: always the current one **+ 1**.
+- **Version**: whatever the user asked for, else bump patch/minor from current.
+
+### Step 2 — Release notes (appcast HTML)
+
+The workflow injects `release_notes` straight into the appcast `<description>` that
+users see in Sparkle's "What's New" dialog, so this is the one part that needs care.
+
+```bash
+# Previous macOS release tag, then macOS-only commits since then
+git tag -l "macos/*" | sort -V | tail -1
+git log <LAST_TAG>..HEAD --oneline --no-merges -- app/macos/
+```
+
+Format as HTML `<li>` items (no wrapping `<ul>` — the workflow adds it). Full rules,
+examples, and an anti-jargon checklist live in
+[references/content-guide.md](references/content-guide.md) and
+[references/style-guide.md](references/style-guide.md). The essentials:
+
+- **3–7 bullets**, ranked by user impact — lead with the most exciting change (new
+  model, big perf win, redesign), end with bug fixes. Never lead with a fix.
+- Write for regular users: what changed *for them*, not how it was built. No internal
+  mechanism names (SSE, URLSession, Core Data, "cold-start tax", etc.).
+- Combine related commits into one bullet; skip refactors, CI, docs, version bumps.
+- If a commit adds a **new model, provider, major feature, or significant perf change**,
+  it *must* appear — auto-generated notes have under-sold releases by dropping exactly
+  these in favor of generic reliability bullets. Don't repeat that.
+- If only backend/website/docs changed, use `<li>Bug fixes and improvements</li>`.
+
+### Step 3 — GitHub release notes (markdown)
+
+Separately, draft a structured markdown body for the GitHub release (`github_release_body`).
+Same tone as the appcast; omit empty sections:
+
+```markdown
+# Highlights
+- **Feature Name**: the single most impactful change
+
+# Features & Improvements
+- ...
+
+# Bug Fixes
+- ...
+```
+
+### Step 4 — Confirm with the user
+
+Show them, and ask before dispatching:
+- Version X.Y.Z (build NN)
+- The appcast `<li>` notes
+- The GitHub markdown notes
+
+### Step 5 — Dispatch
+
+Pre-flight, then run the workflow:
+
+```bash
+git branch --show-current            # must be "main"
+git tag --list "macos/v$VERSION"     # must be empty
+gh auth status
+
+gh workflow run macos-release.yml \
+  -f version="X.Y.Z" \
+  -f build_number="NN" \
+  -f release_notes="<li>Change 1</li><li>Change 2</li>" \
+  -f github_release_body="# Highlights
+- **Feature**: Description
+
+# Bug Fixes
+- Fixed something" \
+  -f skip_upload=false
+```
+
+Dry-run (build + sign + notarize, but no R2 upload and no appcast push) — set
+`skip_upload=true`. Useful to validate a green build without shipping.
+
+### Step 6 — Monitor to completion
+
+Always watch the run and report the outcome — don't just hand over a link.
+
+```bash
+sleep 5 && gh run list --workflow=macos-release.yml --limit=1 --json databaseId,status,createdAt
+gh run watch <RUN_ID> --exit-status   # blocks; non-zero exit on failure
+```
+
+Provide the Actions URL too (resolve the repo dynamically so this skill stays portable):
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)   # e.g. ray-amjad/hyperwhisper-app
+echo "https://github.com/$REPO/actions/runs/<RUN_ID>"
+```
+
+### Step 7 — Report + after-release reminders
+
+On success, tell the user and remind them to:
+1. `git pull` — the Action pushed a commit (version bump + appcast).
+2. Verify the appcast is live: `https://www.hyperwhisper.com/appcast.xml`.
+3. Confirm the published GitHub Release has the DMG attached.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `create-dmg` exits 2 | Normal ("no custom icon set"). The workflow tolerates it. |
+| Notarization auth error | App-specific password expired — regenerate at account.apple.com and update the secret in Infisical. |
+| Ed25519 signing fails | Workflow tries Sparkle's `sign_update`, then a CryptoKit fallback. If both fail, the `SPARKLE_ED25519_PRIVATE_KEY` secret is missing/wrong. |
+| PR merge fails at the end | The workflow lands its commit via an auto-merged PR (0 approvals required on `main`). It retries 5×; if it still fails, check the PR it opened (`release/macos-vX.Y.Z`) and merge it manually. |
+| Fails on a missing secret | See [references/setup-guide.md](references/setup-guide.md); secrets are managed in Infisical. |
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/macos-release.yml` | The release Action (does everything) |
+| `app/macos/hyperwhisper.xcodeproj/project.pbxproj` | Current version (read-only here) |
+| `nextjs/public/appcast.xml` | Sparkle update feed (written by the Action) |
+| `app/macos/ExportOptions.plist` | Developer ID export settings (Team ID injected from a secret at build time) |

--- a/.claude/skills/macos-release/references/content-guide.md
+++ b/.claude/skills/macos-release/references/content-guide.md
@@ -1,0 +1,339 @@
+# Content Selection Guide
+
+How to choose which changes to include in appcast descriptions.
+
+## ⚠️ CRITICAL: macOS App Changes ONLY
+
+**This appcast is for macOS app users.** They do NOT care about:
+- Backend/cloud changes (backend-v1-cloudflare/, backend-v2-flyio/)
+- Website changes (nextjs/)
+- Database changes (drizzle migrations)
+- Documentation or skills (.claude/, *.md)
+
+**ALWAYS filter git commits to `app/macos/` directory only:**
+```bash
+git log PREV_VERSION..HEAD --oneline --no-merges -- app/macos/
+```
+
+If the only changes are backend/website, use a generic description like "Bug fixes and improvements" rather than listing irrelevant backend changes.
+
+## Overview
+
+Appcast descriptions appear in update notifications shown to users. They must be:
+- **Concise**: 4-6 bullet points maximum
+- **User-focused**: Only changes users will notice
+- **Scannable**: Quick to read and understand
+- **Compelling**: Give users a reason to update
+
+## Selection Criteria
+
+### Priority 1: New Features
+Major new capabilities that expand functionality.
+
+**Include**:
+- ✅ New transcription providers
+- ✅ New major features (auto-volume, media control)
+- ✅ New UI sections or workflows
+
+**Skip**:
+- ❌ Minor UI additions (new button, new label)
+- ❌ Developer-only features
+
+**Example**:
+```
+- New Preview Features settings with opt-in Developer Mode toggle
+```
+
+### Priority 2: Major Improvements
+Significant enhancements to existing features.
+
+**Include**:
+- ✅ Performance improvements with measurable impact
+- ✅ UX improvements users will notice
+- ✅ Quality improvements (better accuracy, reliability)
+
+**Skip**:
+- ❌ Internal refactoring
+- ❌ Code quality improvements
+- ❌ Minor spacing/layout tweaks
+
+**Example**:
+```
+- Increased responsiveness from all API and cloud providers
+```
+
+### Priority 3: Important Bug Fixes
+Fixes for issues that affected users.
+
+**Include**:
+- ✅ Crash fixes
+- ✅ Fixes for common bugs
+- ✅ Data loss prevention
+
+**Skip**:
+- ❌ Rare edge case fixes
+- ❌ Developer-only bug fixes
+- ❌ Fixes for unreleased features
+
+**Example**:
+```
+- Fixed transcript editing textarea
+```
+
+### Priority 4: Credit/Trial Changes
+Changes to credit system or trial limitations.
+
+**Include**:
+- ✅ Credit increases
+- ✅ New trial features
+- ✅ Pricing changes
+
+**Example**:
+```
+- Increased trial credits from 100 to 150 (~24 minutes)
+```
+
+## How Many to Include?
+
+**Target: 4-6 bullet points**
+
+### Small Release (1-2 key changes)
+Use 2-3 bullets, focus on the most important:
+
+```xml
+<b>Improved Design</b>
+<ul>
+    <li>New Preview Features settings with opt-in Developer Mode toggle</li>
+    <li>Standardized UI headers and improved spacing consistency across all views</li>
+</ul>
+```
+
+### Medium Release (3-5 key changes)
+Use 4-5 bullets:
+
+```xml
+<b>Error Handling and Transcription Improvements</b>
+<ul>
+    <li>Non-activating error toast notifications for improved visibility when app is minimized</li>
+    <li>Retry functionality for failed audio transcriptions with easy recovery</li>
+    <li>Fixed transcript editing textarea</li>
+    <li>Fixed Push to Talk toggle behavior to prevent accidental recording cancellation</li>
+</ul>
+```
+
+### Large Release (6+ key changes)
+Use 6 bullets, choose highest impact:
+
+```xml
+<b>New Providers and Audio Improvements</b>
+<ul>
+    <li>Added Mistral Voxtral Mini and ElevenLabs Scribe v2 transcription providers</li>
+    <li>Enhanced Parakeet model support with V2 and language badges</li>
+    <li>Media control dropdown with pause/resume for media players</li>
+    <li>Auto-increase microphone volume during recording</li>
+    <li>Faster recording startup by removing health checks</li>
+    <li>Improved error handling and microphone selection persistence</li>
+</ul>
+```
+
+## Decision Matrix
+
+Use this to decide what to include:
+
+| Change Type | User-Visible? | High Impact? | Include? |
+|-------------|---------------|--------------|----------|
+| New transcription provider | Yes | Yes | ✅ Yes |
+| Major performance improvement | Yes | Yes | ✅ Yes |
+| New UI feature | Yes | Yes | ✅ Yes |
+| Important bug fix | Yes | Yes | ✅ Yes |
+| Minor UI tweak | Yes | No | ⚠️ Maybe |
+| Internal refactoring | No | No | ❌ No |
+| Dependency update | No | No | ❌ No |
+| Code quality improvement | No | No | ❌ No |
+
+## Combining Related Changes
+
+Sometimes multiple changes should be combined into one bullet:
+
+### Example 1: Multiple Provider Updates
+**Individual changes**:
+- Added Mistral Voxtral Mini
+- Added ElevenLabs Scribe v2
+- Added Parakeet V2
+
+**Combined**:
+```
+- Added Mistral Voxtral Mini, ElevenLabs Scribe v2, and Parakeet V2 transcription options
+```
+
+### Example 2: UI Consistency Updates
+**Individual changes**:
+- Standardized headers
+- Improved spacing
+- Better alignment
+
+**Combined**:
+```
+- Standardized UI headers and improved spacing consistency across all views
+```
+
+## Sourcing Changes
+
+### From GitHub Release Notes
+
+If release notes exist, use the **Highlights** section as your primary source:
+
+1. Read highlights section
+2. Extract 4-6 most important items
+3. Condense each to one sentence
+4. Maintain user-facing language
+
+**Example mapping**:
+
+**Highlight**:
+> **Faster Recording Startup**: Removed provider health checks that could delay recording by up to 60 seconds. Provider errors now surface during transcription instead of blocking the recording button, making HyperWhisper feel instantly responsive.
+
+**Appcast bullet**:
+```
+- Faster recording startup by removing health checks that could delay up to 60 seconds
+```
+
+### From Git Commits (Primary Method)
+
+Auto-generate descriptions from commit history between version tags:
+
+**Step 1: Find previous version**
+```bash
+git tag -l | sort -V | grep -B1 "^VERSION$" | head -1
+```
+
+**Step 2: Get commits**
+```bash
+git log PREV_VERSION..VERSION --oneline --no-merges
+```
+
+**Step 3: Filter commits by path**
+
+Only include commits affecting app code:
+```bash
+git log PREV_VERSION..VERSION --oneline --no-merges -- "*.swift" "app/"
+```
+
+Exclude commits only touching:
+- `nextjs/` - Website changes
+- `backend-v1-cloudflare/` - Backend changes (v1)
+- `backend-v2-flyio/` - Backend changes (v2)
+- `.claude/` - Skill/documentation
+- `*.md` - Documentation
+
+**Step 4: Categorize by commit message prefix**
+
+| Prefix | Category | Priority |
+|--------|----------|----------|
+| Add, Implement, Introduce | New Feature | 1 |
+| Improve, Update, Enhance | Enhancement | 2 |
+| Fix, Resolve, Correct | Bug Fix | 3 |
+| Refactor, Clean, Optimize | Technical | 4 (skip unless major) |
+
+**Step 5: Group and summarize**
+
+1. Identify user-facing changes
+2. Group related commits (e.g., multiple "Add custom endpoint" commits → one bullet)
+3. Focus on New Features and Enhancements
+4. Create 4-6 bullet points
+
+### From User Input
+
+If user provides changes:
+
+1. Take their list as starting point
+2. Expand or condense as needed
+3. Make language user-friendly
+4. Organize by importance
+
+## Examples by Release Type
+
+### Feature Release
+Focus on new capabilities:
+
+```xml
+<b>New Features and Audio Enhancements</b>
+<ul>
+    <li>Added Mistral Voxtral Mini transcription provider with 8-language support</li>
+    <li>Media control dropdown with pause/resume for Spotify and Apple Music</li>
+    <li>Auto-increase microphone volume during recording</li>
+    <li>Enhanced Parakeet model support with V2 and language badges</li>
+</ul>
+```
+
+### Performance Release
+Emphasize speed and responsiveness:
+
+```xml
+<b>Performance Optimizations and Improvements</b>
+<ul>
+    <li>Faster recording startup by removing provider health checks</li>
+    <li>Increased responsiveness from all API and cloud providers</li>
+    <li>Improved audio processing with intelligent fallback conversion</li>
+</ul>
+```
+
+### Bug Fix Release
+Highlight reliability improvements:
+
+```xml
+<b>Stability and Bug Fixes</b>
+<ul>
+    <li>Fixed app crashes on macOS 26.1 for button handlers</li>
+    <li>Resolved race condition in background validation</li>
+    <li>Improved error handling and recovery</li>
+</ul>
+```
+
+### Mixed Release
+Balance across categories:
+
+```xml
+<b>New Features and Stability Improvements</b>
+<ul>
+    <li>New Preview Features settings with Developer Mode toggle</li>
+    <li>Standardized UI headers across all views</li>
+    <li>Improved error handling and logging</li>
+    <li>Fixed transcript editing textarea</li>
+</ul>
+```
+
+## What to Always Skip
+
+Never include in appcast descriptions:
+
+- Version number bumps
+- Merge commits
+- Internal code refactoring
+- Dependency updates (unless user-facing)
+- Documentation changes
+- Build system changes
+- Test additions
+- Comment updates
+- Typo fixes in code
+
+## Testing Your Selection
+
+Before finalizing, ask:
+
+1. **Would this make me want to update?** If not, reconsider choices
+2. **Can I understand each point in 3 seconds?** If not, simplify
+3. **Are all points user-facing?** If not, remove technical items
+4. **Is anything critical missing?** If yes, add it
+5. **Is anything redundant?** If yes, combine or remove
+
+## Final Checklist
+
+- [ ] 4-6 bullet points (not more, not less)
+- [ ] All points are user-facing
+- [ ] Most important changes included
+- [ ] Technical details removed
+- [ ] Related changes combined
+- [ ] Clear, concise language
+- [ ] No duplicate information
+- [ ] Compelling reasons to update

--- a/.claude/skills/macos-release/references/setup-guide.md
+++ b/.claude/skills/macos-release/references/setup-guide.md
@@ -1,0 +1,40 @@
+# macOS Release Workflow — Setup Guide
+
+The `macos-release.yml` Action reads its credentials from **GitHub Actions
+Production-environment secrets**. This repo is public, so **no secret values live
+here** — they are managed in **Infisical**, which syncs them out to the GitHub
+`Production` environment (and Vercel / Fly for other services). Rotate or add a
+secret **in Infisical only**; editing GitHub directly gets overwritten on the next
+sync. The `macos-release` job declares `environment: Production` so it can read them.
+
+If a run fails with a missing-secret or auth error, this table tells you which
+secret is involved. To fix, update it in Infisical and re-run.
+
+## Secrets the workflow uses
+
+| Secret | What it's for |
+|--------|---------------|
+| `DEVELOPER_ID_P12_BASE64` | Base64 of the "Developer ID Application" cert + private key (.p12), used to codesign the app and DMG. |
+| `DEVELOPER_ID_P12_PASSWORD` | Password protecting that .p12. |
+| `PROVISIONING_PROFILE_BASE64` | Base64 provisioning profile — required for the CloudKit entitlement. |
+| `PROVISIONING_PROFILE_UUID` | UUID the profile is installed under. |
+| `APPLE_ID` | Apple ID email used for notarization. |
+| `APP_SPECIFIC_PASSWORD` | App-specific password for `notarytool`. **These expire** — regenerate at account.apple.com if notarization fails with an auth error. |
+| `APPLE_TEAM_ID` | Apple Developer Team ID. Injected into `ExportOptions.plist` at build time (the plist ships with a `YOUR_TEAM_ID` placeholder so the real ID stays out of source). |
+| `SENTRY_DSN` | Crash-reporting DSN, substituted into `Info.plist`. Empty for forks → crash reporting simply disabled. |
+| `SENTRY_AUTH_TOKEN` | Uploads dSYMs to Sentry. Regenerate under Sentry → Settings → Auth Tokens. |
+| `SPARKLE_ED25519_PRIVATE_KEY` | Ed25519 seed that signs the DMG for Sparkle auto-update. **Never regenerate** — the matching public key is baked into the shipped app's `SUPublicEDKey`, so rotating it breaks auto-update for every existing user. |
+| `CLOUDFLARE_ACCOUNT_ID` | R2 account for the DMG upload. |
+| `CLOUDFLARE_R2_ACCESS_KEY_ID` | R2 API token — access key. |
+| `CLOUDFLARE_R2_SECRET_ACCESS_KEY` | R2 API token — secret key. |
+| `R2_BUCKET_NAME` | R2 bucket backing `builds.hyperwhisper.com`. |
+
+## Notes
+
+- **Sparkle key is the one you must never touch.** Everything else can be rotated;
+  regenerating the Sparkle Ed25519 key orphans every installed copy from updates.
+- The workflow imports the cert into a throwaway keychain and deletes it on exit, and
+  injects the Team ID into `ExportOptions.plist` at runtime — so neither the cert nor
+  the Team ID is ever committed.
+- Verifying setup without shipping: dispatch with `-f skip_upload=true`. It builds,
+  signs, and notarizes but skips the R2 upload and appcast push.

--- a/.claude/skills/macos-release/references/style-guide.md
+++ b/.claude/skills/macos-release/references/style-guide.md
@@ -1,0 +1,388 @@
+# Appcast Description Style Guide
+
+Writing style and language guidelines for appcast descriptions.
+
+## Core Principles
+
+1. **Ultra-Concise**: Users scan update notifications quickly
+2. **User-Focused**: Only include changes users will notice
+3. **Clear Value**: Make it obvious why they should update
+4. **Professional**: Maintain credibility without being stuffy
+5. **Scannable**: Each bullet should be graspable in 3 seconds
+
+## Tone and Voice
+
+### Professional but Approachable
+**Goal**: Sound helpful and informative, not corporate or salesy.
+
+✅ Good:
+```
+- Fixed app crashes on macOS 26.1 for button handlers
+```
+
+❌ Too formal:
+```
+- Resolved critical system-level failures affecting button handler subsystems on macOS version 26.1
+```
+
+❌ Too casual:
+```
+- We squashed those annoying crashes! No more problems on macOS 26.1 :)
+```
+
+### Direct and Specific
+**Goal**: Get to the point immediately with concrete details.
+
+✅ Good:
+```
+- Increased trial credits from 100 to 150 (~24 minutes of transcription)
+```
+
+❌ Too vague:
+```
+- Improved trial experience
+```
+
+❌ Too wordy:
+```
+- We're excited to announce that we've increased the number of trial credits available to new users from the previous limit of 100 credits up to a new generous limit of 150 credits
+```
+
+## Language Patterns
+
+### Starting Phrases
+
+**Use these action verbs**:
+- Added, Introduced, Implemented (for new features)
+- Improved, Enhanced, Optimized (for improvements)
+- Fixed, Resolved, Corrected (for bug fixes)
+- Increased, Decreased, Updated (for changes)
+
+**Good examples**:
+```
+- Added Mistral Voxtral Mini transcription provider
+- Improved microphone selection persistence
+- Fixed race condition in background validation
+- Increased device credits to 150
+```
+
+**Avoid these**:
+- ❌ "Now you can..." (unnecessary words)
+- ❌ "We've added..." (focus on feature, not "we")
+- ❌ "Introducing..." (too marketing-y)
+- ❌ "This release includes..." (obvious from context)
+
+### Sentence Structure
+
+**Pattern**: `[Action] [Feature/Component] [Key Detail]`
+
+✅ Good:
+```
+- Media control dropdown with pause/resume for media players
+```
+- **Action**: (implied "Added")
+- **Feature**: Media control dropdown
+- **Key Detail**: with pause/resume for media players
+
+✅ Good:
+```
+- Faster recording startup by removing health checks
+```
+- **Action**: (implied "Made")
+- **Feature**: recording startup
+- **Key Detail**: by removing health checks
+
+### Length Guidelines
+
+**Target**: 10-15 words per bullet
+
+✅ Good (12 words):
+```
+- New Preview Features settings with opt-in Developer Mode toggle
+```
+
+✅ Good (10 words):
+```
+- Fixed app crashes on macOS 26.1 for button handlers
+```
+
+❌ Too short (3 words):
+```
+- Fixed bugs
+```
+(Not specific enough)
+
+❌ Too long (28 words):
+```
+- Added a new Preview Features settings section that allows users to opt-in to Developer Mode which provides access to advanced features and experimental functionality currently under development
+```
+(Should be: "New Preview Features settings with opt-in Developer Mode toggle")
+
+## Specificity Guidelines
+
+### Include Concrete Details
+
+**Version numbers**:
+```
+✅ Added ElevenLabs Scribe v2 transcription provider
+✅ Enhanced Parakeet model support with V2 and language badges
+```
+
+**Numbers**:
+```
+✅ Increased trial credits from 100 to 150 (~24 minutes)
+✅ Faster recording startup by removing 60-second health checks
+```
+
+**Names and Brands**:
+```
+✅ Media pause/resume for Spotify and Apple Music
+✅ Added Mistral Voxtral Mini with 8-language support
+```
+
+### Avoid Vague Language
+
+❌ Vague:
+```
+- Made improvements to the UI
+- Enhanced performance
+- Fixed various issues
+- Updated some components
+```
+
+✅ Specific:
+```
+- Standardized UI headers and improved spacing consistency
+- Faster recording startup by removing health checks
+- Fixed transcript editing textarea and Push to Talk toggle
+- Updated to ElevenLabs Scribe v2 with improved quality
+```
+
+## Technical vs. User-Facing Language
+
+### Convert Technical to User-Friendly
+
+| Technical | User-Friendly |
+|-----------|---------------|
+| "Implemented Swift Atomics for continuation safety" | Skip (too technical) |
+| "Refactored audio engine architecture" | "Improved audio recording reliability" |
+| "Added MediaRemoteAdapter package" | "Media pause/resume for Spotify and Apple Music" |
+| "Fixed race condition in async validation" | "Fixed validation timing issues" |
+| "Optimized Core Data fetch requests" | "Faster app performance" |
+
+### When to Use Technical Terms
+
+**Use technical terms when**:
+- They're widely known: "API", "UI", "macOS"
+- They're product-specific: "Push to Talk", "Developer Mode"
+- There's no simpler alternative
+
+**Avoid technical terms when**:
+- Users won't understand them
+- A simpler phrase exists
+- They don't add value
+
+✅ Good (appropriate technical terms):
+```
+- Fixed app crashes on macOS 26.1 for button handlers
+- Improved API response times across all providers
+- Enhanced UI consistency across all views
+```
+
+❌ Too technical:
+```
+- Fixed race condition in AVAudioEngine initialization callback
+- Optimized network request dispatch queue
+- Refactored ViewModel observers using Combine framework
+```
+
+## Common Patterns by Change Type
+
+### New Features
+**Pattern**: `[Feature Name] with [Key Capability]`
+
+```
+- Media control dropdown with pause/resume for media players
+- Auto-increase microphone volume during recording
+- New Preview Features settings with Developer Mode toggle
+```
+
+### Improvements
+**Pattern**: `[Improved Aspect] [Specific Benefit]`
+
+```
+- Faster recording startup by removing health checks
+- Improved spacing consistency across all views
+- Better error handling with user-friendly messages
+```
+
+### Bug Fixes
+**Pattern**: `Fixed [Problem] [Location/Context]`
+
+```
+- Fixed app crashes on macOS 26.1
+- Fixed transcript editing textarea
+- Resolved race condition in background validation
+```
+
+### Provider/Integration Updates
+**Pattern**: `[Provider Name] [Version/Capability]`
+
+```
+- Added Mistral Voxtral Mini with 8-language support
+- Updated to ElevenLabs Scribe v2 for improved quality
+- Enhanced Parakeet model support with V2 option
+```
+
+## Numbers and Statistics
+
+### When to Include Numbers
+Include numbers that add meaningful context:
+
+✅ Good uses:
+```
+- Increased trial credits from 100 to 150 (~24 minutes)
+- Faster recording startup by removing 60-second health checks
+- Added 8-language support with Mistral provider
+```
+
+### When to Skip Numbers
+Skip numbers that don't add value:
+
+❌ Not helpful:
+```
+- Fixed 3 bugs in audio system
+- Updated 15 UI components
+- Improved performance by 0.03 seconds
+```
+
+Better without numbers:
+```
+- Fixed audio system bugs
+- Improved UI consistency
+- Faster performance
+```
+
+## Capitalization
+
+### Title Case for Headings
+```
+<b>New Features and Stability Improvements</b>
+<b>Enhanced UI and Clipboard Management</b>
+<b>Performance Optimizations and Bug Fixes</b>
+```
+
+### Sentence case for Bullets
+```
+- New Preview Features settings with opt-in Developer Mode toggle
+- Added Mistral Voxtral Mini transcription provider
+- Fixed app crashes on macOS 26.1
+```
+
+### Proper Nouns
+Always capitalize:
+- Product names: "Mistral Voxtral Mini", "ElevenLabs Scribe v2"
+- Features: "Developer Mode", "Preview Features", "Push to Talk"
+- Platforms: "macOS", "Spotify", "Apple Music"
+- Acronyms: "UI", "API", "UX"
+
+## Punctuation
+
+### No Periods on Single Sentences
+```
+✅ No period:
+- Added new transcription provider
+
+❌ With period:
+- Added new transcription provider.
+```
+
+### Periods on Multiple Sentences (Rare)
+```
+✅ Use periods for multiple sentences:
+- Fixed critical bug in audio engine. This prevents crashes on older hardware.
+```
+
+**However**: Try to combine into one sentence when possible:
+```
+Better:
+- Fixed audio engine bug that caused crashes on older hardware
+```
+
+## Examples by Quality Level
+
+### Excellent Descriptions
+
+**v2.10.1**:
+```xml
+<b>Improved Design</b>
+<ul>
+    <li>New Preview Features settings with opt-in Developer Mode toggle</li>
+    <li>Standardized UI headers and improved spacing consistency across all views</li>
+</ul>
+```
+
+**Why excellent**:
+- Clear, specific heading
+- 2 concise bullets covering key changes
+- User-facing language
+- Concrete details
+
+**v2.10**:
+```xml
+<b>Faster API Processing and Optional M4A</b>
+<ul>
+    <li>Increased responsiveness from all API and cloud providers</li>
+    <li>Intelligent WAV fallback conversion when M4A compression fails, ensuring transcription success</li>
+    <li>Settings for automatic WAV to M4A compression after transcription to reduce storage usage</li>
+</ul>
+```
+
+**Why excellent**:
+- Specific, benefit-focused heading
+- Each bullet describes a clear value
+- Technical details relevant to users
+- Shows how features work together
+
+### Poor Descriptions (to avoid)
+
+❌ **Too vague**:
+```xml
+<b>Updates</b>
+<ul>
+    <li>Made improvements</li>
+    <li>Fixed bugs</li>
+    <li>Enhanced features</li>
+</ul>
+```
+
+❌ **Too technical**:
+```xml
+<b>Code Refactoring</b>
+<ul>
+    <li>Implemented MVVM architecture pattern</li>
+    <li>Refactored dependency injection container</li>
+    <li>Updated to Swift Concurrency with async/await</li>
+</ul>
+```
+
+❌ **Too marketing-y**:
+```xml
+<b>Amazing New Features!</b>
+<ul>
+    <li>We're thrilled to introduce revolutionary new capabilities!</li>
+    <li>The best update ever with game-changing improvements!</li>
+    <li>You're going to love these incredible enhancements!</li>
+</ul>
+```
+
+## Final Quality Check
+
+Before finalizing any description, ask:
+
+1. **Is every word necessary?** Remove fluff
+2. **Would I understand this as a user?** Avoid jargon
+3. **Can I scan it in 10 seconds?** Keep it brief
+4. **Does it make me want to update?** Show clear value
+5. **Is it professional?** No excessive enthusiasm or formality
+6. **Are details concrete?** Be specific, not vague

--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -550,29 +550,54 @@ jobs:
           echo "Upload complete: https://builds.hyperwhisper.com/$KEY"
 
       # ----------------------------------------------------------------
-      # 17. Commit and push version bump + appcast
+      # 17. Commit version bump + appcast, then open & merge a release PR
       # ----------------------------------------------------------------
-      - name: Commit and push changes
+      # The default branch is protected by a ruleset that requires changes to
+      # go through a pull request (0 approvals). A direct push from the release
+      # bot is rejected, so we land the commit via an auto-merged PR instead —
+      # rule-compliant and requires no ruleset bypass or human review.
+      - name: Commit and merge release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
           VERSION="${{ inputs.version }}"
+          BUILD="${{ inputs.build_number }}"
+          BASE="${GITHUB_REF_NAME}"
+          BRANCH="release/macos-v${VERSION}"
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add app/macos/hyperwhisper.xcodeproj/project.pbxproj
-          git add nextjs/public/appcast.xml
+
+          # Fresh branch off the base (clear any stale branch from a failed run)
+          git push origin --delete "$BRANCH" 2>/dev/null || true
+          git checkout -b "$BRANCH"
+          git add app/macos/hyperwhisper.xcodeproj/project.pbxproj nextjs/public/appcast.xml
           git commit -m "release: macOS v${VERSION} — bump version and update appcast"
+          git push -u origin "$BRANCH"
+
+          gh pr create --base "$BASE" --head "$BRANCH" \
+            --title "release: macOS v${VERSION} — version bump + appcast" \
+            --body "Automated release commit from macos-release.yml (build ${BUILD})."
+
+          # Merge with a short retry — a brand-new PR can take a moment to
+          # report as mergeable.
           for i in 1 2 3 4 5; do
-            if git pull --rebase --autostash origin "${GITHUB_REF_NAME}" && git push; then
+            if gh pr merge "$BRANCH" --squash --delete-branch; then
               break
             fi
-
             if [ "$i" = 5 ]; then
-              echo "git push failed after 5 attempts"
+              echo "PR merge failed after 5 attempts"
               exit 1
             fi
-
-            echo "push attempt $i failed, retrying after fetch/rebase..."
+            echo "merge attempt $i failed, retrying..."
             sleep 5
           done
+
+          # Ensure the release step below tags the merged commit on the base.
+          git fetch origin "$BASE"
+          git checkout "$BASE"
+          git reset --hard "origin/$BASE"
 
       # ----------------------------------------------------------------
       # 18. Create draft GitHub Release


### PR DESCRIPTION
Makes future macOS releases self-complete without failing on the Protect Main ruleset, and checks in the sanitized release skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)