### PR TITLE
Fix vocabulary mouse-wheel scrolling

### DIFF
--- a/app/windows/HyperWhisper/Views/Pages/VocabularyPage.xaml
+++ b/app/windows/HyperWhisper/Views/Pages/VocabularyPage.xaml
@@ -327,23 +327,15 @@
                                    Foreground="{DynamicResource TextSecondaryBrush}"/>
                     </StackPanel>
 
-                    <ListView x:Name="VocabularyList"
-                              BorderThickness="0"
-                              Background="Transparent"
-                              Padding="0"
-                              ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-                        <ListView.ItemContainerStyle>
-                            <Style TargetType="ListViewItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                <Setter Property="Padding" Value="0"/>
-                                <Setter Property="Margin" Value="0"/>
-                                <Setter Property="BorderThickness" Value="0,0,0,1"/>
-                                <Setter Property="BorderBrush" Value="{DynamicResource BorderBrush}"/>
-                            </Style>
-                        </ListView.ItemContainerStyle>
-                        <ListView.ItemTemplate>
+                    <ItemsControl x:Name="VocabularyList"
+                                  BorderThickness="0"
+                                  Background="Transparent"
+                                  Padding="0">
+                        <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <Border Padding="16,8">
+                                <Border Padding="16,8"
+                                        BorderThickness="0,0,0,1"
+                                        BorderBrush="{DynamicResource BorderBrush}">
                                     <Grid>
                                         <Grid.ColumnDefinitions>
                                             <ColumnDefinition Width="2*"/>
@@ -418,8 +410,8 @@
                                     </Grid>
                                 </Border>
                             </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                 </StackPanel>
             </Border>
             </StackPanel>


### PR DESCRIPTION
## What changed

- Replace the Vocabulary page's nested `ListView` with an `ItemsControl`.
- Keep the existing bindings, row layout, separators, and edit/delete actions intact.
- Leave the page-level `ScrollViewer` as the sole vertical scroller.

## Why

The `ListView` supplied its own internal `ScrollViewer` while sitting inside the page's outer `ScrollViewer` and vertical `StackPanel`. Its internal viewer consumed mouse-wheel events even though it had no constrained viewport to scroll, so users could move the page only by dragging the scrollbar.

## User impact

Mouse-wheel scrolling now works while the pointer is over vocabulary rows, matching the History page's expected behavior.

## Validation

- `dotnet build app/windows/HyperWhisper/HyperWhisper.csproj --no-restore -p:DesignTimeBuild=true` — passed, 0 errors.
- `xmllint --noout app/windows/HyperWhisper/Views/Pages/VocabularyPage.xaml` — passed.
- `git diff --check` — passed.
- A normal build compiled `HyperWhisper.dll` and then reached the repository's expected packaging guard because the Windows Rust DLL is unavailable on macOS.
- Pre-existing `SQLitePCLRaw.lib.e_sqlite3` NU1903 warning remains unchanged.