### PR TITLE
release: Windows v1.8.0 — version bump + appcast

### DIFF
--- a/app/windows/HyperWhisper/HyperWhisper.csproj
+++ b/app/windows/HyperWhisper/HyperWhisper.csproj
@@ -19,9 +19,9 @@
     <!-- Prevent .NET 8+ from appending +git-hash to AssemblyInformationalVersion,
          which causes NetSparkle to treat the same version as a new update -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <Version>1.7.0</Version>
-    <AssemblyVersion>1.7.0.0</AssemblyVersion>
-    <FileVersion>1.7.0.0</FileVersion>
+    <Version>1.8.0</Version>
+    <AssemblyVersion>1.8.0.0</AssemblyVersion>
+    <FileVersion>1.8.0.0</FileVersion>
     <!-- Scratch/workstream builds sometimes leave alternate intermediate folders
          inside the project tree. Keep SDK globs from compiling their generated
          WPF sources and duplicate assembly attributes. -->
@@ -255,6 +255,7 @@
   </Target>
 
 </Project>
+
 
 
 

--- a/app/windows/setup-arm64.iss
+++ b/app/windows/setup-arm64.iss
@@ -9,7 +9,7 @@
 ;   2. Ensure Inno Setup is installed and iscc.exe is in PATH
 
 #define MyAppName "HyperWhisper"
-#define MyAppVersion "1.7.0"
+#define MyAppVersion "1.8.0"
 #define MyAppPublisher "HyperWhisper"
 #define MyAppURL "https://www.hyperwhisper.com"
 #define MyAppExeName "HyperWhisper.exe"

--- a/app/windows/setup-x64.iss
+++ b/app/windows/setup-x64.iss
@@ -9,7 +9,7 @@
 ;   2. Ensure Inno Setup is installed and iscc.exe is in PATH
 
 #define MyAppName "HyperWhisper"
-#define MyAppVersion "1.7.0"
+#define MyAppVersion "1.8.0"
 #define MyAppPublisher "HyperWhisper"
 #define MyAppURL "https://www.hyperwhisper.com"
 #define MyAppExeName "HyperWhisper.exe"

--- a/nextjs/public/appcast-windows.xml
+++ b/nextjs/public/appcast-windows.xml
@@ -25,6 +25,61 @@ Generate the correct date with PowerShell:
 -->
 
 <!-- ================================================================== -->
+<!-- VERSION 1.8.0 -->
+<!-- ================================================================== -->
+
+<!-- 1.8.0 - ARM64 -->
+<item>
+<title>1.8.0 (ARM64)</title>
+<pubDate>Sun, 05 Jul 2026 14:32:43 +0000</pubDate>
+<sparkle:version>1.8.0</sparkle:version>
+<sparkle:shortVersionString>1.8.0</sparkle:shortVersionString>
+<sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
+<sparkle:os>windows-arm64</sparkle:os>
+<enclosure
+url="https://builds.hyperwhisper.com/HyperWhisper-1.8.0-arm64-Setup.exe"
+length="143909672"
+type="application/octet-stream"
+sparkle:edSignature="83Qpabq67xHLeGtW3CX7fxujkh8tBPf8bwgaapwsJFIxTfvPETEb4STz1qof32qYsZAlbrgiMWD34eaEZn+iDA=="
+/>
+<description><![CDATA[
+<h2>What's New in 1.8.0</h2>
+<ul>
+<li>Local transcription is now completely free and unlimited</li>
+<li>Fixed large cloud uploads being cut off on slow connections</li>
+<li>License and credits now live in one HyperWhisper Cloud panel</li>
+<li>More reliable transcription on Windows on ARM PCs</li>
+<li>Bug fixes and stability improvements</li>
+</ul>
+]]></description>
+</item>
+
+<!-- 1.8.0 - x64 -->
+<item>
+<title>1.8.0 (x64)</title>
+<pubDate>Sun, 05 Jul 2026 14:32:43 +0000</pubDate>
+<sparkle:version>1.8.0</sparkle:version>
+<sparkle:shortVersionString>1.8.0</sparkle:shortVersionString>
+<sparkle:minimumSystemVersion>10.0</sparkle:minimumSystemVersion>
+<sparkle:os>windows-x64</sparkle:os>
+<enclosure
+url="https://builds.hyperwhisper.com/HyperWhisper-1.8.0-x64-Setup.exe"
+length="181439400"
+type="application/octet-stream"
+sparkle:edSignature="cpB4QJS4y5iifOPkehbW3LxXt7IqqwOYQtWOVmSXKsTQZxHWrbFkuWOs35dRAoFNQH5cKzZ9WOpccTgll7XRBg=="
+/>
+<description><![CDATA[
+<h2>What's New in 1.8.0</h2>
+<ul>
+<li>Local transcription is now completely free and unlimited</li>
+<li>Fixed large cloud uploads being cut off on slow connections</li>
+<li>License and credits now live in one HyperWhisper Cloud panel</li>
+<li>More reliable transcription on Windows on ARM PCs</li>
+<li>Bug fixes and stability improvements</li>
+</ul>
+]]></description>
+</item>
+<!-- ================================================================== -->
 <!-- VERSION 1.7.0 -->
 <!-- ================================================================== -->
 


### PR DESCRIPTION
Completes the Windows 1.8.0 release. Build + Authenticode/Ed25519 signing + R2 upload already succeeded in workflow run 28743768303; only the final PR-landing step failed (the Actions bot can't create PRs — fixed separately). This branch is the exact commit that run produced: version bump (csproj + both .iss) and the appcast entries with real signatures/lengths pointing at the uploaded R2 installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)