### PR TITLE
feat(landing): open-source announcement banner + /open-source page

### DIFF
--- a/nextjs/app/[locale]/open-source/page.tsx
+++ b/nextjs/app/[locale]/open-source/page.tsx
@@ -1,0 +1,112 @@
+import { Metadata } from "next";
+
+const GITHUB_URL = "https://github.com/ray-amjad/hyperwhisper-app";
+const LICENSE_URL =
+  "https://github.com/ray-amjad/hyperwhisper-app/blob/main/LICENSE";
+const SUPPORT_EMAIL = "support@hyperwhisper.com";
+const REFUND_MAILTO = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+  "HyperWhisper — refund request"
+)}`;
+const CREDITS_MAILTO = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+  "HyperWhisper — convert my license to Cloud credits"
+)}`;
+
+export const metadata: Metadata = {
+  title: "Open Source | HyperWhisper",
+  description:
+    "HyperWhisper is fully open source under Apache-2.0 — desktop apps and Cloud backend alike. Read the code, audit where your audio goes, fork it, and self-host forever.",
+};
+
+export default function OpenSourcePage() {
+  return (
+    <article className="mx-auto w-full max-w-4xl pt-16 pb-24 md:pt-24">
+      {/* Header */}
+      <div className="space-y-5 text-center">
+        <p className="text-sm uppercase tracking-[0.3em] text-purple-300">
+          Open Source
+        </p>
+        <h1 className="mx-auto max-w-3xl text-4xl font-semibold leading-tight text-white md:text-5xl">
+          Open source. Nothing to hide.
+        </h1>
+        <p className="mx-auto max-w-2xl text-lg leading-8 text-gray-300">
+          HyperWhisper is now fully open source under Apache-2.0 — the desktop
+          apps and the Cloud backend alike.
+        </p>
+      </div>
+
+      {/* Body */}
+      <div className="prose prose-invert mx-auto mt-12 max-w-3xl prose-headings:text-white prose-a:text-purple-300 prose-a:no-underline hover:prose-a:text-purple-200 prose-strong:text-white">
+        <p>
+          An app that listens to your microphone should be something you can
+          verify, not just trust. So we opened everything up. You can read every
+          line of HyperWhisper — the macOS and Windows apps, and the Cloud
+          transcription backend — see exactly where your audio goes, and know
+          you&apos;ll never be locked in. The whole project lives on{" "}
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            GitHub
+          </a>{" "}
+          under the{" "}
+          <a href={LICENSE_URL} target="_blank" rel="noopener noreferrer">
+            Apache-2.0 license
+          </a>
+          .
+        </p>
+
+        <h2>Why it matters</h2>
+        <p>
+          <strong>Verify, don&apos;t trust.</strong> Read every line and audit
+          exactly where your audio goes. An app with microphone access should be
+          something you can inspect, not just take on faith.
+        </p>
+        <p>
+          <strong>No lock-in.</strong> The code is Apache-2.0 — yours to keep,
+          adapt, and run on your own terms. Your workflow is never held hostage.
+        </p>
+        <p>
+          <strong>Fork and self-host.</strong> Clone the repo, build it
+          yourself, or run your own Cloud backend. Everything you need is
+          public.
+        </p>
+        <p>
+          <strong>Built in the open.</strong> HyperWhisper is developed publicly
+          by indie maker Ray Amjad. Issues, discussions, and releases all happen
+          out in the open.
+        </p>
+
+        <h2>Already bought a license?</h2>
+        <p>
+          HyperWhisper is now open source, and paid transcription runs on
+          HyperWhisper Cloud credits. If you bought a license before the switch,
+          here&apos;s how we&apos;re taking care of you — just email{" "}
+          <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a> and we&apos;ll
+          sort it out by hand.
+        </p>
+        <ul>
+          <li>
+            <strong>Bought in the last 30 days:</strong> you&apos;re inside the
+            refund window. We&apos;ll refund your purchase in full — no questions
+            asked. Just{" "}
+            <a href={REFUND_MAILTO}>send us a note</a>.
+          </li>
+          <li>
+            <strong>Bought more than 30 days ago:</strong> we&apos;ll convert
+            what you paid into HyperWhisper Cloud credits — the full purchase
+            price, minus the $5 in credits already added to your account.{" "}
+            <a href={CREDITS_MAILTO}>Email us</a> and we&apos;ll apply the
+            balance.
+          </li>
+        </ul>
+
+        <h2>Want to contribute?</h2>
+        <p>
+          Bug reports, feature ideas, and pull requests are all welcome. Open an
+          issue or start a discussion{" "}
+          <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            on GitHub
+          </a>
+          .
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/nextjs/components/landing/FooterSection.tsx
+++ b/nextjs/components/landing/FooterSection.tsx
@@ -29,6 +29,7 @@ export default function FooterSection() {
       },
       { label: t("links.olderVersions"), href: "/older-versions" },
       { label: t("links.blog"), href: "/blog" },
+      { label: "Open Source", href: "/open-source" },
     ],
     [t("company")]: [
       { label: t("links.about"), href: "/" },

--- a/nextjs/components/landing/HeroSection.tsx
+++ b/nextjs/components/landing/HeroSection.tsx
@@ -3,12 +3,10 @@
 import { Button } from "@heroui/button";
 import { Link } from "@heroui/link";
 import { m } from "framer-motion";
-import { Download, Github, Play } from "lucide-react";
+import { Download, Play } from "lucide-react";
 import { useTranslations } from "next-intl";
 
 import { useDownloadModal } from "@/contexts/DownloadModalContext";
-
-const GITHUB_URL = "https://github.com/ray-amjad/hyperwhisper-app";
 
 export default function HeroSection() {
   const { openModal } = useDownloadModal();
@@ -29,18 +27,6 @@ export default function HeroSection() {
         initial={{ opacity: 0, y: 20 }}
         transition={{ duration: 0.5 }}
       >
-        {/* Open source badge */}
-        <div className="mb-8 flex justify-center">
-          <Link
-            isExternal
-            className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-gray-800/60 border border-gray-700 text-sm text-gray-300 hover:border-gray-500 hover:text-white transition-colors"
-            href={GITHUB_URL}
-          >
-            <Github className="w-4 h-4" />
-            {t("openSourceBadge")}
-          </Link>
-        </div>
-
         {/* Logo */}
         <div className="mb-8 flex justify-center">
           <img

--- a/nextjs/components/layout/LayoutWrapper.tsx
+++ b/nextjs/components/layout/LayoutWrapper.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 
 import { Navbar } from "@/components/navbar";
 import FooterSection from "@/components/landing/FooterSection";
-import { SaleBanner } from "@/components/sale-banner";
+import { OpenSourceBanner } from "@/components/open-source-banner";
 
 /**
  * Client-side layout wrapper that conditionally renders navbar/footer
@@ -20,6 +21,22 @@ export default function LayoutWrapper({
 }) {
   const pathname = usePathname();
 
+  // Open-source announcement banner: shown until the user dismisses it.
+  // Defaults to visible so SSR and first client render match; hidden after
+  // mount if a prior dismissal is stored.
+  const [bannerDismissed, setBannerDismissed] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem("os-banner-dismissed") === "1") {
+      setBannerDismissed(true);
+    }
+  }, []);
+
+  const dismissBanner = () => {
+    setBannerDismissed(true);
+    localStorage.setItem("os-banner-dismissed", "1");
+  };
+
   // Check if this is a full-screen route (user portal)
   const isFullScreenRoute = pathname.includes("/user");
 
@@ -28,17 +45,18 @@ export default function LayoutWrapper({
     return <div className="min-h-screen">{children}</div>;
   }
 
+  const showBanner = !bannerDismissed;
+
   // Regular layout: with navbar and footer
   return (
     <div className="relative flex flex-col min-h-screen">
-      {/* Sticky header container for sale banner + navbar */}
+      {/* Sticky header container for announcement banner + navbar */}
       <div className="fixed top-0 z-50 w-full flex flex-col">
-        {/* Sale banner disabled - uncomment to re-enable */}
-        {/* <SaleBanner /> */}
+        {showBanner && <OpenSourceBanner onDismiss={dismissBanner} />}
         <Navbar />
       </div>
-      {/* Spacer to account for fixed header height (navbar ~64px) */}
-      <div className="h-[64px]" />
+      {/* Spacer for fixed header height (navbar 64px + 48px banner when shown) */}
+      <div className={showBanner ? "h-[112px]" : "h-[64px]"} />
       <main className="container mx-auto max-w-7xl px-6 flex-grow">
         {children}
       </main>

--- a/nextjs/components/open-source-banner.tsx
+++ b/nextjs/components/open-source-banner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { Sparkles, X } from "lucide-react";
+
+import { Link } from "@/src/i18n/navigation";
+
+export const OpenSourceBanner = ({ onDismiss }: { onDismiss: () => void }) => {
+  return (
+    <div className="w-full h-12 bg-black text-white border-b border-white/10 relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-r from-purple-900/30 via-blue-900/30 to-purple-900/30" />
+
+      <div className="h-full flex items-center justify-center gap-2 sm:gap-3 px-3 relative z-10">
+        <Sparkles className="w-3.5 h-3.5 text-purple-300 shrink-0" />
+        <p className="text-xs sm:text-sm font-medium truncate">
+          <span className="hidden sm:inline">
+            HyperWhisper is now fully open source ·{" "}
+          </span>
+          <span className="sm:hidden">Now open source · </span>
+          <Link
+            className="underline underline-offset-2 hover:text-purple-200 transition-colors"
+            href="/open-source"
+          >
+            Learn more
+          </Link>
+        </p>
+        <button
+          aria-label="Dismiss announcement"
+          className="absolute right-2 sm:right-3 p-1 text-gray-400 hover:text-white transition-colors cursor-pointer"
+          onClick={onDismiss}
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## What

Surfaces HyperWhisper's fully-open-source status on the marketing site.

- **Dismissible announcement banner** in the fixed header ("HyperWhisper is now fully open source · Learn more"), linking to a new page. Dismissal persists via `localStorage`; the header spacer is sized for the extra banner height (64px navbar + 48px banner).
- **New `/open-source` page** — a long-form article (prose, inline links, no cards/buttons) on why the app is open source, plus the transition offer for existing license holders (full refund within 30 days, or convert the purchase price to Cloud credits afterward — both handled manually by email). Linked from the footer. English-only, matching the legal pages.
- **Removed the redundant hero "Open source · Apache-2.0" badge** — the banner now carries that message, so the pill directly below the header was duplicative and visually crowded. Dropped the pill and its now-unused `Github` import / `GITHUB_URL` constant; the navbar GitHub icon remains.

## Verification

Ran the branch locally at desktop width: banner + navbar sit cleanly above the hero with no clipping, and the hero flows rocket → headline with the single open-source signal up top. No console errors; no dangling references (`Github` / `GITHUB_URL` / `openSourceBadge` all gone from the hero).

## Notes

- The `hero.openSourceBadge` translation key is now unused across locale files (harmless dead string) — can be swept separately with the localisation-syncer.
- nextjs-only change; no schema/API/native impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)