### PR TITLE
Fix stale macOS recording cancel confirmation

### DIFF
--- a/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+StartRecording.swift
+++ b/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+StartRecording.swift
@@ -129,6 +129,7 @@ extension RecordingTranscriptionFlow {
             appState?.pendingRetryAudioPath = nil
             appState?.transcriptionPasteFailed = false
             appState?.lastDeliveryWasQuickCapture = false
+            appState?.showCancelConfirmation = false
         }
 
         // 1. CAPTURE FRONTMOST APP CONTEXT (instant, ~1ms)


### PR DESCRIPTION
## What changed

Reset `showCancelConfirmation` at the authoritative new-recording lifecycle boundary.

## Why

After a recording longer than 15 seconds showed the **Cancel?** prompt, stopping and pasting via the recording shortcut left that flag set. The next recording therefore reopened with the stale confirmation instead of the waveform.

Clearing the flag alongside the other per-recording `AppState` fields guarantees both normal and streaming sessions start cleanly, without duplicating reset logic in SwiftUI view hooks.

## Validation

- `git diff --check`
- `xcodebuild -project hyperwhisper.xcodeproj -scheme hyperwhisper -configuration Debug -derivedDataPath /tmp/hyperwhisper-issue17-derived -clonedSourcePackagesDirPath /tmp/hyperwhisper-issue17-packages build CODE_SIGNING_ALLOWED=NO`

Closes #17