### PR TITLE
internal: $10 bundle grant + granted-emails endpoint for ACS credit perk

### DIFF
--- a/nextjs/app/api/internal/granted-emails/route.ts
+++ b/nextjs/app/api/internal/granted-emails/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from "next/server";
+import { timingSafeEqualSecret } from "@/lib/security/timing-safe-secret";
+import { getGrantedEmails } from "@/src/lib/db-layer";
+
+/**
+ * Internal bulk read: returns every distinct normalized email that holds at
+ * least one granted Account Key. Powers the ACS admin backfill, which marks
+ * those members as having already claimed their credit perk. Read-only; no
+ * mutation. Same x-internal-secret gate (timing-safe, 401 on bad secret) as the
+ * other internal routes.
+ */
+export async function POST(request: NextRequest) {
+  const secret = request.headers.get("x-internal-secret");
+  if (!timingSafeEqualSecret(secret, process.env.HYPERWHISPER_INTERNAL_SECRET)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const emails = await getGrantedEmails();
+    return NextResponse.json({ emails });
+  } catch (error) {
+    console.error("Error in granted-emails:", error);
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/nextjs/app/api/internal/licenses-for-email/route.ts
+++ b/nextjs/app/api/internal/licenses-for-email/route.ts
@@ -3,7 +3,6 @@ import { timingSafeEqualSecret } from "@/lib/security/timing-safe-secret";
 import {
   getAccountKeysByEmail,
   getCreditBalancesForUsers,
-  provisionAccountKeyForEmail,
 } from "@/src/lib/db-layer";
 
 export async function POST(request: NextRequest) {
@@ -26,15 +25,10 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    // Mint only when the email has *zero* keys of any status. A revoked-only
-    // email is intentionally not re-minted (closes the refund-then-regrant gap):
-    // it returns an empty list rather than a fresh free key.
-    let all = await getAccountKeysByEmail(email);
-    if (all.length === 0) {
-      // The freshly minted row is granted with the full 5,000-credit bundle, so
-      // use it directly instead of issuing a second read for the same row.
-      all = [await provisionAccountKeyForEmail(email)];
-    }
+    // Read-only: this endpoint never mints. An email with no granted key simply
+    // returns an empty list. (Minting happens only via grant-license, driven by
+    // the ACS claim flow — so nothing here can accidentally create a key.)
+    const all = await getAccountKeysByEmail(email);
 
     // Display only active keys; revoked keys are hidden. Credits are pooled per
     // account, so resolve balances by the keys' distinct owning users; each key

--- a/nextjs/src/lib/db-layer.ts
+++ b/nextjs/src/lib/db-layer.ts
@@ -204,6 +204,21 @@ export async function getAllAccountKeysForAdmin(limit = 1000): Promise<AccountKe
   return rows.map(drizzleAccountKeyToRow);
 }
 
+/**
+ * Distinct normalized emails that hold at least one *granted* Account Key (from
+ * the internal bundle or a paid purchase). Powers the ACS admin backfill, which
+ * reconciles its claim flag against emails that already have a key. Read-only.
+ */
+export async function getGrantedEmails(): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ email: accountKeys.email })
+    .from(accountKeys)
+    .where(eq(accountKeys.status, "granted"));
+  return rows
+    .map((r) => r.email.toLowerCase().trim())
+    .filter((email) => email.length > 0);
+}
+
 export async function searchAccountKeysByEmail(
   email: string,
   limit = 1000
@@ -217,15 +232,20 @@ export async function searchAccountKeysByEmail(
   return attachPooledCredits(licenses);
 }
 
+// Credits granted with each internal-bundle Account Key mint. $10 at the
+// 1000-credits-per-dollar rate. This is the ACS member perk; only brand-new
+// emails receive it (an email that already has a granted key gets no top-up).
+const INTERNAL_BUNDLE_CREDITS = 10000;
+
 /**
  * Mint a fresh internal-bundle license for an email: generate a collision-free
  * key, ensure the user exists, insert the license as "granted", and grant the
- * standard 5,000-credit internal bundle.
+ * standard 10,000-credit ($10) internal bundle.
  *
- * This is the single source of truth for the internal mint flow shared by the
- * grant-license and licenses-for-email endpoints. Callers decide *whether* to
- * mint (e.g. only when no license exists); this just performs the mint and
- * returns the new row. Throws on any failure.
+ * This is the single source of truth for the internal mint flow. Its only
+ * caller is the grant-license endpoint (driven by the ACS claim flow), which
+ * mints only when the email has no granted key. licenses-for-email is read-only
+ * and never mints. Throws on any failure.
  */
 export async function provisionAccountKeyForEmail(email: string): Promise<AccountKeyRow> {
   const normalizedEmail = email.toLowerCase().trim();
@@ -259,7 +279,7 @@ export async function provisionAccountKeyForEmail(email: string): Promise<Accoun
 
   await grantCreditLot({
     userId: license.userId,
-    amount: 5000,
+    amount: INTERNAL_BUNDLE_CREDITS,
     sourceType: "internal_bundle",
     sourceId: license.id,
   });


### PR DESCRIPTION
Backend support for the ACS "**\$10 in HyperWhisper Cloud credits**" member perk (paired ACS PR: ray-amjad/agentic-coding-school#587).

## Changes
- **Grant \$5 → \$10.** `provisionAccountKeyForEmail` now uses `INTERNAL_BUNDLE_CREDITS = 10000` (extracted constant); docstrings updated. This is the internal-bundle mint used only by `grant-license` — no Stripe path calls it, so the bump is safe. Idempotent: an email that already has a granted key gets the same key back with no top-up (only brand-new emails receive the \$10).
- **New `POST /api/internal/granted-emails`.** `x-internal-secret` gated (timing-safe, 401 on bad secret), read-only. Returns `{ emails: string[] }` — distinct normalized emails holding any *granted* Account Key. Powers the ACS admin backfill that reconciles its claim flag against members who already have a key from the old auto-mint era.
- **`licenses-for-email` hardened to read-only.** Dropped the auto-mint (it used to mint a key when an email had none). Now returns an empty list for unknown emails, removing an accidental-mint footgun now that ACS no longer calls it for display.

## Not changed
No user-facing copy renamed. The macOS app still labels the Settings tab **"License"** and the field **"License Key"** (`Base.lproj/Localizable.strings`), so the email templates and sign-in copy are left as-is — renaming them would point users at a tab that doesn't exist.

`tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014g1t3US3SeKBjcRndhKbaN