### PR TITLE
fix(landing): banner pushes header down instead of cutting it off

### DIFF
--- a/nextjs/components/layout/LayoutWrapper.tsx
+++ b/nextjs/components/layout/LayoutWrapper.tsx
@@ -50,13 +50,16 @@ export default function LayoutWrapper({
   // Regular layout: with navbar and footer
   return (
     <div className="relative flex flex-col min-h-screen">
-      {/* Sticky header container for announcement banner + navbar */}
-      <div className="fixed top-0 z-50 w-full flex flex-col">
+      {/*
+        Sticky header holds the announcement banner + navbar. Using `sticky`
+        (not `fixed`) keeps it in normal document flow, so the banner naturally
+        pushes the navbar and page content down — no manual spacer / height math
+        to keep in sync, which previously caused the header to be cut off.
+      */}
+      <div className="sticky top-0 z-50 w-full flex flex-col">
         {showBanner && <OpenSourceBanner onDismiss={dismissBanner} />}
         <Navbar />
       </div>
-      {/* Spacer for fixed header height (navbar 64px + 48px banner when shown) */}
-      <div className={showBanner ? "h-[112px]" : "h-[64px]"} />
       <main className="container mx-auto max-w-7xl px-6 flex-grow">
         {children}
       </main>


### PR DESCRIPTION
## Problem

When the open-source announcement banner is shown, the site header was cut off. The header container used `position: fixed` plus a hand-computed spacer div (`h-[112px]` / `h-[64px]`) that had to exactly equal banner height (48px) + navbar height (64px). The HeroUI navbar actually renders ~113px total with the banner, so the fixed overlay and spacer drifted out of sync and the banner clipped the header.

## Fix

Swap the banner+navbar container from `fixed` to `sticky top-0` and drop the magic-number spacer. The header now stays in normal document flow, so the banner naturally pushes the navbar and page content down — no height math to keep in sync — while still pinning to the top on scroll.

## Verification (local dev preview)

- Banner at top with the **full** header (logo, Features/Cloud/FAQ, globe, GitHub, Download) rendering completely below it — nothing cut off.
- Header measured `position: sticky`, `top: 0`, height 113px, in-flow → hero content sits below it, not hidden underneath.
- Header stays pinned at `top: 0` on scroll; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)