### PR TITLE
fix(checkout): clarify credits fee line as Cloud processing fee

### DIFF
--- a/nextjs/app/api/checkout/credits/route.ts
+++ b/nextjs/app/api/checkout/credits/route.ts
@@ -174,8 +174,8 @@ export async function POST(req: NextRequest) {
           price_data: {
             currency: "usd",
             product_data: {
-              name: "Processing fee (6%)",
-              description: "Non-refundable payment processing fee",
+              name: "Cloud processing fee (6%)",
+              description: "Non-refundable HyperWhisper Cloud processing fees",
               // Same Managed Payments requirement: the fee line needs a tax_code.
               tax_code: "txcd_10000000",
             },


### PR DESCRIPTION
Relabels the Stripe credits checkout fee line item for clarity:

- `Processing fee (6%)` → `Cloud processing fee (6%)`
- `Non-refundable payment processing fee` → `Non-refundable HyperWhisper Cloud processing fees`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Xf6Cr63T2eQo6aRZE1UuU