### PR TITLE
fix(release): grant pull-requests:write to release workflows

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -27,6 +27,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write   # release commit lands via an auto-merged PR (gh pr create/merge)
 
 concurrency:
   group: release-push

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -23,6 +23,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write   # release commit lands via an auto-merged PR (gh pr create/merge)
 
 concurrency:
   group: release-push


### PR DESCRIPTION
Root cause of the Windows 1.8.0 release failing at its final step.

Both release workflows land the version-bump + appcast commit via an auto-merged PR (`gh pr create` + `gh pr merge`) because `main`'s ruleset blocks direct pushes. But they declare only `permissions: contents: write`, which sets `pull-requests: none` on the `GITHUB_TOKEN` — so `gh pr create` fails with `Resource not accessible by integration (createPullRequest)`.

Adds `pull-requests: write` to both `windows-release.yml` and `macos-release.yml` (macOS had the same latent bug).

> Note: this also requires the repo setting **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** to be enabled. If the next release still 403s on PR creation, that toggle is the remaining gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)