### PR TITLE
docs: add trademark & brand-assets carve-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ Apache License 2.0 — see [`LICENSE`](./LICENSE). The code for everything,
 including the backend, is covered by this license. The hosted **HyperWhisper
 Cloud** *service* — our managed instance and prepaid credits — is a separate paid
 offering, even though its backend source is included here under the same license.
+
+The **"HyperWhisper" name, logo, and app icon are not covered by the Apache
+license** — see [`TRADEMARKS.md`](./TRADEMARKS.md). You can fork and ship the
+code, but under your own name and branding, not as the official HyperWhisper.

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,52 @@
+# Trademarks & Brand Assets
+
+The **source code** in this repository is licensed under the Apache License 2.0
+(see [`LICENSE`](./LICENSE)). **This trademark notice is not a license to the
+Apache-licensed code — it is a separate statement about names and brand assets,
+which the code license does not grant rights to.**
+
+## What is *not* covered by the Apache 2.0 license
+
+The following are **not** licensed under Apache 2.0 and remain the property of
+Ray Amjad LTD. Nothing in the code license grants any right to use them:
+
+- The names **"HyperWhisper"** and **"HyperWhisper Cloud"**, and any
+  confusingly similar names.
+- The HyperWhisper **logo, wordmark, and app icon**, and any variations.
+- Product **screenshots, marketing copy, and website imagery**.
+- The **`hyperwhisper.com`** domain and associated online identities.
+
+Apache License 2.0 §6 expressly does **not** grant trademark rights. This file
+makes the boundary explicit: you get the code, not the brand.
+
+## What you may do
+
+- **Use, modify, and redistribute the source code** under the terms of the
+  Apache License 2.0.
+- **Refer to HyperWhisper** in truthful, descriptive ways — e.g. "compatible
+  with HyperWhisper", "a fork of HyperWhisper", "based on the HyperWhisper
+  source code" — provided you do not imply endorsement or official affiliation.
+
+## What you may not do
+
+- **Ship a fork or derivative under the "HyperWhisper" name** or a confusingly
+  similar name, or using the HyperWhisper logo or app icon.
+- **Publish to any app store, marketplace, or website** in a way that suggests
+  your build is the official HyperWhisper app or is affiliated with, endorsed
+  by, or sponsored by Ray Amjad.
+- **Use the brand assets** in a way that could cause confusion about the source
+  or official status of a product.
+
+**If you fork this project and distribute it, you must use your own name,
+logo, and app icon, and must not present it as the official HyperWhisper.**
+
+## Registration
+
+"HyperWhisper" is used as an unregistered trademark (™). Unregistered status
+does not waive any rights; common-law and statutory protections against
+passing off and confusion still apply.
+
+## Questions
+
+For permission to use HyperWhisper names or brand assets beyond what is
+described above, contact Ray Amjad LTD.


### PR DESCRIPTION
## What

Adds `TRADEMARKS.md` and links it from the README.

Apache 2.0 (§6) explicitly does **not** grant trademark rights, but it's silent on the app name, logo, and icon — leaving forks in a grey zone. This file makes the boundary explicit:

- **Code** stays Apache 2.0.
- **"HyperWhisper" / "HyperWhisper Cloud" names, logo, and app icon** remain the property of Ray Amjad LTD and are *not* licensed.
- Forks may ship the code, but must **rebrand** and not imply they're the official app.

## Why

Standard permissive-code / reserved-brand pattern (Firefox, Rust, Kubernetes do the same). Protects the brand while keeping the code fully open — stops a confusing "HyperWhisper" clone without restricting legitimate forks.

## Notes

- Nominative use ("a fork of HyperWhisper") is explicitly permitted — that's fair use anyway.
- One known-and-accepted tension: the app icon lives inside the Apache-licensed tree; the carve-out excludes it from the grant (same approach as Firefox). Can be hardened later by moving brand assets to a labeled `brand/` folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsEyuJSJaTbT4EuUJw9vrX