### PR TITLE
docs(support): fix refund payment processor reference to Stripe

### DIFF
--- a/mintlify-help/support.mdx
+++ b/mintlify-help/support.mdx
@@ -40,7 +40,7 @@ If HyperWhisper isn't working out for you, we'll refund your purchase — no qui
 - Your order number (from the receipt) **or** your license key
 - A short note on what didn't work for you (helps us improve — but it's not a requirement)
 
-Refunds are processed through our payment processor (Polar) and typically appear on your statement within 5–10 business days.
+Refunds are processed through our payment processor (Stripe) and typically appear on your statement within 5–10 business days.
 
 ## Feature requests
 


### PR DESCRIPTION
## Summary
- Support docs said refunds go through Polar; purchases/refunds now run through Stripe (Polar is legacy-only for pre-migration customers).

## Test plan
- [x] Verified current checkout flow uses Stripe (`nextjs/app/api/checkout/credits/route.ts`)
- [x] Doc-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)