### PR TITLE
chore(l10n): sync all missing localization keys across macOS + Windows (39 locales)

### DIFF
--- a/app/macos/hyperwhisper/Localizations/ar.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ar.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "الرئيسية";
-"sidebar.statistics" = "الإحصائيات";
 "sidebar.modes" = "الأوضاع";
 "sidebar.vocabulary" = "المفردات";
 "sidebar.streaming" = "البث المباشر";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "ابدأ مع HyperWhisper";
-"sidebar.statistics.help" = "عرض إحصائيات الاستخدام والتحليلات";
 "sidebar.modes.help" = "إدارة أوضاع النسخ لسياقات مختلفة";
 "sidebar.vocabulary.help" = "إضافة كلمات وعبارات مخصصة لتحسين التعرف";
 "sidebar.streaming.help" = "إعدادات البث المباشر في الوقت الفعلي (يتطلب الإنترنت)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "فشل التحقق من المجموع الاختياري للنموذج. قد يكون التحميل تالفاً.";
 
 // MARK: - Statistics View
-"statistics.title" = "الإحصائيات";
-"statistics.header.title" = "إحصائيات استخدامك";
-"statistics.header.subtitle" = "تتبع نشاط وأداء النسخ الخاص بك";
-"statistics.card.recordings" = "إجمالي التسجيلات";
-"statistics.card.recordings.subtitle" = "النسخ المكتملة";
-"statistics.card.duration" = "الوقت الإجمالي";
-"statistics.card.duration.subtitle" = "الوقت المستغرق في التسجيل";
-"statistics.card.words" = "إجمالي الكلمات";
-"statistics.card.words.subtitle" = "الكلمات المنسوخة";
-"statistics.card.average" = "متوسط المدة";
-"statistics.card.average.subtitle" = "لكل تسجيل";
-"statistics.graph.title" = "النشاط على مدى الوقت";
-"statistics.daily.empty" = "لا توجد تسجيلات حتى الآن";
-"statistics.filter.week" = "هذا الأسبوع";
-"statistics.filter.month" = "هذا الشهر";
-"statistics.filter.alltime" = "منذ البداية";
 
 // MARK: - History View
 "history.title" = "السجل";

--- a/app/macos/hyperwhisper/Localizations/ar.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ar.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "الإصدار %@";
 "home.recent.updates.new.badge" = "جديد";
 "home.recent.updates.no.notes" = "لا توجد ملاحظات إصدار متاحة";
+"home.stats.words.week" = "الكلمات هذا الأسبوع";
+"home.stats.words.month" = "الكلمات هذا الشهر";
+"home.stats.speed" = "متوسط السرعة";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "يُوصى به لأجهزة Mac المزودة بذاكرة موحدة بسعة 24 GB أو أكثر. تعتمد السرعة على الشريحة — أسرع على M3/M4 Pro وما فوق.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "الكلمات هذا العام";
+"home.stats.typing.speed.help" = "اضبط سرعة الكتابة المفترضة (WPM) المستخدَمة لتقدير الوقت الموفَّر.";
+"home.stats.saved.week" = "الوقت الموفَّر هذا الأسبوع";
+"home.stats.minutes.value" = "%d دقيقة";
 "vocabulary.input.placeholder" = "أضف كلمة أو أنشئ مقتطفاً";
 "vocabulary.action.addWord" = "إضافة كلمة";
 "vocabulary.action.replaceWith" = "استبدال بـ…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "سريع وبأسعار معقولة. الأفضل للنسخ السريعة.";
 "modes.cloudAccuracy.deepgramNova3.description" = "توازن بين السرعة والدقة. موصى به لمعظم المستخدمين.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - أعلى دقة مع معالجة أبطأ. الأفضل للنسخ المهمة.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ رصيد/دقيقة";
 "modes.cloudAccuracy.grokStt.label" = "الأعلى (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - أعلى دقة مع معالجة أبطأ. الأفضل للنسخ المهمة.";
+"modes.cloudAccuracy.googleChirp3.label" = "مرتفع (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 مع Chirp 3. متعدد اللغات مع تكييف العبارات.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "مرتفع (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 عبر Azure Speech. 43 لغة مع توجيه سياقي.";
 
 "modes.create.title" = "إنشاء وضع جديد";
 "modes.create.subtitle" = "تكوين ملف تعريف نسخ مخصص";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "استغرق الطلب وقتاً طويلاً. تحقق من سرعة الإنترنت الخاصة بك وحاول مرة أخرى.";
 "transcription.error.noSpeechDetected" = "لم يتم الكشف عن أي كلام في التسجيل.";
 "transcription.guidance.noSpeechDetected" = "نصائح:\n• تحدث بوضوح نحو الميكروفون\n• اضغط على المفتاح لفترة أطول قبل التحدث\n• تحقق من أن الميكروفون يعمل\n• تأكد من تحديد جهاز الإدخال الصحيح";
+"transcription.guidance.needsNativeRelaunch" = "أغلق HyperWhisper وأعد فتحه كتطبيق أصلي لاستخدام المعالجة اللاحقة المحلية.";
+"transcription.guidance.localRuntimeUnavailable" = "حاول مرة أخرى، أو اختر نموذجاً محلياً أصغر في إعدادات الوضع.";
+"transcription.error.localRuntimeUnavailable" = "تعذّر على الذكاء الاصطناعي المحلي إكمال المعالجة — تم الاحتفاظ بالنص الأصلي.";
+"settings.backup.localDownload.title" = "تنزيل النماذج المحلية؟";
+"settings.backup.localDownload.message" = "%d من الأوضاع المستعادة تستخدم نماذج ذكاء اصطناعي على الجهاز لم يتم تنزيلها بعد.";
+"settings.backup.localDownload.downloadAll" = "تنزيل الكل";
+"settings.backup.localDownload.dismiss" = "تجاهل";
+"modelLibrary.local.requiresAppleSilicon" = "يتطلب Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "إعادة التشغيل كتطبيق أصلي";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "رصيد غير كافٍ. أضف المزيد من الرصيد في الإعدادات.";

--- a/app/macos/hyperwhisper/Localizations/bg.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/bg.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Версия %@";
 "home.recent.updates.new.badge" = "НОВО";
 "home.recent.updates.no.notes" = "Няма налични бележки за изданието";
+"home.stats.words.week" = "Думи тази седмица";
+"home.stats.words.month" = "Думи този месец";
+"home.stats.speed" = "Средна скорост";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Препоръчва се за Mac с 24 GB унифицирана памет или повече. Скоростта зависи от чипа — по-бърз на M3/M4 Pro и по-нови.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Думи тази година";
+"home.stats.typing.speed.help" = "Коригирайте приетата скорост на писане (WPM), използвана за изчисляване на спестеното време.";
+"home.stats.saved.week" = "Спестени тази седмица";
+"home.stats.minutes.value" = "%d минути";
 "vocabulary.input.placeholder" = "Добавете дума или създайте фрагмент";
 "vocabulary.action.addWord" = "Добавяне на дума";
 "vocabulary.action.replaceWith" = "Замяна с…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "Бърза и достъпна. Най-добра за бързи транскрипции.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Балансирана скорост и точност. Препоръчва се за повечето потребители.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Най-висока точност с по-бавна обработка. Най-добра за важни транскрипции.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ кредита/мин";
 "modes.cloudAccuracy.grokStt.label" = "Най-висока (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Най-висока точност с по-бавна обработка. Най-добра за важни транскрипции.";
+"modes.cloudAccuracy.googleChirp3.label" = "Висока (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 с Chirp 3. Многоезичен, с адаптация на фрази.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Висока (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 през Azure Speech. 43 езика с контекстно насочване.";
 
 "modes.create.title" = "Създаване на нов режим";
 "modes.create.subtitle" = "Конфигуриране на потребителски профил за транскрипция";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "Заявката отне твърде дълго. Проверете скоростта на интернет и опитайте отново.";
 "transcription.error.noSpeechDetected" = "В записа не е открита реч.";
 "transcription.guidance.noSpeechDetected" = "Съвети:\n• Говорете ясно в микрофона\n• Задръжте клавиша по-дълго, преди да говорите\n• Проверете дали микрофонът ви работи\n• Уверете се, че е избрано правилното входно устройство";
+"transcription.guidance.needsNativeRelaunch" = "Затворете и отворете отново HyperWhisper в нативен режим, за да използвате локална последваща обработка.";
+"transcription.guidance.localRuntimeUnavailable" = "Опитайте отново или изберете по-малък локален модел в настройките на режима.";
+"transcription.error.localRuntimeUnavailable" = "Локалният AI не успя да завърши — необработената транскрипция е запазена.";
+"settings.backup.localDownload.title" = "Да се изтеглят ли локалните модели?";
+"settings.backup.localDownload.message" = "%d от възстановените ви режими използват AI модели на устройството, които още не са изтеглени.";
+"settings.backup.localDownload.downloadAll" = "Изтегляне на всички";
+"settings.backup.localDownload.dismiss" = "Отхвърляне";
+"modelLibrary.local.requiresAppleSilicon" = "Изисква Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Рестартиране в нативен режим";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Недостатъчно кредити. Добавете повече кредити в Настройки.";

--- a/app/macos/hyperwhisper/Localizations/bg.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/bg.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Начало";
-"sidebar.statistics" = "Статистики";
 "sidebar.modes" = "Режими";
 "sidebar.vocabulary" = "Речник";
 "sidebar.streaming" = "Поточно предаване";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Започнете работа с HyperWhisper";
-"sidebar.statistics.help" = "Преглед на статистики и анализи за използването";
 "sidebar.modes.help" = "Управление на режимите за транскрипция за различни контексти";
 "sidebar.vocabulary.help" = "Добавяне на потребителски думи и фрази за по-добро разпознаване";
 "sidebar.streaming.help" = "Настройки за поточна транскрипция в реално време (изисква интернет)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "Проверката на контролната сума на модела е неуспешна. Изтеглянето може да е повредено.";
 
 // MARK: - Statistics View
-"statistics.title" = "Статистики";
-"statistics.header.title" = "Вашата статистика за използване";
-"statistics.header.subtitle" = "Следете вашата активност и ефективност при транскрипция";
-"statistics.card.recordings" = "Общо записи";
-"statistics.card.recordings.subtitle" = "Завършени транскрипции";
-"statistics.card.duration" = "Общо време";
-"statistics.card.duration.subtitle" = "Време, прекарано в запис";
-"statistics.card.words" = "Общо думи";
-"statistics.card.words.subtitle" = "Транскрибирани думи";
-"statistics.card.average" = "Средна продължителност";
-"statistics.card.average.subtitle" = "За запис";
-"statistics.graph.title" = "Активност във времето";
-"statistics.daily.empty" = "Все още няма записи";
-"statistics.filter.week" = "Тази седмица";
-"statistics.filter.month" = "Този месец";
-"statistics.filter.alltime" = "За всички времена";
 
 // MARK: - History View
 "history.title" = "История";

--- a/app/macos/hyperwhisper/Localizations/ca.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ca.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Inici";
-"sidebar.statistics" = "Estadístiques";
 "sidebar.modes" = "Modes";
 "sidebar.vocabulary" = "Vocabulari";
 "sidebar.streaming" = "Transmissió en temps real";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Comenceu amb HyperWhisper";
-"sidebar.statistics.help" = "Visualitzeu estadístiques d'ús i analítiques";
 "sidebar.modes.help" = "Gestioneu els modes de transcripció per a diferents contextos";
 "sidebar.vocabulary.help" = "Afegiu paraules i frases personalitzades per a un millor reconeixement";
 "sidebar.streaming.help" = "Configuració de la transmissió en temps real (requereix Internet)";
@@ -553,22 +551,6 @@ Edita aquests modes per seleccionar un model diferent abans de eliminar-lo.";
 "models.error.checksumFailed" = "La verificació de la suma de comprovació del model ha fallat. La descàrrega pot estar corrompuda.";
 
 // MARK: - Statistics View
-"statistics.title" = "Estadístiques";
-"statistics.header.title" = "Les vostres estadístiques d'ús";
-"statistics.header.subtitle" = "Feu seguiment de la vostra activitat i rendiment de transcripció";
-"statistics.card.recordings" = "Gravacions totals";
-"statistics.card.recordings.subtitle" = "Transcripcions completades";
-"statistics.card.duration" = "Temps total";
-"statistics.card.duration.subtitle" = "Temps dedicat a gravar";
-"statistics.card.words" = "Paraules totals";
-"statistics.card.words.subtitle" = "Paraules transcrites";
-"statistics.card.average" = "Durada mitjana";
-"statistics.card.average.subtitle" = "Per gravació";
-"statistics.graph.title" = "Activitat al llarg del temps";
-"statistics.daily.empty" = "Encara no hi ha gravacions";
-"statistics.filter.week" = "Aquesta setmana";
-"statistics.filter.month" = "Aquest mes";
-"statistics.filter.alltime" = "Tot el temps";
 
 // MARK: - History View
 "history.title" = "Historial";

--- a/app/macos/hyperwhisper/Localizations/ca.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ca.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versió %@";
 "home.recent.updates.new.badge" = "NOU";
 "home.recent.updates.no.notes" = "No hi ha notes de la versió disponibles";
+"home.stats.words.week" = "Paraules aquesta setmana";
+"home.stats.words.month" = "Paraules aquest mes";
+"home.stats.speed" = "Velocitat mitjana";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Recomanat per a Mac amb 24 GB de memòria unificada o més. La velocitat depèn del xip — més ràpid en M3/M4 Pro i superiors.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Paraules enguany";
+"home.stats.typing.speed.help" = "Ajusta la velocitat d'escriptura estimada (WPM) que s'utilitza per calcular el temps estalviat.";
+"home.stats.saved.week" = "Estalviat aquesta setmana";
+"home.stats.minutes.value" = "%d minuts";
 "vocabulary.input.placeholder" = "Afegiu una paraula o creeu un fragment";
 "vocabulary.action.addWord" = "Afegir paraula";
 "vocabulary.action.replaceWith" = "Substituir per…";
@@ -671,8 +677,13 @@ Edita aquests modes per seleccionar un model diferent abans de eliminar-lo.";
 "modes.cloudAccuracy.groqWhisper.description" = "Ràpida i assequible. Ideal per a transcripcions ràpides.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Velocitat i precisió equilibrades. Recomanada per a la majoria d'usuaris.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Màxima precisió amb processament més lent. Ideal per a transcripcions importants.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ crèdits/min";
 "modes.cloudAccuracy.grokStt.label" = "Màxima (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Màxima precisió amb processament més lent. Ideal per a transcripcions importants.";
+"modes.cloudAccuracy.googleChirp3.label" = "Alta (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 amb Chirp 3. Multilingüe amb adaptació de frases.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Alta (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 mitjançant Azure Speech. 43 idiomes amb adaptació contextual.";
 
 "modes.create.title" = "Crear nou mode";
 "modes.create.subtitle" = "Configureu un perfil de transcripció personalitzat";
@@ -883,6 +894,15 @@ Actualitza aquests modes per utilitzar un model diferent abans d'eliminar-lo.";
 "transcription.guidance.timeout" = "La sol·licitud ha trigat massa. Comproveu la velocitat d'Internet i torneu-ho a provar.";
 "transcription.error.noSpeechDetected" = "No s'ha detectat veu a la gravació.";
 "transcription.guidance.noSpeechDetected" = "Consells:\n• Parleu clarament al micròfon\n• Manteniu la tecla premuda més temps abans de parlar\n• Comproveu que el micròfon funcioni\n• Assegureu-vos que el dispositiu d'entrada correcte estigui seleccionat";
+"transcription.guidance.needsNativeRelaunch" = "Tanca i torna a obrir HyperWhisper en mode natiu per utilitzar el postprocessament local.";
+"transcription.guidance.localRuntimeUnavailable" = "Torna-ho a provar o tria un model local més petit als ajustos del mode.";
+"transcription.error.localRuntimeUnavailable" = "La IA local no ha pogut acabar — s'ha conservat la transcripció original.";
+"settings.backup.localDownload.title" = "Vols baixar els models locals?";
+"settings.backup.localDownload.message" = "%d dels modes restaurats utilitzen models d'IA locals que encara no s'han baixat.";
+"settings.backup.localDownload.downloadAll" = "Baixar-ho tot";
+"settings.backup.localDownload.dismiss" = "Descartar";
+"modelLibrary.local.requiresAppleSilicon" = "Requereix Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Reobrir en mode natiu";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Crèdits insuficients. Afegiu més crèdits a la Configuració.";

--- a/app/macos/hyperwhisper/Localizations/cs.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/cs.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Domov";
-"sidebar.statistics" = "Statistiky";
 "sidebar.modes" = "Rezimy";
 "sidebar.vocabulary" = "Slovnik";
 "sidebar.streaming" = "Streamovani";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Zacnete s HyperWhisper";
-"sidebar.statistics.help" = "Zobrazit statistiky pouzivani a analyzy";
 "sidebar.modes.help" = "Spravovat rezimy prepisu pro ruzne kontexty";
 "sidebar.vocabulary.help" = "Pridat vlastni slova a fraze pro lepsi rozpoznavani";
 "sidebar.streaming.help" = "Nastaveni streamovani prepisu v realnem case (vyzaduje internet)";
@@ -553,22 +551,6 @@ Upravte tyto režimy a vyberte jiný model před jeho odebráním.";
 "models.error.checksumFailed" = "Overeni kontrolniho souctu modelu selhalo. Stahovani muze byt poskozene.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistiky";
-"statistics.header.title" = "Vase statistiky pouzivani";
-"statistics.header.subtitle" = "Sledujte svou aktivitu a vykon prepisu";
-"statistics.card.recordings" = "Celkem nahravek";
-"statistics.card.recordings.subtitle" = "Dokoncene prepisy";
-"statistics.card.duration" = "Celkovy cas";
-"statistics.card.duration.subtitle" = "Cas straveny nahravanim";
-"statistics.card.words" = "Celkem slov";
-"statistics.card.words.subtitle" = "Prepsana slova";
-"statistics.card.average" = "Prumerna doba trvani";
-"statistics.card.average.subtitle" = "Na nahravku";
-"statistics.graph.title" = "Aktivita v case";
-"statistics.daily.empty" = "Zatim zadne nahravky";
-"statistics.filter.week" = "Tento tyden";
-"statistics.filter.month" = "Tento mesic";
-"statistics.filter.alltime" = "Celkem";
 
 // MARK: - History View
 "history.title" = "Historie";

--- a/app/macos/hyperwhisper/Localizations/cs.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/cs.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Verze %@";
 "home.recent.updates.new.badge" = "NOVE";
 "home.recent.updates.no.notes" = "Poznamky k vydani nejsou k dispozici";
+"home.stats.words.week" = "Slova tento týden";
+"home.stats.words.month" = "Slova tento měsíc";
+"home.stats.speed" = "Průměrná rychlost";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Doporučeno pro Mac s 24 GB sjednocené paměti nebo více. Rychlost závisí na čipu — rychlejší na M3/M4 Pro a vyšších.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Slova tento rok";
+"home.stats.typing.speed.help" = "Upravte předpokládanou rychlost psaní (WPM) použitou k odhadu ušetřeného času.";
+"home.stats.saved.week" = "Ušetřeno tento týden";
+"home.stats.minutes.value" = "%d minut";
 "vocabulary.input.placeholder" = "Přidejte slovo nebo vytvořte úryvek";
 "vocabulary.action.addWord" = "Přidat slovo";
 "vocabulary.action.replaceWith" = "Nahradit za…";
@@ -671,8 +677,13 @@ Upravte tyto režimy a vyberte jiný model před jeho odebráním.";
 "modes.cloudAccuracy.groqWhisper.description" = "Rychly a cenove dostupny. Nejlepsi pro rychle prepisy.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Vyvazena rychlost a presnost. Doporuceno pro vetsinu uzivatelu.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Nejvyssi presnost s pomalejsim zpracovanim. Nejlepsi pro dulezite prepisy.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kreditů/min";
 "modes.cloudAccuracy.grokStt.label" = "Nejvyssi (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Nejvyssi presnost s pomalejsim zpracovanim. Nejlepsi pro dulezite prepisy.";
+"modes.cloudAccuracy.googleChirp3.label" = "Vysoká (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 s Chirp 3. Vícejazyčné s přizpůsobením frází.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Vysoká (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 přes Azure Speech. 43 jazyků s kontextovým přizpůsobením.";
 
 "modes.create.title" = "Vytvorit novy rezim";
 "modes.create.subtitle" = "Nakonfigurujte vlastni profil prepisu";
@@ -883,6 +894,15 @@ Před smazáním aktualizujte tyto režimy, aby používaly jiný model.";
 "transcription.guidance.timeout" = "Pozadavek trval prilis dlouho. Zkontrolujte rychlost internetu a zkuste to znovu.";
 "transcription.error.noSpeechDetected" = "V nahravce nebyla detekovana rec.";
 "transcription.guidance.noSpeechDetected" = "Tipy:\n• Mluvte zretelne do mikrofonu\n• Pred mluvenim podrzte klavesu dele\n• Zkontrolujte, ze mikrofon funguje\n• Ujistete se, ze je vybrano spravne vstupni zarizeni";
+"transcription.guidance.needsNativeRelaunch" = "Ukončete HyperWhisper a spusťte jej znovu nativně, abyste mohli používat lokální následné zpracování.";
+"transcription.guidance.localRuntimeUnavailable" = "Zkuste to znovu nebo v nastavení režimu zvolte menší lokální model.";
+"transcription.error.localRuntimeUnavailable" = "Lokální AI nedokončila zpracování — váš původní přepis byl zachován.";
+"settings.backup.localDownload.title" = "Stáhnout lokální modely?";
+"settings.backup.localDownload.message" = "%d z vašich obnovených režimů používá lokální modely AI, které zatím nejsou stažené.";
+"settings.backup.localDownload.downloadAll" = "Stáhnout vše";
+"settings.backup.localDownload.dismiss" = "Zavřít";
+"modelLibrary.local.requiresAppleSilicon" = "Vyžaduje Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Spustit znovu nativně";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nedostatek kreditů. Přidejte více kreditů v Nastavení.";

--- a/app/macos/hyperwhisper/Localizations/da.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/da.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Hjem";
-"sidebar.statistics" = "Statistik";
 "sidebar.modes" = "Tilstande";
 "sidebar.vocabulary" = "Ordforråd";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Kom i gang med HyperWhisper";
-"sidebar.statistics.help" = "Se brugsstatistik og analyser";
 "sidebar.modes.help" = "Administrer transskriptionstilstande til forskellige sammenhænge";
 "sidebar.vocabulary.help" = "Tilføj brugerdefinerede ord og udtryk for bedre genkendelse";
 "sidebar.streaming.help" = "Indstillinger for realtids-streamingtransskription (kræver internet)";
@@ -553,22 +551,6 @@ Rediger disse tilstande for at vælge en anden model, inden du fjerner den.";
 "models.error.checksumFailed" = "Verifikation af modelkontrolsum mislykkedes. Downloaden kan være beskadiget.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistik";
-"statistics.header.title" = "Din brugsstatistik";
-"statistics.header.subtitle" = "Følg din transskriptionsaktivitet og ydeevne";
-"statistics.card.recordings" = "Samlede optagelser";
-"statistics.card.recordings.subtitle" = "Fuldførte transskriptioner";
-"statistics.card.duration" = "Samlet tid";
-"statistics.card.duration.subtitle" = "Tid brugt på optagelse";
-"statistics.card.words" = "Samlede ord";
-"statistics.card.words.subtitle" = "Transskriberede ord";
-"statistics.card.average" = "Gennemsnitlig varighed";
-"statistics.card.average.subtitle" = "Pr. optagelse";
-"statistics.graph.title" = "Aktivitet over tid";
-"statistics.daily.empty" = "Ingen optagelser endnu";
-"statistics.filter.week" = "Denne uge";
-"statistics.filter.month" = "Denne måned";
-"statistics.filter.alltime" = "Alt tid";
 
 // MARK: - History View
 "history.title" = "Historik";

--- a/app/macos/hyperwhisper/Localizations/da.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/da.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Version %@";
 "home.recent.updates.new.badge" = "NYT";
 "home.recent.updates.no.notes" = "Ingen udgivelsesnoter tilgængelige";
+"home.stats.words.week" = "Ord i denne uge";
+"home.stats.words.month" = "Ord i denne måned";
+"home.stats.speed" = "Gennemsnitshastighed";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Anbefales til Mac med 24 GB unified memory eller mere. Hastigheden afhænger af din chip — hurtigere på M3/M4 Pro og derover.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Ord i år";
+"home.stats.typing.speed.help" = "Justér den antagne skrivehastighed (WPM), der bruges til at estimere den sparede tid.";
+"home.stats.saved.week" = "Sparet i denne uge";
+"home.stats.minutes.value" = "%d minutter";
 "vocabulary.input.placeholder" = "Tilføj et ord eller opret et uddrag";
 "vocabulary.action.addWord" = "Tilføj ord";
 "vocabulary.action.replaceWith" = "Erstat med…";
@@ -671,8 +677,13 @@ Rediger disse tilstande for at vælge en anden model, inden du fjerner den.";
 "modes.cloudAccuracy.groqWhisper.description" = "Hurtig og overkommelig. Bedst til hurtige transskriptioner.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Balanceret hastighed og nøjagtighed. Anbefalet til de fleste brugere.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Højeste nøjagtighed med langsommere behandling. Bedst til vigtige transskriptioner.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ credits/min";
 "modes.cloudAccuracy.grokStt.label" = "Højest (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Højeste nøjagtighed med langsommere behandling. Bedst til vigtige transskriptioner.";
+"modes.cloudAccuracy.googleChirp3.label" = "Høj (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 med Chirp 3. Flersproget med frasetilpasning.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Høj (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 via Azure Speech. 43 sprog med kontekstuel tilpasning.";
 
 "modes.create.title" = "Opret ny tilstand";
 "modes.create.subtitle" = "Konfigurer en brugerdefineret transskriptionsprofil";
@@ -883,6 +894,15 @@ Opdater disse tilstande til at bruge en anden model, inden du sletter.";
 "transcription.guidance.timeout" = "Anmodningen tog for lang tid. Kontroller din internethastighed, og prøv igen.";
 "transcription.error.noSpeechDetected" = "Ingen tale registreret i optagelsen.";
 "transcription.guidance.noSpeechDetected" = "Tips:\n• Tal tydeligt i mikrofonen\n• Hold tasten nede længere, før du taler\n• Kontroller, at din mikrofon virker\n• Sørg for, at den korrekte inputenhed er valgt";
+"transcription.guidance.needsNativeRelaunch" = "Afslut og åbn HyperWhisper igen som native app for at bruge lokal efterbehandling.";
+"transcription.guidance.localRuntimeUnavailable" = "Prøv igen, eller vælg en mindre lokal model i dine tilstandsindstillinger.";
+"transcription.error.localRuntimeUnavailable" = "Lokal AI kunne ikke gøre det færdigt — din rå transskription blev bevaret.";
+"settings.backup.localDownload.title" = "Download lokale modeller?";
+"settings.backup.localDownload.message" = "%d af dine gendannede tilstande bruger AI-modeller på enheden, som endnu ikke er downloadet.";
+"settings.backup.localDownload.downloadAll" = "Download alle";
+"settings.backup.localDownload.dismiss" = "Afvis";
+"modelLibrary.local.requiresAppleSilicon" = "Kræver Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Genstart som native app";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Utilstrækkelige credits. Tilføj flere credits i Indstillinger.";

--- a/app/macos/hyperwhisper/Localizations/de.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/de.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Heim";
-"sidebar.statistics" = "Statistiken";
 "sidebar.modes" = "Modi";
 "sidebar.vocabulary" = "Vokabular";
 "sidebar.streaming" = "Live-Übertragung";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Beginnen Sie mit HyperWhisper";
-"sidebar.statistics.help" = "Sehen Sie sich Nutzungsstatistiken und Analysen an";
 "sidebar.modes.help" = "Verwalten Sie Transkriptionsmodi für verschiedene Kontexte";
 "sidebar.vocabulary.help" = "Fügen Sie zur besseren Erkennung benutzerdefinierte Wörter und Phrasen hinzu";
 "sidebar.streaming.help" = "Einstellungen für Echtzeit-Streaming-Transkription (Internet erforderlich)";
@@ -553,22 +551,6 @@ Bearbeite diese Modi, um ein anderes Modell auszuwählen, bevor du es entfernst.
 "models.error.checksumFailed" = "Die Überprüfung der Modellprüfsumme ist fehlgeschlagen. Der Download ist möglicherweise beschädigt.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistiken";
-"statistics.header.title" = "Ihre Nutzungsstatistik";
-"statistics.header.subtitle" = "Verfolgen Sie Ihre Transkriptionsaktivität und -leistung";
-"statistics.card.recordings" = "Gesamtaufnahmen";
-"statistics.card.recordings.subtitle" = "Abgeschlossene Transkriptionen";
-"statistics.card.duration" = "Gesamtzeit";
-"statistics.card.duration.subtitle" = "Zeitaufwand für die Aufnahme";
-"statistics.card.words" = "Gesamtzahl der Wörter";
-"statistics.card.words.subtitle" = "Wörter transkribiert";
-"statistics.card.average" = "Durchschnittliche Dauer";
-"statistics.card.average.subtitle" = "Pro Aufnahme";
-"statistics.graph.title" = "Aktivität im Zeitverlauf";
-"statistics.daily.empty" = "Noch keine Aufnahmen";
-"statistics.filter.week" = "Diese Woche";
-"statistics.filter.month" = "Diesen Monat";
-"statistics.filter.alltime" = "Alle Zeit";
 
 // MARK: - History View
 "history.title" = "Geschichte";

--- a/app/macos/hyperwhisper/Localizations/de.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/de.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Version %@";
 "home.recent.updates.new.badge" = "NEU";
 "home.recent.updates.no.notes" = "Keine Versionshinweise verfügbar";
+"home.stats.words.week" = "Wörter diese Woche";
+"home.stats.words.month" = "Wörter diesen Monat";
+"home.stats.speed" = "Durchschnittliche Geschwindigkeit";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Empfohlen für Mac mit 24 GB Unified Memory oder mehr. Die Geschwindigkeit hängt vom Chip ab — schneller auf M3/M4 Pro und höher.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Wörter dieses Jahr";
+"home.stats.typing.speed.help" = "Passen Sie die angenommene Tippgeschwindigkeit (WPM) an, mit der die gesparte Zeit geschätzt wird.";
+"home.stats.saved.week" = "Diese Woche gespart";
+"home.stats.minutes.value" = "%d Minuten";
 "vocabulary.input.placeholder" = "Ein Wort hinzufügen oder einen Ausschnitt erstellen";
 "vocabulary.action.addWord" = "Wort hinzufügen";
 "vocabulary.action.replaceWith" = "Ersetzen durch…";
@@ -671,8 +677,13 @@ Bearbeite diese Modi, um ein anderes Modell auszuwählen, bevor du es entfernst.
 "modes.cloudAccuracy.groqWhisper.description" = "Schnell und erschwinglich. Am besten für schnelle Transkriptionen geeignet.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Ausgewogene Geschwindigkeit und Genauigkeit. Für die meisten Benutzer empfohlen.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Höchste Genauigkeit bei langsamerer Verarbeitung. Am besten für wichtige Transkriptionen geeignet.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ Credits/Min.";
 "modes.cloudAccuracy.grokStt.label" = "Höchste (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Höchste Genauigkeit bei langsamerer Verarbeitung. Am besten für wichtige Transkriptionen geeignet.";
+"modes.cloudAccuracy.googleChirp3.label" = "Hoch (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 mit Chirp 3. Mehrsprachig mit Phrasenanpassung.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Hoch (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 über Azure Speech. 43 Sprachen mit kontextbezogener Gewichtung.";
 
 "modes.create.title" = "Neuen Modus erstellen";
 "modes.create.subtitle" = "Konfigurieren Sie ein benutzerdefiniertes Transkriptionsprofil";
@@ -883,6 +894,15 @@ Aktualisiere diese Modi, um ein anderes Modell zu verwenden, bevor du es löschs
 "transcription.guidance.timeout" = "Die Anfrage hat zu lange gedauert. Überprüfen Sie Ihre Internetgeschwindigkeit und versuchen Sie es erneut.";
 "transcription.error.noSpeechDetected" = "Keine Sprache in der Aufnahme erkannt.";
 "transcription.guidance.noSpeechDetected" = "Tipps:\n• Sprechen Sie deutlich in das Mikrofon\n• Halten Sie die Taste länger gedrückt, bevor Sie sprechen\n• Überprüfen Sie, ob Ihr Mikrofon funktioniert\n• Stellen Sie sicher, dass das richtige Eingabegerät ausgewählt ist";
+"transcription.guidance.needsNativeRelaunch" = "Beenden Sie HyperWhisper und öffnen Sie es nativ erneut, um die lokale Nachbearbeitung zu verwenden.";
+"transcription.guidance.localRuntimeUnavailable" = "Versuchen Sie es erneut, oder wählen Sie in Ihren Modus-Einstellungen ein kleineres lokales Modell.";
+"transcription.error.localRuntimeUnavailable" = "Die lokale KI konnte nicht abgeschlossen werden — Ihr Rohtranskript wurde beibehalten.";
+"settings.backup.localDownload.title" = "Lokale Modelle herunterladen?";
+"settings.backup.localDownload.message" = "%d Ihrer wiederhergestellten Modi verwenden lokale KI-Modelle, die noch nicht heruntergeladen sind.";
+"settings.backup.localDownload.downloadAll" = "Alle herunterladen";
+"settings.backup.localDownload.dismiss" = "Schließen";
+"modelLibrary.local.requiresAppleSilicon" = "Erfordert Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Nativ neu starten";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nicht genügend Credits. Fügen Sie in den Einstellungen weitere Credits hinzu.";

--- a/app/macos/hyperwhisper/Localizations/el.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/el.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Έκδοση %@";
 "home.recent.updates.new.badge" = "ΝΕΟ";
 "home.recent.updates.no.notes" = "Καμία σημείωση κυκλοφορίας διαθέσιμη";
+"home.stats.words.week" = "Λέξεις αυτή την εβδομάδα";
+"home.stats.words.month" = "Λέξεις αυτόν τον μήνα";
+"home.stats.speed" = "Μέση ταχύτητα";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Συνιστάται για Mac με 24 GB ενοποιημένης μνήμης ή περισσότερο. Η ταχύτητα εξαρτάται από το chip — ταχύτερο σε M3/M4 Pro και άνω.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Λέξεις φέτος";
+"home.stats.typing.speed.help" = "Προσαρμόστε την εκτιμώμενη ταχύτητα πληκτρολόγησης (WPM) που χρησιμοποιείται για τον υπολογισμό του χρόνου που εξοικονομείται.";
+"home.stats.saved.week" = "Εξοικονομήθηκαν αυτή την εβδομάδα";
+"home.stats.minutes.value" = "%d λεπτά";
 "vocabulary.input.placeholder" = "Προσθέστε λέξη ή δημιουργήστε απόσπασμα";
 "vocabulary.action.addWord" = "Προσθήκη λέξης";
 "vocabulary.action.replaceWith" = "Αντικατάσταση με…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "Γρήγορο και οικονομικό. Καλύτερο για γρήγορες μεταγραφές.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Ισορροπημένη ταχύτητα και ακρίβεια. Συνιστάται για τους περισσότερους χρήστες.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Υψηλότερη ακρίβεια με αργότερη επεξεργασία. Καλύτερο για σημαντικές μεταγραφές.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ πιστώσεις/λεπτό";
 "modes.cloudAccuracy.grokStt.label" = "Υψηλότερο (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Υψηλότερη ακρίβεια με αργότερη επεξεργασία. Καλύτερο για σημαντικές μεταγραφές.";
+"modes.cloudAccuracy.googleChirp3.label" = "Υψηλή (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 με Chirp 3. Πολύγλωσσο, με προσαρμογή φράσεων.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Υψηλή (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 μέσω Azure Speech. 43 γλώσσες με προσαρμογή βάσει συμφραζομένων.";
 
 "modes.create.title" = "Δημιουργία Νέας Λειτουργίας";
 "modes.create.subtitle" = "Διαμόρφωση ενός προσαρμοσμένου προφίλ μεταγραφής";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "Το αίτημα χρειάστηκε πολύ χρόνο. Ελέγξτε την ταχύτητα του διαδικτύου σας και δοκιμάστε ξανά.";
 "transcription.error.noSpeechDetected" = "Δεν ανιχνεύθηκε ομιλία στην εγγραφή.";
 "transcription.guidance.noSpeechDetected" = "Συμβουλές:\n• Μιλήστε καθαρά στο μικροφώνο\n• Κρατήστε το πλήκτρο περισσότερο πριν μιλήσετε\n• Ελέγξτε ότι το μικροφώνο σας λειτουργεί\n• Βεβαιωθείτε ότι είναι επιλεγμένη η σωστή συσκευή εισόδου";
+"transcription.guidance.needsNativeRelaunch" = "Κλείστε και ανοίξτε ξανά το HyperWhisper σε εγγενή λειτουργία για να χρησιμοποιήσετε την τοπική μετεπεξεργασία.";
+"transcription.guidance.localRuntimeUnavailable" = "Δοκιμάστε ξανά ή επιλέξτε μικρότερο τοπικό μοντέλο στις ρυθμίσεις της Λειτουργίας.";
+"transcription.error.localRuntimeUnavailable" = "Το τοπικό AI δεν μπόρεσε να ολοκληρώσει — η αρχική απομαγνητοφώνηση διατηρήθηκε.";
+"settings.backup.localDownload.title" = "Λήψη τοπικών μοντέλων;";
+"settings.backup.localDownload.message" = "%d από τις λειτουργίες που επαναφέρατε χρησιμοποιούν μοντέλα AI στη συσκευή τα οποία δεν έχουν ληφθεί ακόμη.";
+"settings.backup.localDownload.downloadAll" = "Λήψη όλων";
+"settings.backup.localDownload.dismiss" = "Παράβλεψη";
+"modelLibrary.local.requiresAppleSilicon" = "Απαιτεί Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Επανεκκίνηση σε εγγενή λειτουργία";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Ανεπαρκείς πιστώσεις. Προσθέστε περισσότερες πιστώσεις στις Ρυθμίσεις.";

--- a/app/macos/hyperwhisper/Localizations/el.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/el.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Αρχική";
-"sidebar.statistics" = "Στατιστικά";
 "sidebar.modes" = "Λειτουργίες";
 "sidebar.vocabulary" = "Λεξιλόγιο";
 "sidebar.streaming" = "Ροή";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Ξεκινήστε με το HyperWhisper";
-"sidebar.statistics.help" = "Δείτε τα στατιστικά χρήσης και ανάλυση";
 "sidebar.modes.help" = "Διαχειρίστε τις λειτουργίες μεταγραφής για διαφορετικά πλαίσια";
 "sidebar.vocabulary.help" = "Προσθέστε προσαρμοσμένες λέξεις και φράσεις για καλύτερη αναγνώριση";
 "sidebar.streaming.help" = "Ρυθμίσεις ροής ρεμάτων σε πραγματικό χρόνο (απαιτείται Διαδίκτυο)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "Η επαλήθευση ελέγχου μοντέλου απέτυχε. Η λήψη μπορεί να είναι κατεστραμμένη.";
 
 // MARK: - Statistics View
-"statistics.title" = "Στατιστικά";
-"statistics.header.title" = "Τα Στατιστικά Χρήσης σας";
-"statistics.header.subtitle" = "Παρακολουθήστε τη δραστηριότητα μεταγραφής και την απόδοση";
-"statistics.card.recordings" = "Σύνολο Εγγραφών";
-"statistics.card.recordings.subtitle" = "Ολοκληρωμένες μεταγραφές";
-"statistics.card.duration" = "Συνολικός Χρόνος";
-"statistics.card.duration.subtitle" = "Χρόνος ξοδεμένος στην εγγραφή";
-"statistics.card.words" = "Σύνολο Λέξεων";
-"statistics.card.words.subtitle" = "Λέξεις μεταγραφείες";
-"statistics.card.average" = "Μέση Διάρκεια";
-"statistics.card.average.subtitle" = "Ανά εγγραφή";
-"statistics.graph.title" = "Δραστηριότητα Κατά τη Διάρκεια του Χρόνου";
-"statistics.daily.empty" = "Καμία εγγραφή ακόμα";
-"statistics.filter.week" = "Αυτή τη Εβδομάδα";
-"statistics.filter.month" = "Αυτό το Μήνα";
-"statistics.filter.alltime" = "Όλες τις Ώρες";
 
 // MARK: - History View
 "history.title" = "Ιστορικό";

--- a/app/macos/hyperwhisper/Localizations/es.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/es.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versión %@";
 "home.recent.updates.new.badge" = "NUEVO";
 "home.recent.updates.no.notes" = "No hay notas de la versión disponibles";
+"home.stats.words.week" = "Palabras esta semana";
+"home.stats.words.month" = "Palabras este mes";
+"home.stats.speed" = "Velocidad media";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Recomendado para Mac con 24 GB de memoria unificada o más. La velocidad depende del chip — más rápido en M3/M4 Pro y superiores.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Palabras este año";
+"home.stats.typing.speed.help" = "Ajusta la velocidad de escritura estimada (WPM) que se usa para calcular el tiempo ahorrado.";
+"home.stats.saved.week" = "Ahorrado esta semana";
+"home.stats.minutes.value" = "%d minutos";
 "vocabulary.input.placeholder" = "Añadir una palabra o crear un fragmento";
 "vocabulary.action.addWord" = "Añadir palabra";
 "vocabulary.action.replaceWith" = "Sustituir por…";
@@ -677,8 +683,13 @@ Edita esos modos para seleccionar un modelo diferente antes de eliminarlo.";
 "modes.cloudAccuracy.groqWhisper.description" = "Rápida y asequible. Ideal para transcripciones rápidas.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Equilibrio entre velocidad y precisión. Recomendado para la mayoría de usuarios.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Máxima precisión con procesamiento más lento. Ideal para transcripciones importantes.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ créditos/min";
 "modes.cloudAccuracy.grokStt.label" = "Máxima (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Máxima precisión con procesamiento más lento. Ideal para transcripciones importantes.";
+"modes.cloudAccuracy.googleChirp3.label" = "Alta (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 con Chirp 3. Multilingüe con adaptación de frases.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Alta (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 a través de Azure Speech. 43 idiomas con adaptación contextual.";
 
 "modes.create.title" = "Crear nuevo modo";
 "modes.create.subtitle" = "Configura un perfil de transcripción personalizado";
@@ -884,6 +895,15 @@ Actualiza estos modos para usar un modelo diferente antes de eliminarlo.";
 "transcription.guidance.timeout" = "La solicitud tardó demasiado. Revisa tu velocidad de Internet e inténtalo de nuevo.";
 "transcription.error.noSpeechDetected" = "No se detectó voz en la grabación.";
 "transcription.guidance.noSpeechDetected" = "Consejos:\n• Habla con claridad al micrófono\n• Mantén la tecla pulsada más tiempo antes de hablar\n• Comprueba que tu micrófono funciona\n• Asegúrate de que el dispositivo de entrada correcto esté seleccionado";
+"transcription.guidance.needsNativeRelaunch" = "Cierra y vuelve a abrir HyperWhisper en modo nativo para usar el posprocesamiento local.";
+"transcription.guidance.localRuntimeUnavailable" = "Vuelve a intentarlo o elige un modelo local más pequeño en los ajustes del modo.";
+"transcription.error.localRuntimeUnavailable" = "La IA local no pudo terminar — se ha conservado la transcripción sin procesar.";
+"settings.backup.localDownload.title" = "¿Descargar los modelos locales?";
+"settings.backup.localDownload.message" = "%d de los modos restaurados usan modelos de IA en el dispositivo que aún no se han descargado.";
+"settings.backup.localDownload.downloadAll" = "Descargar todos";
+"settings.backup.localDownload.dismiss" = "Descartar";
+"modelLibrary.local.requiresAppleSilicon" = "Requiere Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Reiniciar en modo nativo";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Créditos insuficientes. Añade más créditos en Ajustes.";

--- a/app/macos/hyperwhisper/Localizations/es.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/es.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Inicio";
-"sidebar.statistics" = "Estadísticas";
 "sidebar.modes" = "Modos";
 "sidebar.vocabulary" = "Vocabulario";
 "sidebar.streaming" = "Transmisión";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Empieza con HyperWhisper";
-"sidebar.statistics.help" = "Ver estadísticas y análisis de uso";
 "sidebar.modes.help" = "Gestionar modos de transcripción para distintos contextos";
 "sidebar.vocabulary.help" = "Añadir palabras y frases personalizadas para un mejor reconocimiento";
 "sidebar.streaming.help" = "Ajustes de transcripción en streaming (requiere Internet)";
@@ -553,22 +551,6 @@ Edita esos modos para seleccionar un modelo diferente antes de eliminarlo.";
 "models.error.checksumFailed" = "Falló la verificación de checksum del modelo. La descarga puede estar dañada.";
 
 // MARK: - Statistics View
-"statistics.title" = "Estadísticas";
-"statistics.header.title" = "Tus estadísticas de uso";
-"statistics.header.subtitle" = "Sigue tu actividad y rendimiento de transcripción";
-"statistics.card.recordings" = "Grabaciones totales";
-"statistics.card.recordings.subtitle" = "Transcripciones completadas";
-"statistics.card.duration" = "Tiempo total";
-"statistics.card.duration.subtitle" = "Tiempo de grabación";
-"statistics.card.words" = "Palabras totales";
-"statistics.card.words.subtitle" = "Palabras transcritas";
-"statistics.card.average" = "Duración promedio";
-"statistics.card.average.subtitle" = "Por grabación";
-"statistics.graph.title" = "Actividad a lo largo del tiempo";
-"statistics.daily.empty" = "Aún no hay grabaciones";
-"statistics.filter.week" = "Esta semana";
-"statistics.filter.month" = "Este mes";
-"statistics.filter.alltime" = "Todo el tiempo";
 
 // MARK: - History View
 "history.title" = "Historial";

--- a/app/macos/hyperwhisper/Localizations/et.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/et.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Avaleht";
-"sidebar.statistics" = "Statistika";
 "sidebar.modes" = "Režiimid";
 "sidebar.vocabulary" = "Sõnavara";
 "sidebar.streaming" = "Voogedastus";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Alusta HyperWhisperiga";
-"sidebar.statistics.help" = "Vaata kasutusstatistikat ja analüüse";
 "sidebar.modes.help" = "Halda transkriptsiooni režiime erinevate kontekstide jaoks";
 "sidebar.vocabulary.help" = "Lisa kohandatud sõnu ja fraase parema äratundmise jaoks";
 "sidebar.streaming.help" = "Reaalajas voogedastuse transkriptsiooni seaded (nõuab internetti)";
@@ -553,22 +551,6 @@ Muuda neid režiime, et valida enne eemaldamist mõni muu mudel.";
 "models.error.checksumFailed" = "Mudeli kontrollsumma kontrollimine ebaõnnestus. Allalaadimine võib olla rikutud.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistika";
-"statistics.header.title" = "Teie kasutusstatistika";
-"statistics.header.subtitle" = "Jälgi oma transkriptsiooni tegevust ja jõudlust";
-"statistics.card.recordings" = "Kokku salvestusi";
-"statistics.card.recordings.subtitle" = "Lõpetatud transkriptsioonid";
-"statistics.card.duration" = "Kogu aeg";
-"statistics.card.duration.subtitle" = "Aeg salvestamiseks kulunud";
-"statistics.card.words" = "Kokku sõnu";
-"statistics.card.words.subtitle" = "Transkribeeritud sõnad";
-"statistics.card.average" = "Keskmine kestus";
-"statistics.card.average.subtitle" = "Salvestuse kohta";
-"statistics.graph.title" = "Tegevus aja jooksul";
-"statistics.daily.empty" = "Salvestusi pole veel";
-"statistics.filter.week" = "See nädal";
-"statistics.filter.month" = "See kuu";
-"statistics.filter.alltime" = "Kogu aeg";
 
 // MARK: - History View
 "history.title" = "Ajalugu";

--- a/app/macos/hyperwhisper/Localizations/et.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/et.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versioon %@";
 "home.recent.updates.new.badge" = "UUS";
 "home.recent.updates.no.notes" = "Väljalaskemärkmed puuduvad";
+"home.stats.words.week" = "Sõnu sel nädalal";
+"home.stats.words.month" = "Sõnu sel kuul";
+"home.stats.speed" = "Keskmine kiirus";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Soovitatav Mac-idele, millel on 24 GB ühendatud mälu või rohkem. Kiirus sõltub kiibist — kiirem M3/M4 Pro ja uuematel.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Sõnad sel aastal";
+"home.stats.typing.speed.help" = "Muuda eeldatavat kirjutamiskiirust (WPM), mille alusel säästetud aega hinnatakse.";
+"home.stats.saved.week" = "Sel nädalal säästetud";
+"home.stats.minutes.value" = "%d minutit";
 "vocabulary.input.placeholder" = "Lisa sõna või loo katkend";
 "vocabulary.action.addWord" = "Lisa sõna";
 "vocabulary.action.replaceWith" = "Asenda järgmisega…";
@@ -671,8 +677,13 @@ Muuda neid režiime, et valida enne eemaldamist mõni muu mudel.";
 "modes.cloudAccuracy.groqWhisper.description" = "Kiire ja taskukohane. Parim kiire transkriptsioonide jaoks.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Tasakaalustatud kiirus ja täpsus. Soovitatav enamikule kasutajatele.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Kõrgeim täpsus aeglasema töötlemisega. Parim tähtsate transkriptsioonide jaoks.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ krediiti/min";
 "modes.cloudAccuracy.grokStt.label" = "Kõrgeim (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Kõrgeim täpsus aeglasema töötlemisega. Parim tähtsate transkriptsioonide jaoks.";
+"modes.cloudAccuracy.googleChirp3.label" = "Kõrge (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 mudeliga Chirp 3. Mitmekeelne, fraasikohandusega.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Kõrge (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 Azure Speech kaudu. 43 keelt koos kontekstipõhise kohandusega.";
 
 "modes.create.title" = "Loo uus režiim";
 "modes.create.subtitle" = "Konfigureeri kohandatud transkriptsiooni profiil";
@@ -883,6 +894,15 @@ Ennе kustutamist uuenda neid režiime teise mudeli kasutamiseks.";
 "transcription.guidance.timeout" = "Päring võttis liiga kaua aega. Kontrollige oma interneti kiirust ja proovige uuesti.";
 "transcription.error.noSpeechDetected" = "Salvestuses ei tuvastatud kõnet.";
 "transcription.guidance.noSpeechDetected" = "Näpunäited:\n• Rääkige selgelt mikrofonisse\n• Hoidke klahvi kauem enne rääkimist\n• Kontrollige, et teie mikrofon töötab\n• Veenduge, et õige sisendseade on valitud";
+"transcription.guidance.needsNativeRelaunch" = "Kohaliku järeltöötluse kasutamiseks sulge HyperWhisper ja ava see uuesti natiivselt.";
+"transcription.guidance.localRuntimeUnavailable" = "Proovi uuesti või vali režiimi seadetes väiksem kohalik mudel.";
+"transcription.error.localRuntimeUnavailable" = "Kohalik tehisintellekt ei saanud tööd lõpetada — töötlemata transkriptsioon säilitati.";
+"settings.backup.localDownload.title" = "Kas laadida kohalikud mudelid alla?";
+"settings.backup.localDownload.message" = "%d taastatud režiimi kasutavad seadmesisese tehisintellekti mudeleid, mida pole veel alla laaditud.";
+"settings.backup.localDownload.downloadAll" = "Laadi kõik alla";
+"settings.backup.localDownload.dismiss" = "Sulge";
+"modelLibrary.local.requiresAppleSilicon" = "Vajalik on Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Taaskäivita natiivselt";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Ebapiisavad krediidid. Lisage rohkem krediite seadetes.";

--- a/app/macos/hyperwhisper/Localizations/fi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/fi.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Koti";
-"sidebar.statistics" = "Tilastot";
 "sidebar.modes" = "Tilat";
 "sidebar.vocabulary" = "Sanasto";
 "sidebar.streaming" = "Suoratoisto";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Aloita HyperWhisperin käyttö";
-"sidebar.statistics.help" = "Näytä käyttötilastot ja analytiikka";
 "sidebar.modes.help" = "Hallinnoi transkriptiotiloja eri konteksteissa";
 "sidebar.vocabulary.help" = "Lisää mukautettuja sanoja ja lauseita paremman tunnistuksen saavuttamiseksi";
 "sidebar.streaming.help" = "Reaaliaikaisen suoratranskription asetukset (vaatii internetin)";
@@ -553,22 +551,6 @@ Muokkaa näitä tiloja valitaksesi eri mallin ennen sen poistamista.";
 "models.error.checksumFailed" = "Mallin tarkistussumman vahvistus epäonnistui. Lataus saattaa olla vaurioitunut.";
 
 // MARK: - Statistics View
-"statistics.title" = "Tilastot";
-"statistics.header.title" = "Käyttötilastosi";
-"statistics.header.subtitle" = "Seuraa transkriptiotoimintaasi ja suorituskykyäsi";
-"statistics.card.recordings" = "Nauhoitukset yhteensä";
-"statistics.card.recordings.subtitle" = "Valmiit transkriptiot";
-"statistics.card.duration" = "Aika yhteensä";
-"statistics.card.duration.subtitle" = "Nauhoitukseen käytetty aika";
-"statistics.card.words" = "Sanat yhteensä";
-"statistics.card.words.subtitle" = "Transkriptoituja sanoja";
-"statistics.card.average" = "Keskimääräinen kesto";
-"statistics.card.average.subtitle" = "Per nauhoitus";
-"statistics.graph.title" = "Toiminta ajan mittaan";
-"statistics.daily.empty" = "Ei vielä nauhoituksia";
-"statistics.filter.week" = "Tällä viikolla";
-"statistics.filter.month" = "Tässä kuussa";
-"statistics.filter.alltime" = "Kaikkina aikoina";
 
 // MARK: - History View
 "history.title" = "Historia";

--- a/app/macos/hyperwhisper/Localizations/fi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/fi.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versio %@";
 "home.recent.updates.new.badge" = "UUTTA";
 "home.recent.updates.no.notes" = "Ei julkaisumuistiinpanoja saatavilla";
+"home.stats.words.week" = "Sanoja tällä viikolla";
+"home.stats.words.month" = "Sanoja tässä kuussa";
+"home.stats.speed" = "Keskinopeus";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Suositellaan Mac-tietokoneille, joissa on 24 GB yhtenäistä muistia tai enemmän. Nopeus riippuu sirusta — nopeampi M3/M4 Pro -piirillä ja sitä uudemmilla.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Sanoja tänä vuonna";
+"home.stats.typing.speed.help" = "Säädä oletettua kirjoitusnopeutta (WPM), jonka perusteella säästetty aika arvioidaan.";
+"home.stats.saved.week" = "Säästetty tällä viikolla";
+"home.stats.minutes.value" = "%d minuuttia";
 "vocabulary.input.placeholder" = "Lisää sana tai luo katkelma";
 "vocabulary.action.addWord" = "Lisää sana";
 "vocabulary.action.replaceWith" = "Korvaa seuraavalla…";
@@ -671,8 +677,13 @@ Muokkaa näitä tiloja valitaksesi eri mallin ennen sen poistamista.";
 "modes.cloudAccuracy.groqWhisper.description" = "Nopea ja edullinen. Paras nopeisiin transkriptioihin.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Tasapainoinen nopeus ja tarkkuus. Suositeltu useimmille käyttäjille.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Korkein tarkkuus hitaamman käsittelyn kustannuksella. Paras tärkeisiin transkriptioihin.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ krediittiä/min";
 "modes.cloudAccuracy.grokStt.label" = "Korkein (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Korkein tarkkuus hitaamman käsittelyn kustannuksella. Paras tärkeisiin transkriptioihin.";
+"modes.cloudAccuracy.googleChirp3.label" = "Korkea (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 ja Chirp 3. Monikielinen, tukee lausemukautusta.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Korkea (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 Azure Speech -palvelun kautta. 43 kieltä ja kontekstipohjainen painotus.";
 
 "modes.create.title" = "Luo uusi tila";
 "modes.create.subtitle" = "Määritä mukautettu transkriptioprofiili";
@@ -883,6 +894,15 @@ Päivitä nämä tilat käyttämään eri mallia ennen poistamista.";
 "transcription.guidance.timeout" = "Pyyntö kesti liian kauan. Tarkista internet-nopeutesi ja yritä uudelleen.";
 "transcription.error.noSpeechDetected" = "Nauhoituksessa ei havaittu puhetta.";
 "transcription.guidance.noSpeechDetected" = "Vinkkejä:\n• Puhu selvästi mikrofoniin\n• Pidä näppäintä pidempään ennen puhumista\n• Tarkista, että mikrofonisi toimii\n• Varmista, että oikea tulolaite on valittu";
+"transcription.guidance.needsNativeRelaunch" = "Lopeta HyperWhisper ja avaa se uudelleen natiivina, jotta voit käyttää paikallista jälkikäsittelyä.";
+"transcription.guidance.localRuntimeUnavailable" = "Yritä uudelleen tai valitse pienempi paikallinen malli tilan asetuksista.";
+"transcription.error.localRuntimeUnavailable" = "Paikallinen tekoäly ei saanut käsittelyä valmiiksi — käsittelemätön litterointi säilytettiin.";
+"settings.backup.localDownload.title" = "Ladataanko paikalliset mallit?";
+"settings.backup.localDownload.message" = "%d palautetuista tiloistasi käyttää laitteessa toimivia tekoälymalleja, joita ei ole vielä ladattu.";
+"settings.backup.localDownload.downloadAll" = "Lataa kaikki";
+"settings.backup.localDownload.dismiss" = "Sulje";
+"modelLibrary.local.requiresAppleSilicon" = "Vaatii Apple Silicon -suorittimen";
+"modelLibrary.local.needsNativeRelaunch" = "Käynnistä uudelleen natiivina";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Krediitit eivät riitä. Lisää krediittejä asetuksissa.";

--- a/app/macos/hyperwhisper/Localizations/fr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/fr.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Version %@";
 "home.recent.updates.new.badge" = "NOUVEAU";
 "home.recent.updates.no.notes" = "Aucune note de version disponible";
+"home.stats.words.week" = "Mots cette semaine";
+"home.stats.words.month" = "Mots ce mois-ci";
+"home.stats.speed" = "Vitesse moyenne";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Recommandé pour les Mac avec 24 GB de mémoire unifiée ou plus. La vitesse dépend de la puce — plus rapide sur M3/M4 Pro et supérieur.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Mots cette année";
+"home.stats.typing.speed.help" = "Ajustez la vitesse de frappe supposée (WPM) utilisée pour estimer le temps gagné.";
+"home.stats.saved.week" = "Gagné cette semaine";
+"home.stats.minutes.value" = "%d minutes";
 "vocabulary.input.placeholder" = "Ajouter un mot ou créer un extrait";
 "vocabulary.action.addWord" = "Ajouter un mot";
 "vocabulary.action.replaceWith" = "Remplacer par…";
@@ -671,8 +677,13 @@ Modifiez ces modes pour sélectionner un modèle différent avant de le supprime
 "modes.cloudAccuracy.groqWhisper.description" = "Rapide et économique. Idéal pour les transcriptions rapides.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Équilibre entre vitesse et précision. Recommandé pour la plupart des utilisateurs.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Précision maximale avec traitement plus lent. Idéal pour les transcriptions importantes.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ crédits/min";
 "modes.cloudAccuracy.grokStt.label" = "Maximale (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Précision maximale avec traitement plus lent. Idéal pour les transcriptions importantes.";
+"modes.cloudAccuracy.googleChirp3.label" = "Élevée (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 avec Chirp 3. Multilingue avec adaptation d'expressions.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Élevée (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 via Azure Speech. 43 langues avec adaptation contextuelle.";
 
 "modes.create.title" = "Créer un nouveau mode";
 "modes.create.subtitle" = "Configurer un profil de transcription personnalisé";
@@ -883,6 +894,15 @@ Mettez à jour ces modes pour utiliser un autre modèle avant de supprimer.";
 "transcription.guidance.timeout" = "La requête a pris trop de temps. Vérifiez votre vitesse Internet et réessayez.";
 "transcription.error.noSpeechDetected" = "Aucune parole détectée dans l'enregistrement.";
 "transcription.guidance.noSpeechDetected" = "Conseils :\n• Parlez clairement dans le microphone\n• Maintenez la touche plus longtemps avant de parler\n• Vérifiez que votre microphone fonctionne\n• Assurez-vous que le bon périphérique d'entrée est sélectionné";
+"transcription.guidance.needsNativeRelaunch" = "Quittez puis rouvrez HyperWhisper en mode natif pour utiliser le post-traitement local.";
+"transcription.guidance.localRuntimeUnavailable" = "Réessayez ou choisissez un modèle local plus léger dans les réglages de votre mode.";
+"transcription.error.localRuntimeUnavailable" = "L'IA locale n'a pas pu terminer — votre transcription brute a été conservée.";
+"settings.backup.localDownload.title" = "Télécharger les modèles locaux ?";
+"settings.backup.localDownload.message" = "%d de vos modes restaurés utilisent des modèles d'IA sur l'appareil qui ne sont pas encore téléchargés.";
+"settings.backup.localDownload.downloadAll" = "Tout télécharger";
+"settings.backup.localDownload.dismiss" = "Ignorer";
+"modelLibrary.local.requiresAppleSilicon" = "Nécessite Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Relancer en mode natif";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Crédits insuffisants. Ajoutez des crédits dans Réglages.";

--- a/app/macos/hyperwhisper/Localizations/fr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/fr.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Accueil";
-"sidebar.statistics" = "Statistiques";
 "sidebar.modes" = "Modes";
 "sidebar.vocabulary" = "Vocabulary";
 "sidebar.streaming" = "Diffusion";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Commencer avec HyperWhisper";
-"sidebar.statistics.help" = "Voir les statistiques et analyses d’utilisation";
 "sidebar.modes.help" = "Gérer les modes de transcription selon le contexte";
 "sidebar.vocabulary.help" = "Ajouter des mots et expressions personnalisés pour une meilleure reconnaissance";
 "sidebar.streaming.help" = "Réglages de transcription en streaming temps réel (Internet requis)";
@@ -553,22 +551,6 @@ Modifiez ces modes pour sélectionner un modèle différent avant de le supprime
 "models.error.checksumFailed" = "Échec de vérification de checksum du modèle. Le téléchargement peut être corrompu.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistiques";
-"statistics.header.title" = "Vos statistiques d’utilisation";
-"statistics.header.subtitle" = "Suivez votre activité et vos performances de transcription";
-"statistics.card.recordings" = "Enregistrements totaux";
-"statistics.card.recordings.subtitle" = "Transcriptions terminées";
-"statistics.card.duration" = "Temps total";
-"statistics.card.duration.subtitle" = "Temps passé à enregistrer";
-"statistics.card.words" = "Mots totaux";
-"statistics.card.words.subtitle" = "Mots transcrits";
-"statistics.card.average" = "Durée moyenne";
-"statistics.card.average.subtitle" = "Par enregistrement";
-"statistics.graph.title" = "Activité dans le temps";
-"statistics.daily.empty" = "Aucun enregistrement pour l’instant";
-"statistics.filter.week" = "Cette semaine";
-"statistics.filter.month" = "Ce mois-ci";
-"statistics.filter.alltime" = "Depuis le début";
 
 // MARK: - History View
 "history.title" = "Historique";

--- a/app/macos/hyperwhisper/Localizations/he.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/he.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "גרסה %@";
 "home.recent.updates.new.badge" = "חדש";
 "home.recent.updates.no.notes" = "אין הערות שחרור זמינות";
+"home.stats.words.week" = "מילים השבוע";
+"home.stats.words.month" = "מילים החודש";
+"home.stats.speed" = "מהירות ממוצעת";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "מומלץ עבור Mac עם 24 GB של זיכרון מאוחד או יותר. המהירות תלויה בשבב — מהיר יותר ב-M3/M4 Pro ומעלה.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "מילים השנה";
+"home.stats.typing.speed.help" = "התאמת מהירות ההקלדה המשוערת (WPM) המשמשת לחישוב הזמן שנחסך.";
+"home.stats.saved.week" = "נחסכו השבוע";
+"home.stats.minutes.value" = "%d דקות";
 "vocabulary.input.placeholder" = "הוסף מילה או צור קטע";
 "vocabulary.action.addWord" = "הוסף מילה";
 "vocabulary.action.replaceWith" = "החלף בـ…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "מהיר ומשתלם. הטוב ביותר לתמלולים מהירים.";
 "modes.cloudAccuracy.deepgramNova3.description" = "מאוזן בין מהירות לדיוק. מומלץ לרוב המשתמשים.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - הדיוק הגבוה ביותר עם עיבוד איטי יותר. הטוב ביותר לתמלולים חשובים.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ קרדיטים/דק׳";
 "modes.cloudAccuracy.grokStt.label" = "הגבוה ביותר (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - הדיוק הגבוה ביותר עם עיבוד איטי יותר. הטוב ביותר לתמלולים חשובים.";
+"modes.cloudAccuracy.googleChirp3.label" = "גבוהה (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 עם Chirp 3. רב-לשוני עם התאמת ביטויים.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "גבוהה (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 דרך Azure Speech. 43 שפות עם הטיה לפי הקשר.";
 
 "modes.create.title" = "צור מצב חדש";
 "modes.create.subtitle" = "הגדר פרופיל תמלול מותאם אישית";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "הבקשה ארכה יותר מדי זמן. בדוק את מהירות האינטרנט שלך ונסה שוב.";
 "transcription.error.noSpeechDetected" = "לא זוהה דיבור בהקלטה.";
 "transcription.guidance.noSpeechDetected" = "טיפים:\n• דבר בבירור למיקרופון\n• החזק את המקש זמן רב יותר לפני הדיבור\n• בדוק שהמיקרופון שלך עובד\n• ודא שהתקן הקלט הנכון נבחר";
+"transcription.guidance.needsNativeRelaunch" = "צא מ-HyperWhisper ופתח אותה מחדש כאפליקציה מקורית כדי להשתמש בעיבוד מקומי.";
+"transcription.guidance.localRuntimeUnavailable" = "נסה שוב, או בחר מודל מקומי קטן יותר בהגדרות המצב.";
+"transcription.error.localRuntimeUnavailable" = "ה-AI המקומי לא הצליח לסיים — התמלול הגולמי נשמר.";
+"settings.backup.localDownload.title" = "להוריד מודלים מקומיים?";
+"settings.backup.localDownload.message" = "%d מהמצבים ששוחזרו משתמשים במודלי AI מקומיים שטרם הורדו.";
+"settings.backup.localDownload.downloadAll" = "הורד הכול";
+"settings.backup.localDownload.dismiss" = "התעלם";
+"modelLibrary.local.requiresAppleSilicon" = "דורש Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "הפעלה מחדש כאפליקציה מקורית";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "אין מספיק נקודות זכות. הוסף עוד נקודות זכות בהגדרות.";

--- a/app/macos/hyperwhisper/Localizations/he.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/he.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "בית";
-"sidebar.statistics" = "סטטיסטיקה";
 "sidebar.modes" = "מצבים";
 "sidebar.vocabulary" = "אוצר מילים";
 "sidebar.streaming" = "סטרימינג";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "התחל עם HyperWhisper";
-"sidebar.statistics.help" = "הצג סטטיסטיקות שימוש וניתוח";
 "sidebar.modes.help" = "נהל מצבי תמלול להקשרים שונים";
 "sidebar.vocabulary.help" = "הוסף מילים וביטויים מותאמים אישית לזיהוי טוב יותר";
 "sidebar.streaming.help" = "הגדרות תמלול סטרימינג בזמן אמת (דורש אינטרנט)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "אימות סכום ביקורת של המודל נכשל. ייתכן שההורדה פגומה.";
 
 // MARK: - Statistics View
-"statistics.title" = "סטטיסטיקה";
-"statistics.header.title" = "סטטיסטיקת השימוש שלך";
-"statistics.header.subtitle" = "עקוב אחר פעילות התמלול והביצועים שלך";
-"statistics.card.recordings" = "סה\"כ הקלטות";
-"statistics.card.recordings.subtitle" = "תמלולים שהושלמו";
-"statistics.card.duration" = "זמן כולל";
-"statistics.card.duration.subtitle" = "זמן שהוקדש להקלטה";
-"statistics.card.words" = "סה\"כ מילים";
-"statistics.card.words.subtitle" = "מילים שתומללו";
-"statistics.card.average" = "משך ממוצע";
-"statistics.card.average.subtitle" = "לכל הקלטה";
-"statistics.graph.title" = "פעילות לאורך זמן";
-"statistics.daily.empty" = "אין עדיין הקלטות";
-"statistics.filter.week" = "השבוע";
-"statistics.filter.month" = "החודש";
-"statistics.filter.alltime" = "כל הזמנים";
 
 // MARK: - History View
 "history.title" = "היסטוריה";

--- a/app/macos/hyperwhisper/Localizations/hi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hi.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "होम";
-"sidebar.statistics" = "आंकड़े";
 "sidebar.modes" = "मोड";
 "sidebar.vocabulary" = "शब्दावली";
 "sidebar.streaming" = "स्ट्रीमिंग";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "HyperWhisper के साथ शुरुआत करें";
-"sidebar.statistics.help" = "उपयोग आंकड़े और विश्लेषण देखें";
 "sidebar.modes.help" = "विभिन्न संदर्भों के लिए ट्रांसक्रिप्शन मोड प्रबंधित करें";
 "sidebar.vocabulary.help" = "बेहतर पहचान के लिए कस्टम शब्द और वाक्यांश जोड़ें";
 "sidebar.streaming.help" = "रीयल-टाइम स्ट्रीमिंग ट्रांसक्रिप्शन सेटिंग्स (इंटरनेट की आवश्यकता है)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "मॉडल चेकसम सत्यापन विफल। डाउनलोड क्षतिग्रस्त हो सकता है।";
 
 // MARK: - Statistics View
-"statistics.title" = "आंकड़े";
-"statistics.header.title" = "आपके उपयोग के आंकड़े";
-"statistics.header.subtitle" = "अपनी ट्रांसक्रिप्शन गतिविधि और प्रदर्शन को ट्रैक करें";
-"statistics.card.recordings" = "कुल रिकॉर्डिंग";
-"statistics.card.recordings.subtitle" = "पूर्ण ट्रांसक्रिप्शन";
-"statistics.card.duration" = "कुल समय";
-"statistics.card.duration.subtitle" = "रिकॉर्डिंग में बिताया गया समय";
-"statistics.card.words" = "कुल शब्द";
-"statistics.card.words.subtitle" = "ट्रांसक्राइब किए गए शब्द";
-"statistics.card.average" = "औसत अवधि";
-"statistics.card.average.subtitle" = "प्रति रिकॉर्डिंग";
-"statistics.graph.title" = "समय के साथ गतिविधि";
-"statistics.daily.empty" = "अभी तक कोई रिकॉर्डिंग नहीं";
-"statistics.filter.week" = "इस हफ्ते";
-"statistics.filter.month" = "इस महीने";
-"statistics.filter.alltime" = "सभी समय";
 
 // MARK: - History View
 "history.title" = "इतिहास";

--- a/app/macos/hyperwhisper/Localizations/hi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hi.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "संस्करण %@";
 "home.recent.updates.new.badge" = "नया";
 "home.recent.updates.no.notes" = "कोई रिलीज़ नोट उपलब्ध नहीं";
+"home.stats.words.week" = "इस सप्ताह के शब्द";
+"home.stats.words.month" = "इस महीने के शब्द";
+"home.stats.speed" = "औसत गति";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "24 GB यूनिफाइड मेमोरी या अधिक वाले Mac के लिए अनुशंसित। गति आपके चिप पर निर्भर करती है — M3/M4 Pro और उससे ऊपर पर तेज़।";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "इस वर्ष के शब्द";
+"home.stats.typing.speed.help" = "बचे हुए समय का अनुमान लगाने के लिए मानी गई टाइपिंग गति (WPM) समायोजित करें।";
+"home.stats.saved.week" = "इस सप्ताह बचा समय";
+"home.stats.minutes.value" = "%d मिनट";
 "vocabulary.input.placeholder" = "कोई शब्द जोड़ें या स्निपेट बनाएं";
 "vocabulary.action.addWord" = "शब्द जोड़ें";
 "vocabulary.action.replaceWith" = "इससे बदलें…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "तेज़ और सस्ता। त्वरित ट्रांसक्रिप्शन के लिए सर्वोत्तम।";
 "modes.cloudAccuracy.deepgramNova3.description" = "संतुलित गति और सटीकता। अधिकांश उपयोगकर्ताओं के लिए अनुशंसित।";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - सर्वोच्च सटीकता धीमी प्रोसेसिंग के साथ। महत्वपूर्ण ट्रांसक्रिप्शन के लिए सर्वोत्तम।";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ क्रेडिट/मिनट";
 "modes.cloudAccuracy.grokStt.label" = "सर्वोच्च (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - सर्वोच्च सटीकता धीमी प्रोसेसिंग के साथ। महत्वपूर्ण ट्रांसक्रिप्शन के लिए सर्वोत्तम।";
+"modes.cloudAccuracy.googleChirp3.label" = "उच्च (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Chirp 3 के साथ Google Cloud Speech-to-Text V2। फ़्रेज़ अनुकूलन के साथ बहुभाषी।";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "उच्च (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Azure Speech के ज़रिए Microsoft MAI-Transcribe 1.5। संदर्भ-आधारित बायसिंग के साथ 43 भाषाएँ।";
 
 "modes.create.title" = "नया मोड बनाएं";
 "modes.create.subtitle" = "एक कस्टम ट्रांसक्रिप्शन प्रोफ़ाइल कॉन्फ़िगर करें";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "अनुरोध में बहुत समय लगा। अपनी इंटरनेट गति जांचें और फिर से प्रयास करें।";
 "transcription.error.noSpeechDetected" = "रिकॉर्डिंग में कोई भाषण का पता नहीं चला।";
 "transcription.guidance.noSpeechDetected" = "सुझाव:\n• माइक्रोफ़ोन में स्पष्ट रूप से बोलें\n• कुंजी को दबाने से पहले लंबे समय तक दबाएं\n• जांचें कि आपका माइक्रोफ़ोन काम कर रहा है\n• सुनिश्चित करें कि सही इनपुट डिवाइस चयनित है";
+"transcription.guidance.needsNativeRelaunch" = "लोकल पोस्ट-प्रोसेसिंग इस्तेमाल करने के लिए HyperWhisper को बंद करके नेटिव रूप से फिर से खोलें।";
+"transcription.guidance.localRuntimeUnavailable" = "फिर से कोशिश करें, या अपनी मोड सेटिंग में कोई छोटा लोकल मॉडल चुनें।";
+"transcription.error.localRuntimeUnavailable" = "लोकल AI पूरा नहीं कर सका — आपका मूल ट्रांसक्रिप्ट सहेज लिया गया है।";
+"settings.backup.localDownload.title" = "लोकल मॉडल डाउनलोड करें?";
+"settings.backup.localDownload.message" = "आपके पुनर्स्थापित किए गए %d मोड ऐसे ऑन-डिवाइस AI मॉडल का उपयोग करते हैं जो अभी डाउनलोड नहीं हुए हैं।";
+"settings.backup.localDownload.downloadAll" = "सभी डाउनलोड करें";
+"settings.backup.localDownload.dismiss" = "खारिज करें";
+"modelLibrary.local.requiresAppleSilicon" = "Apple Silicon आवश्यक है";
+"modelLibrary.local.needsNativeRelaunch" = "नेटिव रूप से फिर से लॉन्च करें";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "अपर्याप्त क्रेडिट। सेटिंग्स में अधिक क्रेडिट जोड़ें।";

--- a/app/macos/hyperwhisper/Localizations/hr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hr.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Početna";
-"sidebar.statistics" = "Statistika";
 "sidebar.modes" = "Načini";
 "sidebar.vocabulary" = "Rječnik";
 "sidebar.streaming" = "Strujanje";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Započnite s HyperWhisper";
-"sidebar.statistics.help" = "Pregledajte statistiku korištenja i analitiku";
 "sidebar.modes.help" = "Upravljajte načinima transkripcije za različite kontekste";
 "sidebar.vocabulary.help" = "Dodajte prilagođene riječi i fraze za bolje prepoznavanje";
 "sidebar.streaming.help" = "Postavke transkripcije u stvarnom vremenu (potreban internet)";
@@ -553,22 +551,6 @@ Uredi te načine rada kako bi odabrao drugi model prije uklanjanja.";
 "models.error.checksumFailed" = "Provjera kontrolnog zbroja modela nije uspjela. Preuzimanje može biti oštećeno.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistika";
-"statistics.header.title" = "Vaša statistika korištenja";
-"statistics.header.subtitle" = "Pratite svoju aktivnost transkripcije i performanse";
-"statistics.card.recordings" = "Ukupno snimanja";
-"statistics.card.recordings.subtitle" = "Dovršene transkripcije";
-"statistics.card.duration" = "Ukupno vrijeme";
-"statistics.card.duration.subtitle" = "Vrijeme provedeno snimajući";
-"statistics.card.words" = "Ukupno riječi";
-"statistics.card.words.subtitle" = "Transkribirane riječi";
-"statistics.card.average" = "Prosječno trajanje";
-"statistics.card.average.subtitle" = "Po snimanju";
-"statistics.graph.title" = "Aktivnost tijekom vremena";
-"statistics.daily.empty" = "Još nema snimanja";
-"statistics.filter.week" = "Ovaj tjedan";
-"statistics.filter.month" = "Ovaj mjesec";
-"statistics.filter.alltime" = "Cijelo vrijeme";
 
 // MARK: - History View
 "history.title" = "Povijest";

--- a/app/macos/hyperwhisper/Localizations/hr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hr.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Verzija %@";
 "home.recent.updates.new.badge" = "NOVO";
 "home.recent.updates.no.notes" = "Nema dostupnih bilješki o izdanju";
+"home.stats.words.week" = "Riječi ovaj tjedan";
+"home.stats.words.month" = "Riječi ovaj mjesec";
+"home.stats.speed" = "Prosječna brzina";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Preporučeno za Mac s 24 GB objedinjene memorije ili više. Brzina ovisi o čipu — brže na M3/M4 Pro i novijima.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Riječi ove godine";
+"home.stats.typing.speed.help" = "Prilagodite pretpostavljenu brzinu tipkanja (WPM) koja se koristi za procjenu uštede vremena.";
+"home.stats.saved.week" = "Ušteđeno ovaj tjedan";
+"home.stats.minutes.value" = "%d minuta";
 "vocabulary.input.placeholder" = "Dodajte riječ ili stvorite isječak";
 "vocabulary.action.addWord" = "Dodaj riječ";
 "vocabulary.action.replaceWith" = "Zamijeni s…";
@@ -671,8 +677,13 @@ Uredi te načine rada kako bi odabrao drugi model prije uklanjanja.";
 "modes.cloudAccuracy.groqWhisper.description" = "Brzo i pristupačno. Najbolje za brze transkripcije.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Uravnotežena brzina i točnost. Preporučeno za većinu korisnika.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Najviša točnost sa sporijim obradom. Najbolje za važne transkripcije.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredita/min";
 "modes.cloudAccuracy.grokStt.label" = "Najviša (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Najviša točnost sa sporijim obradom. Najbolje za važne transkripcije.";
+"modes.cloudAccuracy.googleChirp3.label" = "Visoka (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 s modelom Chirp 3. Višejezično uz prilagodbu fraza.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Visoka (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 putem Azure Speech. 43 jezika s kontekstualnim usmjeravanjem.";
 
 "modes.create.title" = "Stvori novi način";
 "modes.create.subtitle" = "Konfiguriraj prilagođeni profil transkripcije";
@@ -883,6 +894,15 @@ Prije brisanja ažurirajte ove načine rada da koriste drugi model.";
 "transcription.guidance.timeout" = "Zahtjev je trajao predugo. Provjerite brzinu svog interneta i pokušajte ponovno.";
 "transcription.error.noSpeechDetected" = "Nije otkriven govor u snimci.";
 "transcription.guidance.noSpeechDetected" = "Savjeti:\n• Govorite jasno u mikrofon\n• Držite tipku dulje prije govora\n• Provjerite radi li vaš mikrofon\n• Osigurajte da je odabran ispravan ulazni uređaj";
+"transcription.guidance.needsNativeRelaunch" = "Zatvorite i ponovno otvorite HyperWhisper kao izvornu aplikaciju kako biste koristili lokalnu naknadnu obradu.";
+"transcription.guidance.localRuntimeUnavailable" = "Pokušajte ponovno ili u postavkama načina rada odaberite manji lokalni model.";
+"transcription.error.localRuntimeUnavailable" = "Lokalni AI nije uspio dovršiti obradu — vaš izvorni prijepis je sačuvan.";
+"settings.backup.localDownload.title" = "Preuzeti lokalne modele?";
+"settings.backup.localDownload.message" = "%d vaših vraćenih načina rada koristi AI modele na uređaju koji još nisu preuzeti.";
+"settings.backup.localDownload.downloadAll" = "Preuzmi sve";
+"settings.backup.localDownload.dismiss" = "Odbaci";
+"modelLibrary.local.requiresAppleSilicon" = "Zahtijeva Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Ponovno pokreni izvorno";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nedovoljno kredita. Dodajte više kredita u Postavkama.";

--- a/app/macos/hyperwhisper/Localizations/hu.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hu.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Verzió %@";
 "home.recent.updates.new.badge" = "ÚJ";
 "home.recent.updates.no.notes" = "Nincsenek kiadási megjegyzések";
+"home.stats.words.week" = "Szavak ezen a héten";
+"home.stats.words.month" = "Szavak ebben a hónapban";
+"home.stats.speed" = "Átlagos sebesség";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "24 GB egységesített memóriával vagy többel rendelkező Mac számítógépekhez ajánlott. A sebesség a chiptől függ — gyorsabb M3/M4 Pro és újabb chipeken.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Szavak ebben az évben";
+"home.stats.typing.speed.help" = "Az időmegtakarítás becsléséhez használt feltételezett gépelési sebesség (WPM) módosítása.";
+"home.stats.saved.week" = "Megtakarítva ezen a héten";
+"home.stats.minutes.value" = "%d perc";
 "vocabulary.input.placeholder" = "Adjon hozzá egy szót vagy hozzon létre részletet";
 "vocabulary.action.addWord" = "Szó hozzáadása";
 "vocabulary.action.replaceWith" = "Csere erre…";
@@ -671,8 +677,13 @@ Szerkeszd ezeket a módokat, hogy eltávolítás előtt válassz másik modellt.
 "modes.cloudAccuracy.groqWhisper.description" = "Gyors és megfizethető. Legjobb gyors átírásokhoz.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Kiegyensúlyozott sebesség és pontosság. Ajánlott a legtöbb felhasználónak.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Legmagasabb pontosság lassabb feldolgozással. Legjobb fontos átírásokhoz.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredit/perc";
 "modes.cloudAccuracy.grokStt.label" = "Legmagasabb (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Legmagasabb pontosság lassabb feldolgozással. Legjobb fontos átírásokhoz.";
+"modes.cloudAccuracy.googleChirp3.label" = "Magas (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 a Google Chirp 3 modellel. Többnyelvű, kifejezésadaptációval.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Magas (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 az Azure Speech szolgáltatáson keresztül. 43 nyelv, kontextusalapú súlyozással.";
 
 "modes.create.title" = "Új mód létrehozása";
 "modes.create.subtitle" = "Egyéni átírási profil konfigurálása";
@@ -883,6 +894,15 @@ A törlés előtt frissítsd ezeket a módokat, hogy más modellt használjanak.
 "transcription.guidance.timeout" = "A kérés túl sokáig tartott. Ellenőrizd az internet sebességet és próbáld újra.";
 "transcription.error.noSpeechDetected" = "Nem észlelhető beszéd a felvételben.";
 "transcription.guidance.noSpeechDetected" = "Tippek:\n• Beszélj tisztán a mikrofonba\n• Tartsd lenyomva a billentyűt hosszabb ideig beszélés előtt\n• Ellenőrizd, hogy a mikrofonod működik-e\n• Győződj meg róla, hogy a helyes bemeneti eszköz van kiválasztva";
+"transcription.guidance.needsNativeRelaunch" = "A helyi utófeldolgozáshoz lépjen ki, és indítsa újra a HyperWhispert natív módban.";
+"transcription.guidance.localRuntimeUnavailable" = "Próbálja újra, vagy válasszon kisebb helyi modellt a Mód beállításaiban.";
+"transcription.error.localRuntimeUnavailable" = "A helyi MI nem tudta befejezni — a nyers átirat megmaradt.";
+"settings.backup.localDownload.title" = "Letölti a helyi modelleket?";
+"settings.backup.localDownload.message" = "A visszaállított módok közül %d olyan helyi MI-modellt használ, amely még nincs letöltve.";
+"settings.backup.localDownload.downloadAll" = "Az összes letöltése";
+"settings.backup.localDownload.dismiss" = "Elvetés";
+"modelLibrary.local.requiresAppleSilicon" = "Apple Silicon szükséges";
+"modelLibrary.local.needsNativeRelaunch" = "Újraindítás natív módban";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nincs elég kredit. Adj hozzá több kreditet a Beállításokban.";

--- a/app/macos/hyperwhisper/Localizations/hu.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hu.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Kezdőlap";
-"sidebar.statistics" = "Statisztikák";
 "sidebar.modes" = "Módok";
 "sidebar.vocabulary" = "Szókincs";
 "sidebar.streaming" = "Streamelés";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Kezdj el a HyperWhisperrel";
-"sidebar.statistics.help" = "Használati statisztikák és elemzések megtekintése";
 "sidebar.modes.help" = "Átírási módok kezelése különböző kontextusokhoz";
 "sidebar.vocabulary.help" = "Egyéni szavak és kifejezések hozzáadása jobb felismerésért";
 "sidebar.streaming.help" = "Valós idejű streamelési átírás beállítások (Internet szükséges)";
@@ -553,22 +551,6 @@ Szerkeszd ezeket a módokat, hogy eltávolítás előtt válassz másik modellt.
 "models.error.checksumFailed" = "Modell ellenőrző összeg ellenőrzés sikertelen. A letöltés sérült lehet.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statisztikák";
-"statistics.header.title" = "Használati statisztikáid";
-"statistics.header.subtitle" = "Átírási aktivitás és teljesítmény követése";
-"statistics.card.recordings" = "Összes felvétel";
-"statistics.card.recordings.subtitle" = "Befejezett átírások";
-"statistics.card.duration" = "Összes idő";
-"statistics.card.duration.subtitle" = "Felvételre fordított idő";
-"statistics.card.words" = "Összes szó";
-"statistics.card.words.subtitle" = "Átírt szavak";
-"statistics.card.average" = "Átlagos időtartam";
-"statistics.card.average.subtitle" = "Felvételenként";
-"statistics.graph.title" = "Aktivitás idővel";
-"statistics.daily.empty" = "Még nincsenek felvételek";
-"statistics.filter.week" = "Ez a hét";
-"statistics.filter.month" = "Ez a hónap";
-"statistics.filter.alltime" = "Minden idők";
 
 // MARK: - History View
 "history.title" = "Előzmények";

--- a/app/macos/hyperwhisper/Localizations/id.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/id.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Beranda";
-"sidebar.statistics" = "Statistik";
 "sidebar.modes" = "Mode";
 "sidebar.vocabulary" = "Kosakata";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Mulai dengan HyperWhisper";
-"sidebar.statistics.help" = "Lihat statistik penggunaan dan analitik";
 "sidebar.modes.help" = "Kelola mode transkripsi untuk konteks berbeda";
 "sidebar.vocabulary.help" = "Tambahkan kata dan frasa khusus untuk pengenalan lebih baik";
 "sidebar.streaming.help" = "Pengaturan transkripsi streaming waktu nyata (memerlukan Internet)";
@@ -553,22 +551,6 @@ Edit mode tersebut untuk memilih model yang berbeda sebelum menghapusnya.";
 "models.error.checksumFailed" = "Verifikasi checksum model gagal. Unduhan mungkin rusak.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistik";
-"statistics.header.title" = "Statistik Penggunaan Anda";
-"statistics.header.subtitle" = "Lacak aktivitas dan kinerja transkripsi Anda";
-"statistics.card.recordings" = "Total Rekaman";
-"statistics.card.recordings.subtitle" = "Transkripsi selesai";
-"statistics.card.duration" = "Total Waktu";
-"statistics.card.duration.subtitle" = "Waktu yang dihabiskan untuk merekam";
-"statistics.card.words" = "Total Kata";
-"statistics.card.words.subtitle" = "Kata-kata yang ditranskripsi";
-"statistics.card.average" = "Durasi Rata-rata";
-"statistics.card.average.subtitle" = "Per rekaman";
-"statistics.graph.title" = "Aktivitas Seiring Waktu";
-"statistics.daily.empty" = "Belum ada rekaman";
-"statistics.filter.week" = "Minggu Ini";
-"statistics.filter.month" = "Bulan Ini";
-"statistics.filter.alltime" = "Sepanjang Waktu";
 
 // MARK: - History View
 "history.title" = "Riwayat";

--- a/app/macos/hyperwhisper/Localizations/id.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/id.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versi %@";
 "home.recent.updates.new.badge" = "BARU";
 "home.recent.updates.no.notes" = "Tidak ada catatan rilis";
+"home.stats.words.week" = "Kata minggu ini";
+"home.stats.words.month" = "Kata bulan ini";
+"home.stats.speed" = "Kecepatan rata-rata";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Direkomendasikan untuk Mac dengan 24 GB unified memory atau lebih. Kecepatan tergantung pada chip — lebih cepat di M3/M4 Pro dan yang lebih tinggi.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Kata tahun ini";
+"home.stats.typing.speed.help" = "Sesuaikan asumsi kecepatan mengetik (WPM) yang dipakai untuk memperkirakan waktu yang dihemat.";
+"home.stats.saved.week" = "Dihemat minggu ini";
+"home.stats.minutes.value" = "%d menit";
 "vocabulary.input.placeholder" = "Tambahkan kata atau buat cuplikan";
 "vocabulary.action.addWord" = "Tambah kata";
 "vocabulary.action.replaceWith" = "Ganti dengan…";
@@ -671,8 +677,13 @@ Edit mode tersebut untuk memilih model yang berbeda sebelum menghapusnya.";
 "modes.cloudAccuracy.groqWhisper.description" = "Cepat dan terjangkau. Terbaik untuk transkripsi cepat.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Kecepatan dan akurasi seimbang. Direkomendasikan untuk sebagian besar pengguna.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Akurasi tertinggi dengan pemrosesan lebih lambat. Terbaik untuk transkripsi penting.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredit/mnt";
 "modes.cloudAccuracy.grokStt.label" = "Tertinggi (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Akurasi tertinggi dengan pemrosesan lebih lambat. Terbaik untuk transkripsi penting.";
+"modes.cloudAccuracy.googleChirp3.label" = "Tinggi (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 dengan Chirp 3. Multibahasa dengan adaptasi frasa.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Tinggi (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 melalui Azure Speech. 43 bahasa dengan bias kontekstual.";
 
 "modes.create.title" = "Buat Mode Baru";
 "modes.create.subtitle" = "Konfigurasi profil transkripsi khusus";
@@ -883,6 +894,15 @@ Perbarui mode-mode ini untuk menggunakan model yang berbeda sebelum menghapus.";
 "transcription.guidance.timeout" = "Permintaan memakan waktu terlalu lama. Periksa kecepatan internet Anda dan coba lagi.";
 "transcription.error.noSpeechDetected" = "Tidak ada ucapan terdeteksi dalam rekaman.";
 "transcription.guidance.noSpeechDetected" = "Tips:\n• Berbicara dengan jelas ke mikrofon\n• Tahan tombol lebih lama sebelum berbicara\n• Periksa apakah mikrofon Anda berfungsi\n• Pastikan perangkat input yang benar dipilih";
+"transcription.guidance.needsNativeRelaunch" = "Keluar lalu buka kembali HyperWhisper secara native untuk memakai pasca-pemrosesan lokal.";
+"transcription.guidance.localRuntimeUnavailable" = "Coba lagi, atau pilih model lokal yang lebih kecil di pengaturan Mode Anda.";
+"transcription.error.localRuntimeUnavailable" = "AI lokal tidak dapat menyelesaikan prosesnya — transkrip mentah Anda tetap disimpan.";
+"settings.backup.localDownload.title" = "Unduh model lokal?";
+"settings.backup.localDownload.message" = "%d mode yang Anda pulihkan menggunakan model AI di perangkat yang belum diunduh.";
+"settings.backup.localDownload.downloadAll" = "Unduh Semua";
+"settings.backup.localDownload.dismiss" = "Abaikan";
+"modelLibrary.local.requiresAppleSilicon" = "Memerlukan Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Jalankan ulang secara native";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Kredit tidak mencukupi. Tambahkan lebih banyak kredit di Pengaturan.";

--- a/app/macos/hyperwhisper/Localizations/is.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/is.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Heim";
-"sidebar.statistics" = "Tölfræði";
 "sidebar.modes" = "Hamar";
 "sidebar.vocabulary" = "Orðaforði";
 "sidebar.streaming" = "Streymi";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Byrjaðu með HyperWhisper";
-"sidebar.statistics.help" = "Skoða notkunartölfræði og greiningar";
 "sidebar.modes.help" = "Stjórna afritunarhamum fyrir mismunandi samhengi";
 "sidebar.vocabulary.help" = "Bæta við sérsniðnum orðum og orðasamböndum fyrir betri þekkingu";
 "sidebar.streaming.help" = "Rauntímastraumsafritun stillingar (krefst internets)";
@@ -553,22 +551,6 @@ Breyttu þessum stillingum til að velja annað líkan áður en þú fjarlægir
 "models.error.checksumFailed" = "Líkans gátsumustaðfesting mistókst. Sóttin gæti verið skemmd.";
 
 // MARK: - Statistics View
-"statistics.title" = "Tölfræði";
-"statistics.header.title" = "Notkunartölfræði þín";
-"statistics.header.subtitle" = "Fylgstu með afritunarstarfsemi og frammistöðu";
-"statistics.card.recordings" = "Heildarupptökur";
-"statistics.card.recordings.subtitle" = "Loknar afritanir";
-"statistics.card.duration" = "Heildartími";
-"statistics.card.duration.subtitle" = "Tími í upptöku";
-"statistics.card.words" = "Heildarorð";
-"statistics.card.words.subtitle" = "Orð afrituð";
-"statistics.card.average" = "Meðallengd";
-"statistics.card.average.subtitle" = "Á hverja upptöku";
-"statistics.graph.title" = "Starfsemi með tímanum";
-"statistics.daily.empty" = "Engar upptökur ennþá";
-"statistics.filter.week" = "Þessi vika";
-"statistics.filter.month" = "Þessi mánuður";
-"statistics.filter.alltime" = "Allan tímann";
 
 // MARK: - History View
 "history.title" = "Saga";

--- a/app/macos/hyperwhisper/Localizations/is.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/is.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Útgáfa %@";
 "home.recent.updates.new.badge" = "NÝTT";
 "home.recent.updates.no.notes" = "Engar útgáfuupplýsingar tiltækar";
+"home.stats.words.week" = "Orð í þessari viku";
+"home.stats.words.month" = "Orð í þessum mánuði";
+"home.stats.speed" = "Meðalhraði";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Mælt með fyrir Mac með 24 GB sameinað minni eða meira. Hraði fer eftir örgjörvanum — hraðari á M3/M4 Pro og nýrri.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Orð þetta ár";
+"home.stats.typing.speed.help" = "Stilltu áætlaðan innsláttarhraða (WPM) sem notaður er til að meta sparaðan tíma.";
+"home.stats.saved.week" = "Sparað í þessari viku";
+"home.stats.minutes.value" = "%d mínútur";
 "vocabulary.input.placeholder" = "Bættu við orði eða búðu til brot";
 "vocabulary.action.addWord" = "Bæta við orði";
 "vocabulary.action.replaceWith" = "Skipta út með…";
@@ -671,8 +677,13 @@ Breyttu þessum stillingum til að velja annað líkan áður en þú fjarlægir
 "modes.cloudAccuracy.groqWhisper.description" = "Hratt og hagkvæmt. Best fyrir skjótar afritanir.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Jafnvægi hraða og nákvæmni. Mælt með fyrir flesta notendur.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Hæsta nákvæmni með hægari vinnslu. Best fyrir mikilvægar afritanir.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ einingar/mín";
 "modes.cloudAccuracy.grokStt.label" = "Hæst (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Hæsta nákvæmni með hægari vinnslu. Best fyrir mikilvægar afritanir.";
+"modes.cloudAccuracy.googleChirp3.label" = "Há (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 með Chirp 3. Fjöltyngt með frasaaðlögun.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Há (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 í gegnum Azure Speech. 43 tungumál með samhengisaðlögun.";
 
 "modes.create.title" = "Búa til nýjan ham";
 "modes.create.subtitle" = "Stilltu sérsniðna afritunarnotendaupplýsingu";
@@ -883,6 +894,15 @@ Upperfærðu þessar stillingar til að nota annað líkan áður en þú eyðir
 "transcription.guidance.timeout" = "Beiðnin tók of langan tíma. Athugaðu nethraðann þinn og reyndu aftur.";
 "transcription.error.noSpeechDetected" = "Engin tala greind í upptökunni.";
 "transcription.guidance.noSpeechDetected" = "Ábendingar:\n• Talaðu skýrt í hljóðnemanninn\n• Haltu lyklinum lengur áður en þú talar\n• Athugaðu að hljóðneminn þinn sé að virka\n• Gakktu úr skugga um að rétt inntakstæki sé valið";
+"transcription.guidance.needsNativeRelaunch" = "Lokaðu HyperWhisper og opnaðu forritið aftur sem innbyggt forrit til að nota staðbundna eftirvinnslu.";
+"transcription.guidance.localRuntimeUnavailable" = "Reyndu aftur eða veldu minna staðbundið líkan í hamstillingunum þínum.";
+"transcription.error.localRuntimeUnavailable" = "Staðbundna gervigreindin gat ekki lokið verkinu — hráa uppskriftin þín var varðveitt.";
+"settings.backup.localDownload.title" = "Sækja staðbundin líkön?";
+"settings.backup.localDownload.message" = "%d af endurheimtu hömunum þínum nota gervigreindarlíkön í tækinu sem hafa ekki verið sótt.";
+"settings.backup.localDownload.downloadAll" = "Hlaða öllu niður";
+"settings.backup.localDownload.dismiss" = "Loka";
+"modelLibrary.local.requiresAppleSilicon" = "Krefst Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Endurræsa sem innbyggt forrit";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Ófullnægjandi einingar. Bættu við fleiri einingum í stillingum.";

--- a/app/macos/hyperwhisper/Localizations/it.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/it.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Home";
-"sidebar.statistics" = "Statistiche";
 "sidebar.modes" = "Modalità";
 "sidebar.vocabulary" = "Vocabolario";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Inizia con HyperWhisper";
-"sidebar.statistics.help" = "Visualizza statistiche di utilizzo e analisi";
 "sidebar.modes.help" = "Gestisci le modalità di trascrizione per diversi contesti";
 "sidebar.vocabulary.help" = "Aggiungi parole e frasi personalizzate per un migliore riconoscimento";
 "sidebar.streaming.help" = "Impostazioni di trascrizione streaming in tempo reale (richiede Internet)";
@@ -553,22 +551,6 @@ Modifica queste modalità per selezionare un modello diverso prima di rimuoverlo
 "models.error.checksumFailed" = "Verifica checksum del modello fallita. Il download potrebbe essere danneggiato.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistiche";
-"statistics.header.title" = "Le tue Statistiche di Utilizzo";
-"statistics.header.subtitle" = "Traccia la tua attività e prestazioni di trascrizione";
-"statistics.card.recordings" = "Totale Registrazioni";
-"statistics.card.recordings.subtitle" = "Trascrizioni completate";
-"statistics.card.duration" = "Tempo Totale";
-"statistics.card.duration.subtitle" = "Tempo trascorso nella registrazione";
-"statistics.card.words" = "Totale Parole";
-"statistics.card.words.subtitle" = "Parole trascritte";
-"statistics.card.average" = "Durata Media";
-"statistics.card.average.subtitle" = "Per registrazione";
-"statistics.graph.title" = "Attività nel Tempo";
-"statistics.daily.empty" = "Nessuna registrazione ancora";
-"statistics.filter.week" = "Questa Settimana";
-"statistics.filter.month" = "Questo Mese";
-"statistics.filter.alltime" = "Tutto il Tempo";
 
 // MARK: - History View
 "history.title" = "Cronologia";

--- a/app/macos/hyperwhisper/Localizations/it.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/it.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versione %@";
 "home.recent.updates.new.badge" = "NUOVO";
 "home.recent.updates.no.notes" = "Nessuna nota di rilascio disponibile";
+"home.stats.words.week" = "Parole questa settimana";
+"home.stats.words.month" = "Parole questo mese";
+"home.stats.speed" = "Velocità media";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Consigliato per Mac con 24 GB di memoria unificata o più. La velocità dipende dal chip — più veloce su M3/M4 Pro e superiori.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Parole quest'anno";
+"home.stats.typing.speed.help" = "Regola la velocità di digitazione presunta (WPM) usata per stimare il tempo risparmiato.";
+"home.stats.saved.week" = "Risparmiati questa settimana";
+"home.stats.minutes.value" = "%d minuti";
 "vocabulary.input.placeholder" = "Aggiungi una parola o crea uno snippet";
 "vocabulary.action.addWord" = "Aggiungi parola";
 "vocabulary.action.replaceWith" = "Sostituisci con…";
@@ -671,8 +677,13 @@ Modifica queste modalità per selezionare un modello diverso prima di rimuoverlo
 "modes.cloudAccuracy.groqWhisper.description" = "Veloce ed economico. Migliore per trascrizioni rapide.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Equilibrio tra velocità e accuratezza. Consigliato per la maggior parte degli utenti.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Massima accuratezza con elaborazione più lenta. Migliore per trascrizioni importanti.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ crediti/min";
 "modes.cloudAccuracy.grokStt.label" = "Massima (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Massima accuratezza con elaborazione più lenta. Migliore per trascrizioni importanti.";
+"modes.cloudAccuracy.googleChirp3.label" = "Alta (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 con Chirp 3. Multilingue con adattamento delle frasi.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Alta (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 tramite Azure Speech. 43 lingue con adattamento contestuale.";
 
 "modes.create.title" = "Crea Nuova Modalità";
 "modes.create.subtitle" = "Configura un profilo di trascrizione personalizzato";
@@ -883,6 +894,15 @@ Aggiorna queste modalità per usare un modello diverso prima di eliminarlo.";
 "transcription.guidance.timeout" = "La richiesta ha impiegato troppo tempo. Controlla la velocità di Internet e riprova.";
 "transcription.error.noSpeechDetected" = "Nessun parlato rilevato nella registrazione.";
 "transcription.guidance.noSpeechDetected" = "Suggerimenti:\n• Parla chiaramente nel microfono\n• Tieni premuto il tasto più a lungo prima di parlare\n• Controlla che il microfono funzioni\n• Assicurati che sia selezionato il dispositivo di input corretto";
+"transcription.guidance.needsNativeRelaunch" = "Chiudi e riapri HyperWhisper in modalità nativa per usare la post-elaborazione locale.";
+"transcription.guidance.localRuntimeUnavailable" = "Riprova oppure scegli un modello locale più piccolo nelle impostazioni della modalità.";
+"transcription.error.localRuntimeUnavailable" = "L'IA locale non ha potuto completare l'operazione — è stata mantenuta la trascrizione grezza.";
+"settings.backup.localDownload.title" = "Scaricare i modelli locali?";
+"settings.backup.localDownload.message" = "%d delle modalità ripristinate usano modelli IA su dispositivo non ancora scaricati.";
+"settings.backup.localDownload.downloadAll" = "Scarica tutti";
+"settings.backup.localDownload.dismiss" = "Ignora";
+"modelLibrary.local.requiresAppleSilicon" = "Richiede Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Riavvia in modalità nativa";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Crediti insufficienti. Aggiungi più crediti nelle Impostazioni.";

--- a/app/macos/hyperwhisper/Localizations/ja.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ja.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "バージョン %@";
 "home.recent.updates.new.badge" = "新着";
 "home.recent.updates.no.notes" = "リリースノートはありません";
+"home.stats.words.week" = "今週の単語数";
+"home.stats.words.month" = "今月の単語数";
+"home.stats.speed" = "平均速度";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "24 GB以上のユニファイドメモリを搭載したMacに推奨されます。速度はチップに依存します — M3/M4 Pro以上でより高速です。";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "今年の単語数";
+"home.stats.typing.speed.help" = "節約時間の推定に使用するタイピング速度（WPM）を調整します。";
+"home.stats.saved.week" = "今週の節約時間";
+"home.stats.minutes.value" = "%d 分";
 "vocabulary.input.placeholder" = "単語を追加するかスニペットを作成";
 "vocabulary.action.addWord" = "単語を追加";
 "vocabulary.action.replaceWith" = "置換先…";
@@ -677,8 +683,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "高速で手頃。素早い文字起こしに最適。";
 "modes.cloudAccuracy.deepgramNova3.description" = "速度と精度のバランス。ほとんどのユーザーにおすすめ。";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - 最高精度、処理は遅め。重要な文字起こしに最適。";
+"modes.cloudAccuracy.creditsPerMinute" = "約 %@ クレジット/分";
 "modes.cloudAccuracy.grokStt.label" = "最高 (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - 最高精度、処理は遅め。重要な文字起こしに最適。";
+"modes.cloudAccuracy.googleChirp3.label" = "高 (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Chirp 3 を使用する Google Cloud Speech-to-Text V2。多言語に対応し、フレーズ適応を利用できます。";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "高 (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Azure Speech 経由の Microsoft MAI-Transcribe 1.5。43 言語に対応し、文脈バイアスを利用できます。";
 
 "modes.create.title" = "新しいモードを作成";
 "modes.create.subtitle" = "カスタム文字起こしプロファイルを設定します";
@@ -884,6 +895,15 @@
 "transcription.guidance.timeout" = "リクエストに時間がかかり過ぎました。ネットワーク速度を確認して再試行してください。";
 "transcription.error.noSpeechDetected" = "録音内に音声が検出されませんでした。";
 "transcription.guidance.noSpeechDetected" = "ヒント:\n• マイクに向かってはっきり話してください\n• 話し始める前にキーを長めに押し続けてください\n• マイクが正常に動作しているか確認してください\n• 正しい入力デバイスが選択されているか確認してください";
+"transcription.guidance.needsNativeRelaunch" = "ローカル後処理を使用するには、HyperWhisper を終了し、ネイティブで開き直してください。";
+"transcription.guidance.localRuntimeUnavailable" = "もう一度お試しいただくか、モード設定でより小さいローカルモデルを選択してください。";
+"transcription.error.localRuntimeUnavailable" = "ローカル AI が処理を完了できませんでした — 未処理の文字起こしは保持されています。";
+"settings.backup.localDownload.title" = "ローカルモデルをダウンロードしますか？";
+"settings.backup.localDownload.message" = "復元したモードのうち %d 個は、まだダウンロードされていないオンデバイス AI モデルを使用します。";
+"settings.backup.localDownload.downloadAll" = "すべてダウンロード";
+"settings.backup.localDownload.dismiss" = "閉じる";
+"modelLibrary.local.requiresAppleSilicon" = "Apple Silicon が必要です";
+"modelLibrary.local.needsNativeRelaunch" = "ネイティブで再起動";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "クレジットが不足しています。設定でクレジットを追加してください。";

--- a/app/macos/hyperwhisper/Localizations/ja.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ja.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "ホーム";
-"sidebar.statistics" = "統計";
 "sidebar.modes" = "モード";
 "sidebar.vocabulary" = "語彙";
 "sidebar.streaming" = "ストリーミング";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "HyperWhisperを始めましょう";
-"sidebar.statistics.help" = "使用統計と分析を表示します";
 "sidebar.modes.help" = "利用シーンに合わせて文字起こしモードを管理します";
 "sidebar.vocabulary.help" = "精度向上のためにカスタム単語やフレーズを追加します";
 "sidebar.streaming.help" = "リアルタイムストリーミング文字起こしの設定（インターネット接続が必要）";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "モデルのチェックサム検証に失敗しました。ダウンロードが破損している可能性があります。";
 
 // MARK: - Statistics View
-"statistics.title" = "統計";
-"statistics.header.title" = "使用統計";
-"statistics.header.subtitle" = "文字起こしの活動とパフォーマンスを追跡します";
-"statistics.card.recordings" = "総録音数";
-"statistics.card.recordings.subtitle" = "完了した文字起こし";
-"statistics.card.duration" = "総時間";
-"statistics.card.duration.subtitle" = "録音に費やした時間";
-"statistics.card.words" = "総単語数";
-"statistics.card.words.subtitle" = "文字起こしされた単語";
-"statistics.card.average" = "平均時間";
-"statistics.card.average.subtitle" = "録音あたり";
-"statistics.graph.title" = "時間経過";
-"statistics.daily.empty" = "まだ録音がありません";
-"statistics.filter.week" = "今週";
-"statistics.filter.month" = "今月";
-"statistics.filter.alltime" = "すべて";
 
 // MARK: - History View
 "history.title" = "履歴";

--- a/app/macos/hyperwhisper/Localizations/ko.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ko.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "홈";
-"sidebar.statistics" = "통계";
 "sidebar.modes" = "모드";
 "sidebar.vocabulary" = "어휘";
 "sidebar.streaming" = "스트리밍";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "HyperWhisper 시작하기";
-"sidebar.statistics.help" = "사용 통계 및 분석 보기";
 "sidebar.modes.help" = "다양한 컨텍스트에 대한 음성 인식 모드 관리";
 "sidebar.vocabulary.help" = "더 나은 인식을 위한 사용자 정의 단어 및 구문 추가";
 "sidebar.streaming.help" = "실시간 스트리밍 음성 인식 설정 (인터넷 필요)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "모델 체크섬 확인 실패. 다운로드가 손상되었을 수 있습니다.";
 
 // MARK: - Statistics View
-"statistics.title" = "통계";
-"statistics.header.title" = "사용 통계";
-"statistics.header.subtitle" = "음성 인식 활동 및 성능 추적";
-"statistics.card.recordings" = "총 녹음";
-"statistics.card.recordings.subtitle" = "완료된 음성 인식";
-"statistics.card.duration" = "총 시간";
-"statistics.card.duration.subtitle" = "녹음에 소요된 시간";
-"statistics.card.words" = "총 단어";
-"statistics.card.words.subtitle" = "음성 인식된 단어";
-"statistics.card.average" = "평균 기간";
-"statistics.card.average.subtitle" = "녹음당";
-"statistics.graph.title" = "시간에 따른 활동";
-"statistics.daily.empty" = "아직 녹음이 없습니다";
-"statistics.filter.week" = "이번 주";
-"statistics.filter.month" = "이번 달";
-"statistics.filter.alltime" = "전체 기간";
 
 // MARK: - History View
 "history.title" = "기록";

--- a/app/macos/hyperwhisper/Localizations/ko.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ko.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "버전 %@";
 "home.recent.updates.new.badge" = "새로운 기능";
 "home.recent.updates.no.notes" = "릴리스 노트가 없습니다";
+"home.stats.words.week" = "이번 주 단어 수";
+"home.stats.words.month" = "이번 달 단어 수";
+"home.stats.speed" = "평균 속도";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "24 GB 이상의 통합 메모리가 있는 Mac에 권장됩니다. 속도는 칩에 따라 다릅니다 — M3/M4 Pro 이상에서 더 빠릅니다.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "올해 단어 수";
+"home.stats.typing.speed.help" = "절약한 시간을 계산할 때 기준이 되는 타이핑 속도(WPM)를 조정합니다.";
+"home.stats.saved.week" = "이번 주 절약한 시간";
+"home.stats.minutes.value" = "%d분";
 "vocabulary.input.placeholder" = "단어 추가 또는 스니펫 만들기";
 "vocabulary.action.addWord" = "단어 추가";
 "vocabulary.action.replaceWith" = "다음으로 교체…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "빠르고 저렴합니다. 빠른 음성 인식에 가장 적합합니다.";
 "modes.cloudAccuracy.deepgramNova3.description" = "속도와 정확도의 균형. 대부분의 사용자에게 권장됩니다.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - 처리가 느린 최고 정확도. 중요한 음성 인식에 가장 적합합니다.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ 크레딧/분";
 "modes.cloudAccuracy.grokStt.label" = "최고 (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - 처리가 느린 최고 정확도. 중요한 음성 인식에 가장 적합합니다.";
+"modes.cloudAccuracy.googleChirp3.label" = "높음 (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Chirp 3 기반 Google Cloud Speech-to-Text V2. 문구 적응을 지원하는 다국어.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "높음 (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Azure Speech 기반 Microsoft MAI-Transcribe 1.5. 문맥 기반 보정을 지원하는 43개 언어.";
 
 "modes.create.title" = "새 모드 만들기";
 "modes.create.subtitle" = "사용자 정의 음성 인식 프로필 구성";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "요청이 너무 오래 걸렸습니다. 인터넷 속도를 확인하고 다시 시도하세요.";
 "transcription.error.noSpeechDetected" = "녹음에서 음성이 감지되지 않았습니다.";
 "transcription.guidance.noSpeechDetected" = "팁:\n• 마이크에 명확하게 말하세요\n• 말하기 전에 키를 더 오래 누르세요\n• 마이크가 작동하는지 확인하세요\n• 올바른 입력 장치가 선택되었는지 확인하세요";
+"transcription.guidance.needsNativeRelaunch" = "로컬 후처리를 사용하려면 HyperWhisper를 종료한 후 네이티브로 다시 실행하세요.";
+"transcription.guidance.localRuntimeUnavailable" = "다시 시도하거나, 모드 설정에서 더 작은 로컬 모델을 선택하세요.";
+"transcription.error.localRuntimeUnavailable" = "로컬 AI가 처리를 완료하지 못했습니다 — 원본 받아쓰기 결과는 그대로 유지했습니다.";
+"settings.backup.localDownload.title" = "로컬 모델을 다운로드할까요?";
+"settings.backup.localDownload.message" = "복원된 모드 중 %d개가 아직 다운로드되지 않은 온디바이스 AI 모델을 사용합니다.";
+"settings.backup.localDownload.downloadAll" = "모두 다운로드";
+"settings.backup.localDownload.dismiss" = "닫기";
+"modelLibrary.local.requiresAppleSilicon" = "Apple Silicon 필요";
+"modelLibrary.local.needsNativeRelaunch" = "네이티브로 다시 실행";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "크레딧이 부족합니다. 설정에서 크레딧을 더 추가하세요.";

--- a/app/macos/hyperwhisper/Localizations/lt.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/lt.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versija %@";
 "home.recent.updates.new.badge" = "NAUJA";
 "home.recent.updates.no.notes" = "Nėra išleistos informacijos";
+"home.stats.words.week" = "Žodžiai šią savaitę";
+"home.stats.words.month" = "Žodžiai šį mėnesį";
+"home.stats.speed" = "Vidutinis greitis";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Rekomenduojama Mac su 24 GB suvienodintos atminties arba daugiau. Greitis priklauso nuo lusto — greitesnis su M3/M4 Pro ir naujesniais.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Žodžiai šiais metais";
+"home.stats.typing.speed.help" = "Pakoreguokite numatomą rašymo greitį (WPM), pagal kurį apskaičiuojamas sutaupytas laikas.";
+"home.stats.saved.week" = "Sutaupyta šią savaitę";
+"home.stats.minutes.value" = "%d min.";
 "vocabulary.input.placeholder" = "Pridėkite žodį arba sukurkite ištrauką";
 "vocabulary.action.addWord" = "Pridėti žodį";
 "vocabulary.action.replaceWith" = "Pakeisti į…";
@@ -671,8 +677,13 @@ Redaguokite tuos režimus, kad pasirinktumėte kitą modelį prieš jį pašalin
 "modes.cloudAccuracy.groqWhisper.description" = "Greitas ir paaustas. Geriausias greitams transkriptsiniu.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Subalansuotas greitis ir tikslumas. Rekomenduojamas daugumai vartotojų.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Aukščiausias tikslumas su lėtesniu apdorojimu. Geriausia svarbių transkriptsiniu.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kreditų/min";
 "modes.cloudAccuracy.grokStt.label" = "Aukščiausias (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Aukščiausias tikslumas su lėtesniu apdorojimu. Geriausia svarbių transkriptsiniu.";
+"modes.cloudAccuracy.googleChirp3.label" = "Aukštas (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 su Chirp 3. Daugiakalbis, su frazių pritaikymu.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Aukštas (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 per Azure Speech. 43 kalbos su kontekstiniu pritaikymu.";
 
 "modes.create.title" = "Sukurti naują režimą";
 "modes.create.subtitle" = "Sukonfigūruokite pasirinktą transkriptsiniu profilį";
@@ -883,6 +894,15 @@ Prieš trindami atnaujinkite šiuos režimus, kad naudotų kitą modelį.";
 "transcription.guidance.timeout" = "Užklausa užtruko per ilgai. Patikrinkite savo interneto greitį ir bandykite iš naujo.";
 "transcription.error.noSpeechDetected" = "Neaptiktas joks balsas įrašyme.";
 "transcription.guidance.noSpeechDetected" = "Patarimai:\n• Kalbėkite aiškiai į mikrofon\n• Laikykite raktą ilgiau prieš pradėdami kalbėti\n• Patikrinkite, ar jūsų mikrofon veikia\n• Įsitikinkite, kad pasirinktas teisingas įvesties įrenginys";
+"transcription.guidance.needsNativeRelaunch" = "Uždarykite ir vėl atidarykite HyperWhisper natyviai, kad galėtumėte naudoti vietinį papildomą apdorojimą.";
+"transcription.guidance.localRuntimeUnavailable" = "Bandykite dar kartą arba režimo nustatymuose pasirinkite mažesnį vietinį modelį.";
+"transcription.error.localRuntimeUnavailable" = "Vietiniam DI nepavyko baigti apdorojimo — jūsų neapdorotas nuorašas išsaugotas.";
+"settings.backup.localDownload.title" = "Atsisiųsti vietinius modelius?";
+"settings.backup.localDownload.message" = "%d iš jūsų atkurtų režimų naudoja įrenginyje veikiančius DI modelius, kurie dar neatsisiųsti.";
+"settings.backup.localDownload.downloadAll" = "Atsisiųsti visus";
+"settings.backup.localDownload.dismiss" = "Atmesti";
+"modelLibrary.local.requiresAppleSilicon" = "Reikia Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Paleisti iš naujo natyviai";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nepakanka kreditų. Pridėkite daugiau kreditų nustatymuose.";

--- a/app/macos/hyperwhisper/Localizations/lt.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/lt.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Pradžia";
-"sidebar.statistics" = "Statistika";
 "sidebar.modes" = "Režimai";
 "sidebar.vocabulary" = "Žodynas";
 "sidebar.streaming" = "Srautinis";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Pradėkite su HyperWhisper";
-"sidebar.statistics.help" = "Žiūrėkite naudojimo statistiką ir analitika";
 "sidebar.modes.help" = "Valdyti transkriptsiniu režimai skirtingiems kontekstams";
 "sidebar.vocabulary.help" = "Pridėkite pasirinktinius žodžius ir žodžių junginius geresniam atpažinimui";
 "sidebar.streaming.help" = "Realiojo laiko srautinio transkriptsiniu nustatymai (reikalingas internetas)";
@@ -553,22 +551,6 @@ Redaguokite tuos režimus, kad pasirinktumėte kitą modelį prieš jį pašalin
 "models.error.checksumFailed" = "Modelio kontrol sumos patikra nepavyko. Atsisiunčiamą failą gali sugadinti.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistika";
-"statistics.header.title" = "Jūsų naudojimo statistika";
-"statistics.header.subtitle" = "Sekite savo transkriptsiniu veiklą ir produktyvumą";
-"statistics.card.recordings" = "Iš viso įrašymų";
-"statistics.card.recordings.subtitle" = "Baigta transkripcija";
-"statistics.card.duration" = "Bendras laikas";
-"statistics.card.duration.subtitle" = "Laikas praleistas įrašant";
-"statistics.card.words" = "Bendri žodžiai";
-"statistics.card.words.subtitle" = "Transkripcijos žodžiai";
-"statistics.card.average" = "Vidutinis trukmė";
-"statistics.card.average.subtitle" = "Per įrašymą";
-"statistics.graph.title" = "Veikla bėgant laikui";
-"statistics.daily.empty" = "Dar nėra įrašymų";
-"statistics.filter.week" = "Šią savaitę";
-"statistics.filter.month" = "Šį mėnesį";
-"statistics.filter.alltime" = "Visą laiką";
 
 // MARK: - History View
 "history.title" = "Istorija";

--- a/app/macos/hyperwhisper/Localizations/lv.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/lv.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versija %@";
 "home.recent.updates.new.badge" = "JAUNS";
 "home.recent.updates.no.notes" = "Nav pieejamu izlaišanas piezīmju";
+"home.stats.words.week" = "Vārdi šonedēļ";
+"home.stats.words.month" = "Vārdi šomēnes";
+"home.stats.speed" = "Vidējais ātrums";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Ieteicams Mac ar 24 GB vienotas atmiņas vai vairāk. Ātrums ir atkarīgs no mikroshēmas — ātrāk ar M3/M4 Pro un jaunākiem.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Vārdi šogad";
+"home.stats.typing.speed.help" = "Pielāgojiet pieņemto rakstīšanas ātrumu (WPM), ko izmanto ietaupītā laika aprēķinam.";
+"home.stats.saved.week" = "Ietaupīts šonedēļ";
+"home.stats.minutes.value" = "%d minūtes";
 "vocabulary.input.placeholder" = "Pievienojiet vārdu vai izveidojiet fragmentu";
 "vocabulary.action.addWord" = "Pievienot vārdu";
 "vocabulary.action.replaceWith" = "Aizstāt ar…";
@@ -671,8 +677,13 @@ Rediģē šos režīmus, lai pirms noņemšanas atlasītu citu modeli.";
 "modes.cloudAccuracy.groqWhisper.description" = "Ātrs un pieejams. Labākais ātrajiem transkripcijām.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Līdzsvarots ātrums un precizitāte. Ieteicams lielākajai daļai lietotāju.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Augstākā precizitāte ar lēnāku apstrādi. Labākais svarīgajiem transkripcijām.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredīti/min";
 "modes.cloudAccuracy.grokStt.label" = "Augstākā (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Augstākā precizitāte ar lēnāku apstrādi. Labākais svarīgajiem transkripcijām.";
+"modes.cloudAccuracy.googleChirp3.label" = "Augsta (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 ar Chirp 3. Daudzvalodu atpazīšana ar frāžu pielāgošanu.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Augsta (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5, izmantojot Azure Speech. 43 valodas ar konteksta pielāgošanu.";
 
 "modes.create.title" = "Izveidot jaunu režīmu";
 "modes.create.subtitle" = "Konfigurējiet pielāgotu transkripciijas profilu";
@@ -883,6 +894,15 @@ Pirms dzēšanas atjauniniet šos režīmus, lai izmantotu citu modeli.";
 "transcription.guidance.timeout" = "Pieprasījums aizņēma pārāk daudz laika. Pārbaudiet interneta ātrumu un mēģiniet vēlreiz.";
 "transcription.error.noSpeechDetected" = "Ierakstā runas nav noteikta.";
 "transcription.guidance.noSpeechDetected" = "Padomi:\n• Runājiet skaidri mikrofonā\n• Turiet taustiņu ilgāk, pirms sākat runāt\n• Pārbaudiet, ka jūsu mikrofons darbojas\n• Pārliecinieties, ka ir atlasīta pareizā ievades ierīce";
+"transcription.guidance.needsNativeRelaunch" = "Aizveriet un atveriet HyperWhisper natīvajā režīmā, lai izmantotu lokālo pēcapstrādi.";
+"transcription.guidance.localRuntimeUnavailable" = "Mēģiniet vēlreiz vai režīma iestatījumos izvēlieties mazāku lokālo modeli.";
+"transcription.error.localRuntimeUnavailable" = "Lokālais AI nevarēja pabeigt darbu — jūsu sākotnējais transkripts tika saglabāts.";
+"settings.backup.localDownload.title" = "Vai lejupielādēt lokālos modeļus?";
+"settings.backup.localDownload.message" = "%d no atjaunotajiem režīmiem izmanto ierīcē darbināmus AI modeļus, kas vēl nav lejupielādēti.";
+"settings.backup.localDownload.downloadAll" = "Lejupielādēt visus";
+"settings.backup.localDownload.dismiss" = "Aizvērt";
+"modelLibrary.local.requiresAppleSilicon" = "Nepieciešams Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Pārstartēt natīvajā režīmā";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nepietiekami kredīti. Pievienojiet vairāk kredītu iestatījumos.";

--- a/app/macos/hyperwhisper/Localizations/lv.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/lv.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Sākums";
-"sidebar.statistics" = "Statistika";
 "sidebar.modes" = "Režīmi";
 "sidebar.vocabulary" = "Vārdu krājums";
 "sidebar.streaming" = "Straumēšana";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Sākt darbību ar HyperWhisper";
-"sidebar.statistics.help" = "Skatiet lietojuma statistiku un analītiku";
 "sidebar.modes.help" = "Pārvaldiet transkripciijas režīmus dažādiem kontekstiem";
 "sidebar.vocabulary.help" = "Pievienojiet pielāgotus vārdus un frāzes labākai atpazīšanai";
 "sidebar.streaming.help" = "Reāllaika straumēšanas transkripciijas iestatījumi (nepieciešams internets)";
@@ -553,22 +551,6 @@ Rediģē šos režīmus, lai pirms noņemšanas atlasītu citu modeli.";
 "models.error.checksumFailed" = "Modeļa kontrolsummas verifikācija neizdevās. Lejupielāde var būt bojāta.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistika";
-"statistics.header.title" = "Jūsu lietojuma statistika";
-"statistics.header.subtitle" = "Izsekot transkripciijas darbības un veiktspēju";
-"statistics.card.recordings" = "Kopējie ieraksti";
-"statistics.card.recordings.subtitle" = "Pabeigtas transkripciijas";
-"statistics.card.duration" = "Kopējais laiks";
-"statistics.card.duration.subtitle" = "Laiks, kas pavadīts ierakstīšanai";
-"statistics.card.words" = "Kopējie vārdi";
-"statistics.card.words.subtitle" = "Transkriēti vārdi";
-"statistics.card.average" = "Vidējais ilgums";
-"statistics.card.average.subtitle" = "Par ierakstu";
-"statistics.graph.title" = "Darbības laika gaitā";
-"statistics.daily.empty" = "Vēl nav ierakstu";
-"statistics.filter.week" = "Šonedēļ";
-"statistics.filter.month" = "Šomēnesi";
-"statistics.filter.alltime" = "Visu laiku";
 
 // MARK: - History View
 "history.title" = "Vēsture";

--- a/app/macos/hyperwhisper/Localizations/ms.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ms.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Utama";
-"sidebar.statistics" = "Statistik";
 "sidebar.modes" = "Mod";
 "sidebar.vocabulary" = "Perbendaharaan Kata";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Mulakan dengan HyperWhisper";
-"sidebar.statistics.help" = "Lihat statistik penggunaan dan analitik";
 "sidebar.modes.help" = "Urus mod transkripsi untuk konteks berbeza";
 "sidebar.vocabulary.help" = "Tambah perkataan dan frasa tersuai untuk pengiktirafan yang lebih baik";
 "sidebar.streaming.help" = "Tetapan transkripsi streaming masa nyata (memerlukan Internet)";
@@ -553,22 +551,6 @@ Edit mod tersebut untuk memilih model yang berbeza sebelum mengalihkannya.";
 "models.error.checksumFailed" = "Pengesahan checksum model gagal. Muat turun mungkin rosak.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistik";
-"statistics.header.title" = "Statistik Penggunaan Anda";
-"statistics.header.subtitle" = "Jejaki aktiviti dan prestasi transkripsi anda";
-"statistics.card.recordings" = "Jumlah Rakaman";
-"statistics.card.recordings.subtitle" = "Transkripsi yang selesai";
-"statistics.card.duration" = "Jumlah Masa";
-"statistics.card.duration.subtitle" = "Masa dihabiskan merakam";
-"statistics.card.words" = "Jumlah Perkataan";
-"statistics.card.words.subtitle" = "Perkataan yang ditranskrip";
-"statistics.card.average" = "Tempoh Purata";
-"statistics.card.average.subtitle" = "Setiap rakaman";
-"statistics.graph.title" = "Aktiviti Sepanjang Masa";
-"statistics.daily.empty" = "Belum ada rakaman lagi";
-"statistics.filter.week" = "Minggu Ini";
-"statistics.filter.month" = "Bulan Ini";
-"statistics.filter.alltime" = "Sepanjang Masa";
 
 // MARK: - History View
 "history.title" = "Sejarah";

--- a/app/macos/hyperwhisper/Localizations/ms.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ms.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versi %@";
 "home.recent.updates.new.badge" = "BAHARU";
 "home.recent.updates.no.notes" = "Tiada nota keluaran tersedia";
+"home.stats.words.week" = "Perkataan minggu ini";
+"home.stats.words.month" = "Perkataan bulan ini";
+"home.stats.speed" = "Kelajuan purata";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Disyorkan untuk Mac dengan 24 GB memori bersepadu atau lebih. Kelajuan bergantung pada cip — lebih pantas pada M3/M4 Pro dan ke atas.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Perkataan tahun ini";
+"home.stats.typing.speed.help" = "Laraskan andaian kelajuan menaip (WPM) yang digunakan untuk menganggarkan masa yang dijimatkan.";
+"home.stats.saved.week" = "Dijimatkan minggu ini";
+"home.stats.minutes.value" = "%d minit";
 "vocabulary.input.placeholder" = "Tambah perkataan atau buat petikan";
 "vocabulary.action.addWord" = "Tambah perkataan";
 "vocabulary.action.replaceWith" = "Ganti dengan…";
@@ -671,8 +677,13 @@ Edit mod tersebut untuk memilih model yang berbeza sebelum mengalihkannya.";
 "modes.cloudAccuracy.groqWhisper.description" = "Pantas dan berpatutan. Terbaik untuk transkripsi pantas.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Kelajuan dan ketepatan seimbang. Disyorkan untuk kebanyakan pengguna.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Ketepatan tertinggi dengan pemprosesan yang lebih perlahan. Terbaik untuk transkripsi penting.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredit/min";
 "modes.cloudAccuracy.grokStt.label" = "Tertinggi (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Ketepatan tertinggi dengan pemprosesan yang lebih perlahan. Terbaik untuk transkripsi penting.";
+"modes.cloudAccuracy.googleChirp3.label" = "Tinggi (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 dengan Chirp 3. Berbilang bahasa dengan penyesuaian frasa.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Tinggi (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 melalui Azure Speech. 43 bahasa dengan pemberatan kontekstual.";
 
 "modes.create.title" = "Cipta Mod Baharu";
 "modes.create.subtitle" = "Konfigurasi profil transkripsi tersuai";
@@ -883,6 +894,15 @@ Kemas kini mod-mod ini untuk menggunakan model yang berbeza sebelum memadam.";
 "transcription.guidance.timeout" = "Permintaan mengambil masa terlalu lama. Periksa kelajuan internet anda dan cuba lagi.";
 "transcription.error.noSpeechDetected" = "Tiada pertuturan dikesan dalam rakaman.";
 "transcription.guidance.noSpeechDetected" = "Petua:\n• Bercakap dengan jelas ke dalam mikrofon\n• Tahan kekunci lebih lama sebelum bercakap\n• Periksa bahawa mikrofon anda berfungsi\n• Pastikan peranti input yang betul dipilih";
+"transcription.guidance.needsNativeRelaunch" = "Berhenti dan buka semula HyperWhisper secara asli untuk menggunakan pasca-pemprosesan tempatan.";
+"transcription.guidance.localRuntimeUnavailable" = "Cuba lagi, atau pilih model tempatan yang lebih kecil dalam tetapan Mod anda.";
+"transcription.error.localRuntimeUnavailable" = "AI tempatan tidak dapat menyelesaikannya — transkrip mentah anda telah disimpan.";
+"settings.backup.localDownload.title" = "Muat turun model tempatan?";
+"settings.backup.localDownload.message" = "%d daripada mod yang anda pulihkan menggunakan model AI pada peranti yang belum dimuat turun.";
+"settings.backup.localDownload.downloadAll" = "Muat Turun Semua";
+"settings.backup.localDownload.dismiss" = "Ketepikan";
+"modelLibrary.local.requiresAppleSilicon" = "Memerlukan Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Lancar semula secara asli";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Kredit tidak mencukupi. Tambah lebih banyak kredit dalam Tetapan.";

--- a/app/macos/hyperwhisper/Localizations/nb.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/nb.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Hjem";
-"sidebar.statistics" = "Statistikk";
 "sidebar.modes" = "Moduser";
 "sidebar.vocabulary" = "Ordforråd";
 "sidebar.streaming" = "Strømming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Kom i gang med HyperWhisper";
-"sidebar.statistics.help" = "Vis bruksstatistikk og analyser";
 "sidebar.modes.help" = "Administrer transkripsjonsmodi for ulike kontekster";
 "sidebar.vocabulary.help" = "Legg til tilpassede ord og fraser for bedre gjenkjenning";
 "sidebar.streaming.help" = "Sanntids strømmetranskripsjon innstillinger (krever internett)";
@@ -553,22 +551,6 @@ Rediger disse modusene for å velge en annen modell før du fjerner den.";
 "models.error.checksumFailed" = "Modellsjekksumverifisering mislyktes. Nedlastingen kan være korrupt.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistikk";
-"statistics.header.title" = "Din bruksstatistikk";
-"statistics.header.subtitle" = "Spor transkripsjonaktivitet og ytelse";
-"statistics.card.recordings" = "Totalt antall opptak";
-"statistics.card.recordings.subtitle" = "Fullførte transkripsjoner";
-"statistics.card.duration" = "Totaltid";
-"statistics.card.duration.subtitle" = "Tid brukt på opptak";
-"statistics.card.words" = "Totalt antall ord";
-"statistics.card.words.subtitle" = "Ord transkribert";
-"statistics.card.average" = "Gjennomsnittlig varighet";
-"statistics.card.average.subtitle" = "Per opptak";
-"statistics.graph.title" = "Aktivitet over tid";
-"statistics.daily.empty" = "Ingen opptak ennå";
-"statistics.filter.week" = "Denne uken";
-"statistics.filter.month" = "Denne måneden";
-"statistics.filter.alltime" = "All tid";
 
 // MARK: - History View
 "history.title" = "Historikk";

--- a/app/macos/hyperwhisper/Localizations/nb.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/nb.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versjon %@";
 "home.recent.updates.new.badge" = "NYTT";
 "home.recent.updates.no.notes" = "Ingen utgivelsesnotater tilgjengelig";
+"home.stats.words.week" = "Ord denne uken";
+"home.stats.words.month" = "Ord denne måneden";
+"home.stats.speed" = "Gjennomsnittlig hastighet";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Anbefalt for Mac med 24 GB unified memory eller mer. Hastigheten avhenger av brikken — raskere på M3/M4 Pro og høyere.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Ord i år";
+"home.stats.typing.speed.help" = "Juster antatt skrivehastighet (WPM) som brukes til å beregne spart tid.";
+"home.stats.saved.week" = "Spart denne uken";
+"home.stats.minutes.value" = "%d minutter";
 "vocabulary.input.placeholder" = "Legg til et ord eller opprett et utdrag";
 "vocabulary.action.addWord" = "Legg til ord";
 "vocabulary.action.replaceWith" = "Erstatt med…";
@@ -671,8 +677,13 @@ Rediger disse modusene for å velge en annen modell før du fjerner den.";
 "modes.cloudAccuracy.groqWhisper.description" = "Rask og rimelig. Best for raske transkripsjoner.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Balansert hastighet og nøyaktighet. Anbefalt for de fleste brukere.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Høyeste nøyaktighet med langsommere behandling. Best for viktige transkripsjoner.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kreditter/min";
 "modes.cloudAccuracy.grokStt.label" = "Høyest (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Høyeste nøyaktighet med langsommere behandling. Best for viktige transkripsjoner.";
+"modes.cloudAccuracy.googleChirp3.label" = "Høy (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 med Chirp 3. Flerspråklig med frasetilpasning.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Høy (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 via Azure Speech. 43 språk med kontekstuell tilpasning.";
 
 "modes.create.title" = "Opprett ny modus";
 "modes.create.subtitle" = "Konfigurer en tilpasset transkirpsjonsprofil";
@@ -883,6 +894,15 @@ Oppdater disse modusene til å bruke en annen modell før du sletter.";
 "transcription.guidance.timeout" = "Forespørselen tok for lang tid. Sjekk internettshastigheten din og prøv igjen.";
 "transcription.error.noSpeechDetected" = "Ingen tale oppdaget i opptaket.";
 "transcription.guidance.noSpeechDetected" = "Tips:\n• Snakk tydelig inn i mikrofonen\n• Hold tasten lengre før du snakker\n• Sjekk at mikrofonen din fungerer\n• Sørg for at riktig inngangsenhet er valgt";
+"transcription.guidance.needsNativeRelaunch" = "Avslutt og åpne HyperWhisper nativt på nytt for å bruke lokal etterbehandling.";
+"transcription.guidance.localRuntimeUnavailable" = "Prøv igjen, eller velg en mindre lokal modell i modusinnstillingene.";
+"transcription.error.localRuntimeUnavailable" = "Lokal AI ble ikke ferdig — den rå transkripsjonen ble beholdt.";
+"settings.backup.localDownload.title" = "Vil du laste ned lokale modeller?";
+"settings.backup.localDownload.message" = "%d av modusene du gjenopprettet, bruker lokale AI-modeller som ikke er lastet ned ennå.";
+"settings.backup.localDownload.downloadAll" = "Last ned alle";
+"settings.backup.localDownload.dismiss" = "Avvis";
+"modelLibrary.local.requiresAppleSilicon" = "Krever Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Start på nytt nativt";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Utilstrekkelige kreditter. Legg til flere kreditter i Innstillinger.";

--- a/app/macos/hyperwhisper/Localizations/nl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/nl.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Startpagina";
-"sidebar.statistics" = "Statistieken";
 "sidebar.modes" = "Modi";
 "sidebar.vocabulary" = "Woordenlijst";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Aan de slag met HyperWhisper";
-"sidebar.statistics.help" = "Bekijk gebruiksstatistieken en analyses";
 "sidebar.modes.help" = "Beheer transcriptiemodi voor verschillende contexten";
 "sidebar.vocabulary.help" = "Voeg aangepaste woorden en zinnen toe voor betere herkenning";
 "sidebar.streaming.help" = "Instellingen voor real-time streamingtranscriptie (vereist internet)";
@@ -553,22 +551,6 @@ Bewerk die modi om een ander model te selecteren voordat je het verwijdert.";
 "models.error.checksumFailed" = "Verificatie van modelcontrolesom mislukt. De download is mogelijk beschadigd.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistieken";
-"statistics.header.title" = "Je gebruiksstatistieken";
-"statistics.header.subtitle" = "Volg je transcriptieactiviteit en prestaties";
-"statistics.card.recordings" = "Totale opnamen";
-"statistics.card.recordings.subtitle" = "Voltooide transcripties";
-"statistics.card.duration" = "Totale tijd";
-"statistics.card.duration.subtitle" = "Tijd besteed aan opnamen";
-"statistics.card.words" = "Totale woorden";
-"statistics.card.words.subtitle" = "Getranscribeerde woorden";
-"statistics.card.average" = "Gemiddelde duur";
-"statistics.card.average.subtitle" = "Per opname";
-"statistics.graph.title" = "Activiteit in de loop van de tijd";
-"statistics.daily.empty" = "Nog geen opnamen";
-"statistics.filter.week" = "Deze week";
-"statistics.filter.month" = "Deze maand";
-"statistics.filter.alltime" = "Altijd";
 
 // MARK: - History View
 "history.title" = "Geschiedenis";

--- a/app/macos/hyperwhisper/Localizations/nl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/nl.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versie %@";
 "home.recent.updates.new.badge" = "NIEUW";
 "home.recent.updates.no.notes" = "Geen opmerkingen uitgebracht beschikbaar";
+"home.stats.words.week" = "Woorden deze week";
+"home.stats.words.month" = "Woorden deze maand";
+"home.stats.speed" = "Gemiddelde snelheid";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Aanbevolen voor Mac met 24 GB unified memory of meer. De snelheid hangt af van de chip — sneller op M3/M4 Pro en hoger.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Woorden dit jaar";
+"home.stats.typing.speed.help" = "Pas de aangenomen typesnelheid (WPM) aan die wordt gebruikt om de bespaarde tijd te schatten.";
+"home.stats.saved.week" = "Bespaard deze week";
+"home.stats.minutes.value" = "%d minuten";
 "vocabulary.input.placeholder" = "Voeg een woord toe of maak een fragment";
 "vocabulary.action.addWord" = "Woord toevoegen";
 "vocabulary.action.replaceWith" = "Vervangen door…";
@@ -671,8 +677,13 @@ Bewerk die modi om een ander model te selecteren voordat je het verwijdert.";
 "modes.cloudAccuracy.groqWhisper.description" = "Snel en betaalbaar. Het beste voor snelle transcripties.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Evenwichtige snelheid en nauwkeurigheid. Aanbevolen voor de meeste gebruikers.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Hoogste nauwkeurigheid met langzamere verwerking. Het beste voor belangrijke transcripties.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ credits/min";
 "modes.cloudAccuracy.grokStt.label" = "Hoogste (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Hoogste nauwkeurigheid met langzamere verwerking. Het beste voor belangrijke transcripties.";
+"modes.cloudAccuracy.googleChirp3.label" = "Hoog (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 met Chirp 3. Meertalig met woordgroepaanpassing.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Hoog (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 via Azure Speech. 43 talen met contextuele afstemming.";
 
 "modes.create.title" = "Nieuwe modus maken";
 "modes.create.subtitle" = "Configureer een aangepast transcriptieprofiel";
@@ -883,6 +894,15 @@ Wijzig deze modi zodat ze een ander model gebruiken voordat je verwijdert.";
 "transcription.guidance.timeout" = "Het verzoek duurde te lang. Controleer je internetsnelheid en probeer het opnieuw.";
 "transcription.error.noSpeechDetected" = "Geen spraak gedetecteerd in de opname.";
 "transcription.guidance.noSpeechDetected" = "Tips:\n• Spreek duidelijk in de microfoon\n• Houd de toets langer vast voordat je spreekt\n• Controleer of je microfoon werkt\n• Zorg ervoor dat het juiste invoerapparaat is geselecteerd";
+"transcription.guidance.needsNativeRelaunch" = "Stop HyperWhisper en open het native opnieuw om lokale nabewerking te gebruiken.";
+"transcription.guidance.localRuntimeUnavailable" = "Probeer het opnieuw of kies een kleiner lokaal model in je modusinstellingen.";
+"transcription.error.localRuntimeUnavailable" = "Lokale AI kon niet worden voltooid — je onbewerkte transcriptie is behouden.";
+"settings.backup.localDownload.title" = "Lokale modellen downloaden?";
+"settings.backup.localDownload.message" = "%d van je herstelde modi gebruiken lokale AI-modellen die nog niet zijn gedownload.";
+"settings.backup.localDownload.downloadAll" = "Download alles";
+"settings.backup.localDownload.dismiss" = "Negeer";
+"modelLibrary.local.requiresAppleSilicon" = "Vereist Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Native opnieuw starten";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Onvoldoende tegoed. Voeg meer tegoed toe in Instellingen.";

--- a/app/macos/hyperwhisper/Localizations/pl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/pl.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Strona główna";
-"sidebar.statistics" = "Statystyki";
 "sidebar.modes" = "Tryby";
 "sidebar.vocabulary" = "Słownictwo";
 "sidebar.streaming" = "Transmisja";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Rozpocznij pracę z HyperWhisper";
-"sidebar.statistics.help" = "Przeglądaj statystyki użycia i analitykę";
 "sidebar.modes.help" = "Zarządzaj trybami transkrypcji dla różnych kontekstów";
 "sidebar.vocabulary.help" = "Dodaj niestandardowe słowa i zwroty dla lepszego rozpoznawania";
 "sidebar.streaming.help" = "Ustawienia transkrypcji przesyłania w czasie rzeczywistym (wymaga Internetu)";
@@ -553,22 +551,6 @@ Edytuj te tryby, aby wybrać inny model przed jego usunięciem.";
 "models.error.checksumFailed" = "Weryfikacja sumy kontrolnej modelu nie powiodła się. Pobieranie może być uszkodzone.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statystyki";
-"statistics.header.title" = "Twoje statystyki użycia";
-"statistics.header.subtitle" = "Śledź działalność transkrypcji i wydajność";
-"statistics.card.recordings" = "Wszystkie nagrania";
-"statistics.card.recordings.subtitle" = "Ukończone transkrypcje";
-"statistics.card.duration" = "Całkowity czas";
-"statistics.card.duration.subtitle" = "Czas spędzony na nagrywaniu";
-"statistics.card.words" = "Wszystkie słowa";
-"statistics.card.words.subtitle" = "Słowa transkrybowane";
-"statistics.card.average" = "Średni czas";
-"statistics.card.average.subtitle" = "Na nagranie";
-"statistics.graph.title" = "Aktywność w czasie";
-"statistics.daily.empty" = "Brak nagrań";
-"statistics.filter.week" = "Ten tydzień";
-"statistics.filter.month" = "Ten miesiąc";
-"statistics.filter.alltime" = "Cały czas";
 
 // MARK: - History View
 "history.title" = "Historia";

--- a/app/macos/hyperwhisper/Localizations/pl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/pl.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Wersja %@";
 "home.recent.updates.new.badge" = "NOWE";
 "home.recent.updates.no.notes" = "Brak dostępnych notatek wydania";
+"home.stats.words.week" = "Słowa w tym tygodniu";
+"home.stats.words.month" = "Słowa w tym miesiącu";
+"home.stats.speed" = "Średnia prędkość";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Zalecane dla Mac z 24 GB zunifikowanej pamięci lub więcej. Szybkość zależy od układu — szybciej na M3/M4 Pro i nowszych.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Słowa w tym roku";
+"home.stats.typing.speed.help" = "Dostosuj zakładaną szybkość pisania (WPM) używaną do szacowania zaoszczędzonego czasu.";
+"home.stats.saved.week" = "Zaoszczędzono w tym tygodniu";
+"home.stats.minutes.value" = "%d min";
 "vocabulary.input.placeholder" = "Dodaj słowo lub utwórz fragment";
 "vocabulary.action.addWord" = "Dodaj słowo";
 "vocabulary.action.replaceWith" = "Zastąp przez…";
@@ -671,8 +677,13 @@ Edytuj te tryby, aby wybrać inny model przed jego usunięciem.";
 "modes.cloudAccuracy.groqWhisper.description" = "Szybka i przystępna cenowo. Najlepsze dla szybkich transkrypcji.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Zrównoważona szybkość i dokładność. Rekomendowane dla większości użytkowników.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Najwyższa dokładność z wolniejszym przetwarzaniem. Najlepsze dla ważnych transkrypcji.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredytów/min";
 "modes.cloudAccuracy.grokStt.label" = "Najwyższa (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Najwyższa dokładność z wolniejszym przetwarzaniem. Najlepsze dla ważnych transkrypcji.";
+"modes.cloudAccuracy.googleChirp3.label" = "Wysoka (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 z Chirp 3. Wielojęzyczny, z adaptacją fraz.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Wysoka (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 przez Azure Speech. 43 języki z uwzględnianiem kontekstu.";
 
 "modes.create.title" = "Utwórz nowy tryb";
 "modes.create.subtitle" = "Skonfiguruj niestandardowy profil transkrypcji";
@@ -883,6 +894,15 @@ Przed usunięciem zaktualizuj te tryby, aby korzystały z innego modelu.";
 "transcription.guidance.timeout" = "Żądanie trwało zbyt długo. Sprawdź szybkość Internetu i spróbuj ponownie.";
 "transcription.error.noSpeechDetected" = "W nagraniu nie wykryto mowy.";
 "transcription.guidance.noSpeechDetected" = "Porady:\n• Mów wyraźnie do mikrofonu\n• Przytrzymaj klawisz dłużej przed mówieniem\n• Sprawdź, czy mikrofon działa\n• Upewnij się, że wybrane jest prawidłowe urządzenie wejściowe";
+"transcription.guidance.needsNativeRelaunch" = "Zamknij i otwórz HyperWhisper ponownie w trybie natywnym, aby korzystać z lokalnego przetwarzania końcowego.";
+"transcription.guidance.localRuntimeUnavailable" = "Spróbuj ponownie lub wybierz mniejszy model lokalny w ustawieniach trybu.";
+"transcription.error.localRuntimeUnavailable" = "Lokalna AI nie ukończyła przetwarzania — zachowano surową transkrypcję.";
+"settings.backup.localDownload.title" = "Pobrać modele lokalne?";
+"settings.backup.localDownload.message" = "%d przywróconych trybów korzysta z modeli AI działających na urządzeniu, które nie zostały jeszcze pobrane.";
+"settings.backup.localDownload.downloadAll" = "Pobierz wszystkie";
+"settings.backup.localDownload.dismiss" = "Zamknij";
+"modelLibrary.local.requiresAppleSilicon" = "Wymaga Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Uruchom ponownie natywnie";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Niewystarczające kredyty. Dodaj więcej kredytów w Ustawieniach.";

--- a/app/macos/hyperwhisper/Localizations/pt.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/pt.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Início";
-"sidebar.statistics" = "Estatísticas";
 "sidebar.modes" = "Modos";
 "sidebar.vocabulary" = "Vocabulário";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Comece com o HyperWhisper";
-"sidebar.statistics.help" = "Ver estatísticas de uso e análises";
 "sidebar.modes.help" = "Gerenciar modos de transcrição para diferentes contextos";
 "sidebar.vocabulary.help" = "Adicione palavras e frases personalizadas para melhor reconhecimento";
 "sidebar.streaming.help" = "Configurações de transcrição de streaming em tempo real (requer Internet)";
@@ -553,22 +551,6 @@ Edite esses modos para selecionar um modelo diferente antes de removê-lo.";
 "models.error.checksumFailed" = "Falha na verificação de checksum do modelo. O download pode estar corrompido.";
 
 // MARK: - Statistics View
-"statistics.title" = "Estatísticas";
-"statistics.header.title" = "Suas Estatísticas de Uso";
-"statistics.header.subtitle" = "Rastreie sua atividade de transcrição e desempenho";
-"statistics.card.recordings" = "Gravações Totais";
-"statistics.card.recordings.subtitle" = "Transcrições concluídas";
-"statistics.card.duration" = "Tempo Total";
-"statistics.card.duration.subtitle" = "Tempo gasto gravando";
-"statistics.card.words" = "Palavras Totais";
-"statistics.card.words.subtitle" = "Palavras transcritas";
-"statistics.card.average" = "Duração Média";
-"statistics.card.average.subtitle" = "Por gravação";
-"statistics.graph.title" = "Atividade ao Longo do Tempo";
-"statistics.daily.empty" = "Nenhuma gravação ainda";
-"statistics.filter.week" = "Esta Semana";
-"statistics.filter.month" = "Este Mês";
-"statistics.filter.alltime" = "Tempo Total";
 
 // MARK: - History View
 "history.title" = "Histórico";

--- a/app/macos/hyperwhisper/Localizations/pt.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/pt.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versão %@";
 "home.recent.updates.new.badge" = "NOVO";
 "home.recent.updates.no.notes" = "Nenhuma nota de lançamento disponível";
+"home.stats.words.week" = "Palavras esta semana";
+"home.stats.words.month" = "Palavras este mês";
+"home.stats.speed" = "Velocidade média";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Recomendado para Mac com 24 GB de memória unificada ou mais. A velocidade depende do chip — mais rápido no M3/M4 Pro e superiores.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Palavras este ano";
+"home.stats.typing.speed.help" = "Ajuste a velocidade de escrita presumida (WPM) usada para estimar o tempo poupado.";
+"home.stats.saved.week" = "Poupado esta semana";
+"home.stats.minutes.value" = "%d minutos";
 "vocabulary.input.placeholder" = "Adicionar uma palavra ou criar um trecho";
 "vocabulary.action.addWord" = "Adicionar palavra";
 "vocabulary.action.replaceWith" = "Substituir por…";
@@ -671,8 +677,13 @@ Edite esses modos para selecionar um modelo diferente antes de removê-lo.";
 "modes.cloudAccuracy.groqWhisper.description" = "Rápido e acessível. Melhor para transcrições rápidas.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Equilíbrio entre velocidade e precisão. Recomendado para a maioria dos usuários.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Maior precisão com processamento mais lento. Melhor para transcrições importantes.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ créditos/min";
 "modes.cloudAccuracy.grokStt.label" = "Mais Alto (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Maior precisão com processamento mais lento. Melhor para transcrições importantes.";
+"modes.cloudAccuracy.googleChirp3.label" = "Alta (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 com Chirp 3. Multilingue com adaptação de frases.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Alta (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 através do Azure Speech. 43 idiomas com adaptação contextual.";
 
 "modes.create.title" = "Criar Novo Modo";
 "modes.create.subtitle" = "Configure um perfil de transcrição personalizado";
@@ -883,6 +894,15 @@ Atualize esses modos para usar um modelo diferente antes de excluir.";
 "transcription.guidance.timeout" = "A solicitação levou muito tempo. Verifique sua velocidade de Internet e tente novamente.";
 "transcription.error.noSpeechDetected" = "Nenhuma fala detectada na gravação.";
 "transcription.guidance.noSpeechDetected" = "Dicas:\n• Fale claramente no microfone\n• Segure a tecla mais tempo antes de falar\n• Verifique se seu microfone está funcionando\n• Certifique-se de que o dispositivo de entrada correto está selecionado";
+"transcription.guidance.needsNativeRelaunch" = "Encerre e reabra o HyperWhisper nativamente para usar o pós-processamento local.";
+"transcription.guidance.localRuntimeUnavailable" = "Tente novamente ou escolha um modelo local mais pequeno nas definições do Modo.";
+"transcription.error.localRuntimeUnavailable" = "A IA local não conseguiu concluir — a transcrição original foi mantida.";
+"settings.backup.localDownload.title" = "Transferir modelos locais?";
+"settings.backup.localDownload.message" = "%d dos modos restaurados usam modelos de IA no dispositivo que ainda não foram transferidos.";
+"settings.backup.localDownload.downloadAll" = "Transferir tudo";
+"settings.backup.localDownload.dismiss" = "Ignorar";
+"modelLibrary.local.requiresAppleSilicon" = "Requer Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Reiniciar nativamente";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Créditos insuficientes. Adicione mais créditos em Configurações.";

--- a/app/macos/hyperwhisper/Localizations/ro.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ro.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Acasă";
-"sidebar.statistics" = "Statistici";
 "sidebar.modes" = "Moduri";
 "sidebar.vocabulary" = "Vocabular";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Porniți cu HyperWhisper";
-"sidebar.statistics.help" = "Vizualizați statisticile de utilizare și analitica";
 "sidebar.modes.help" = "Gestionați moduri de transcriere pentru contexte diferite";
 "sidebar.vocabulary.help" = "Adăugați cuvinte și expresii personalizate pentru o recunoaștere mai bună";
 "sidebar.streaming.help" = "Setări de transcriere de streaming în timp real (necesită Internet)";
@@ -553,22 +551,6 @@ Editează acele moduri pentru a selecta un alt model înainte de a-l elimina.";
 "models.error.checksumFailed" = "Verificarea sumei de control a modelului a eșuat. Descărcarea poate fi coruptă.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistici";
-"statistics.header.title" = "Statisticile dvs. de utilizare";
-"statistics.header.subtitle" = "Urmăriți activitatea și performanța transcrierii";
-"statistics.card.recordings" = "Total înregistrări";
-"statistics.card.recordings.subtitle" = "Transcrieri completate";
-"statistics.card.duration" = "Timp total";
-"statistics.card.duration.subtitle" = "Timp petrecut înregistrând";
-"statistics.card.words" = "Total cuvinte";
-"statistics.card.words.subtitle" = "Cuvinte transcrise";
-"statistics.card.average" = "Durată medie";
-"statistics.card.average.subtitle" = "Per înregistrare";
-"statistics.graph.title" = "Activitate în timp";
-"statistics.daily.empty" = "Nicio înregistrare încă";
-"statistics.filter.week" = "Săptămâna aceasta";
-"statistics.filter.month" = "Luna aceasta";
-"statistics.filter.alltime" = "Tot timpul";
 
 // MARK: - History View
 "history.title" = "Istoric";

--- a/app/macos/hyperwhisper/Localizations/ro.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ro.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Versiunea %@";
 "home.recent.updates.new.badge" = "NOU";
 "home.recent.updates.no.notes" = "Nicio notă de lansare disponibilă";
+"home.stats.words.week" = "Cuvinte săptămâna aceasta";
+"home.stats.words.month" = "Cuvinte luna aceasta";
+"home.stats.speed" = "Viteză medie";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Recomandat pentru Mac cu 24 GB de memorie unificată sau mai mult. Viteza depinde de cip — mai rapid pe M3/M4 Pro și superioare.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Cuvinte în acest an";
+"home.stats.typing.speed.help" = "Ajustează viteza de tastare presupusă (WPM) folosită pentru a estima timpul economisit.";
+"home.stats.saved.week" = "Timp economisit săptămâna aceasta";
+"home.stats.minutes.value" = "%d minute";
 "vocabulary.input.placeholder" = "Adaugă un cuvânt sau creează un fragment";
 "vocabulary.action.addWord" = "Adaugă cuvânt";
 "vocabulary.action.replaceWith" = "Înlocuiește cu…";
@@ -671,8 +677,13 @@ Editează acele moduri pentru a selecta un alt model înainte de a-l elimina.";
 "modes.cloudAccuracy.groqWhisper.description" = "Rapid și accesibil. Cel mai bun pentru transcrieri rapide.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Echilibru între viteză și precizie. Recomandat pentru cei mai mulți utilizatori.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Precizie maximă cu procesare mai lentă. Cel mai bun pentru transcrieri importante.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ credite/min";
 "modes.cloudAccuracy.grokStt.label" = "Cel mai înalt (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Precizie maximă cu procesare mai lentă. Cel mai bun pentru transcrieri importante.";
+"modes.cloudAccuracy.googleChirp3.label" = "Ridicată (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 cu Chirp 3. Multilingv, cu adaptare de expresii.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Ridicată (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 prin Azure Speech. 43 de limbi, cu adaptare contextuală.";
 
 "modes.create.title" = "Creați mod nou";
 "modes.create.subtitle" = "Configurați un profil de transcriere personalizat";
@@ -883,6 +894,15 @@ Actualizați aceste moduri pentru a utiliza un model diferit înainte de șterge
 "transcription.guidance.timeout" = "Cererea a durat prea mult. Verificați viteza internetului și reîncercați.";
 "transcription.error.noSpeechDetected" = "Nicio vorbire detectată în înregistrare.";
 "transcription.guidance.noSpeechDetected" = "Sfaturi:\n• Vorbiți clar în microfon\n• Țineti cheia mai mult înainte de a vorbi\n• Verificați că microfonul funcționează\n• Asigurați-vă că dispozitivul de intrare corect este selectat";
+"transcription.guidance.needsNativeRelaunch" = "Închide și redeschide HyperWhisper în mod nativ pentru a folosi post-procesarea locală.";
+"transcription.guidance.localRuntimeUnavailable" = "Încearcă din nou sau alege un model local mai mic în setările modului.";
+"transcription.error.localRuntimeUnavailable" = "AI-ul local nu a putut finaliza — transcrierea brută a fost păstrată.";
+"settings.backup.localDownload.title" = "Descarci modelele locale?";
+"settings.backup.localDownload.message" = "%d dintre modurile restaurate folosesc modele AI locale care nu sunt încă descărcate.";
+"settings.backup.localDownload.downloadAll" = "Descarcă toate";
+"settings.backup.localDownload.dismiss" = "Ignoră";
+"modelLibrary.local.requiresAppleSilicon" = "Necesită Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Repornește nativ";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Credite insuficiente. Adăugați mai multe credite în Setări.";

--- a/app/macos/hyperwhisper/Localizations/ru.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ru.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Версия %@";
 "home.recent.updates.new.badge" = "НОВОЕ";
 "home.recent.updates.no.notes" = "Примечания к выпуску недоступны";
+"home.stats.words.week" = "Слов за неделю";
+"home.stats.words.month" = "Слов за месяц";
+"home.stats.speed" = "Средняя скорость";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Рекомендуется для Mac с 24 GB объединённой памяти или более. Скорость зависит от чипа — быстрее на M3/M4 Pro и выше.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Слов за этот год";
+"home.stats.typing.speed.help" = "Укажите предполагаемую скорость печати (WPM), по которой оценивается сэкономленное время.";
+"home.stats.saved.week" = "Сэкономлено за неделю";
+"home.stats.minutes.value" = "%d мин";
 "vocabulary.input.placeholder" = "Добавьте слово или создайте фрагмент";
 "vocabulary.action.addWord" = "Добавить слово";
 "vocabulary.action.replaceWith" = "Заменить на…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "Быстро и доступно. Лучше для быстрых транскрипций.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Сбалансированная скорость и точность. Рекомендуется для большинства пользователей.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Наивысшая точность с более медленной обработкой. Лучше для важных транскрипций.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ кред./мин";
 "modes.cloudAccuracy.grokStt.label" = "Наивысшая (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Наивысшая точность с более медленной обработкой. Лучше для важных транскрипций.";
+"modes.cloudAccuracy.googleChirp3.label" = "Высокая (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 с Chirp 3. Многоязычная модель с адаптацией по фразам.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Высокая (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 через Azure Speech. 43 языка с контекстной адаптацией.";
 
 "modes.create.title" = "Создать новый режим";
 "modes.create.subtitle" = "Настроить пользовательский профиль транскрипции";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "Запрос занял слишком много времени. Проверьте скорость интернета и повторите попытку.";
 "transcription.error.noSpeechDetected" = "В записи не обнаружена речь.";
 "transcription.guidance.noSpeechDetected" = "Советы:\n• Говорите четко в микрофон\n• Держите клавишу дольше перед разговором\n• Проверьте, что микрофон работает\n• Убедитесь, что выбрано правильное устройство ввода";
+"transcription.guidance.needsNativeRelaunch" = "Завершите работу HyperWhisper и откройте программу в нативном режиме, чтобы использовать локальную постобработку.";
+"transcription.guidance.localRuntimeUnavailable" = "Повторите попытку или выберите более компактную локальную модель в настройках режима.";
+"transcription.error.localRuntimeUnavailable" = "Локальный ИИ не смог завершить обработку — исходная расшифровка сохранена.";
+"settings.backup.localDownload.title" = "Загрузить локальные модели?";
+"settings.backup.localDownload.message" = "Восстановленных режимов, использующих локальные ИИ-модели, которые ещё не загружены: %d.";
+"settings.backup.localDownload.downloadAll" = "Загрузить все";
+"settings.backup.localDownload.dismiss" = "Закрыть";
+"modelLibrary.local.requiresAppleSilicon" = "Требуется Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Перезапустить в нативном режиме";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Недостаточно кредитов. Добавьте больше кредитов в Настройках.";

--- a/app/macos/hyperwhisper/Localizations/ru.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ru.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Главная";
-"sidebar.statistics" = "Статистика";
 "sidebar.modes" = "Режимы";
 "sidebar.vocabulary" = "Словарь";
 "sidebar.streaming" = "Потоковая передача";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Начните работу с HyperWhisper";
-"sidebar.statistics.help" = "Просмотрите статистику использования и аналитику";
 "sidebar.modes.help" = "Управляйте режимами транскрипции для различных контекстов";
 "sidebar.vocabulary.help" = "Добавьте пользовательские слова и фразы для лучшего распознавания";
 "sidebar.streaming.help" = "Параметры потоковой транскрипции в реальном времени (требует интернета)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "Ошибка проверки контрольной суммы модели. Загрузка может быть повреждена.";
 
 // MARK: - Statistics View
-"statistics.title" = "Статистика";
-"statistics.header.title" = "Ваша статистика использования";
-"statistics.header.subtitle" = "Отслеживайте активность транскрипции и производительность";
-"statistics.card.recordings" = "Всего записей";
-"statistics.card.recordings.subtitle" = "Завершенных транскрипций";
-"statistics.card.duration" = "Общее время";
-"statistics.card.duration.subtitle" = "Время, потраченное на запись";
-"statistics.card.words" = "Всего слов";
-"statistics.card.words.subtitle" = "Слов транскрибировано";
-"statistics.card.average" = "Средняя продолжительность";
-"statistics.card.average.subtitle" = "На одну запись";
-"statistics.graph.title" = "Активность во времени";
-"statistics.daily.empty" = "Записей нет";
-"statistics.filter.week" = "На этой неделе";
-"statistics.filter.month" = "В этом месяце";
-"statistics.filter.alltime" = "Всегда";
 
 // MARK: - History View
 "history.title" = "История";

--- a/app/macos/hyperwhisper/Localizations/sk.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sk.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Verzia %@";
 "home.recent.updates.new.badge" = "NOVÉ";
 "home.recent.updates.no.notes" = "Žiadne poznámky k vydaniu dostupné";
+"home.stats.words.week" = "Slová tento týždeň";
+"home.stats.words.month" = "Slová tento mesiac";
+"home.stats.speed" = "Priemerná rýchlosť";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Odporúčané pre Mac s 24 GB zjednotenej pamäte alebo viac. Rýchlosť závisí od čipu — rýchlejšie na M3/M4 Pro a vyšších.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Slová tento rok";
+"home.stats.typing.speed.help" = "Upravte predpokladanú rýchlosť písania (WPM), ktorá sa používa na odhad ušetreného času.";
+"home.stats.saved.week" = "Ušetrené tento týždeň";
+"home.stats.minutes.value" = "%d min";
 "vocabulary.input.placeholder" = "Pridajte slovo alebo vytvorte úryvok";
 "vocabulary.action.addWord" = "Pridať slovo";
 "vocabulary.action.replaceWith" = "Nahradiť za…";
@@ -671,8 +677,13 @@ Uprav tieto režimy a vyber iný model pred jeho odstránením.";
 "modes.cloudAccuracy.groqWhisper.description" = "Rýchla a dostupná. Najvhodnejšia na rýchle prepisy.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Vyvážená rýchlosť a presnosť. Odporúčané pre väčšinu používateľov.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Najvyššia presnosť s pomalším spracúvaním. Najlepšie pre dôležité prepisy.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kreditov/min";
 "modes.cloudAccuracy.grokStt.label" = "Najvyššia (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Najvyššia presnosť s pomalším spracúvaním. Najlepšie pre dôležité prepisy.";
+"modes.cloudAccuracy.googleChirp3.label" = "Vysoká (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 s Chirp 3. Viacjazyčné, s prispôsobením fráz.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Vysoká (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 cez Azure Speech. 43 jazykov s kontextovým prispôsobením.";
 
 "modes.create.title" = "Vytvoriť nový režim";
 "modes.create.subtitle" = "Konfigurovať vlastný profil prepisu";
@@ -883,6 +894,15 @@ Pred odstránením aktualizujte tieto režimy, aby používali iný model.";
 "transcription.guidance.timeout" = "Požiadavka trvala príliš dlho. Skontrolujte rýchlosť internetu a skúste znova.";
 "transcription.error.noSpeechDetected" = "V nahrávke nebola detekovaná reč.";
 "transcription.guidance.noSpeechDetected" = "Tipy:\n• Jasne rozprávajtea do mikrofónu\n• Držte kľúč dlhšie pred rozprávaním\n• Skontrolujte, či mikrofón funguje\n• Uistite sa, že je vybrané správne vstupné zariadenie";
+"transcription.guidance.needsNativeRelaunch" = "Ukončite a znova otvorte HyperWhisper natívne, aby ste mohli používať lokálne dodatočné spracovanie.";
+"transcription.guidance.localRuntimeUnavailable" = "Skúste to znova alebo v nastaveniach režimu vyberte menší lokálny model.";
+"transcription.error.localRuntimeUnavailable" = "Lokálna AI nedokázala dokončiť spracovanie — váš pôvodný prepis sa zachoval.";
+"settings.backup.localDownload.title" = "Stiahnuť lokálne modely?";
+"settings.backup.localDownload.message" = "%d z vašich obnovených režimov používa modely AI v zariadení, ktoré ešte nie sú stiahnuté.";
+"settings.backup.localDownload.downloadAll" = "Stiahnuť všetky";
+"settings.backup.localDownload.dismiss" = "Zavrieť";
+"modelLibrary.local.requiresAppleSilicon" = "Vyžaduje Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Spustiť natívne";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nedostatočné kredity. Pridajte ďalšie kredity v Nastaveniach.";

--- a/app/macos/hyperwhisper/Localizations/sk.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sk.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Domov";
-"sidebar.statistics" = "Štatistika";
 "sidebar.modes" = "Režimy";
 "sidebar.vocabulary" = "Slovník";
 "sidebar.streaming" = "Streamovanie";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Začať s HyperWhisper";
-"sidebar.statistics.help" = "Zobraziť štatistiku použitia a analýzy";
 "sidebar.modes.help" = "Spravovať režimy prepisu pre rôzne kontexty";
 "sidebar.vocabulary.help" = "Pridať vlastné slová a frázy pre lepšie rozpoznávanie";
 "sidebar.streaming.help" = "Nastavenia streamovania prepisov v reálnom čase (vyžaduje Internet)";
@@ -553,22 +551,6 @@ Uprav tieto režimy a vyber iný model pred jeho odstránením.";
 "models.error.checksumFailed" = "Overenie kontrolného súčtu modelu zlyhalo. Stiahnutie môže byť poškodené.";
 
 // MARK: - Statistics View
-"statistics.title" = "Štatistika";
-"statistics.header.title" = "Vaša štatistika použitia";
-"statistics.header.subtitle" = "Sledujte svoju aktivitu prepisu a výkon";
-"statistics.card.recordings" = "Spolu nahrávok";
-"statistics.card.recordings.subtitle" = "Dokončené prepisy";
-"statistics.card.duration" = "Celkový čas";
-"statistics.card.duration.subtitle" = "Čas strávený nahrávaním";
-"statistics.card.words" = "Celkem slov";
-"statistics.card.words.subtitle" = "Prepísaných slov";
-"statistics.card.average" = "Priemerné trvanie";
-"statistics.card.average.subtitle" = "Na nahrávku";
-"statistics.graph.title" = "Aktivita v čase";
-"statistics.daily.empty" = "Zatiaľ žiadne nahrávky";
-"statistics.filter.week" = "Tento týždeň";
-"statistics.filter.month" = "Tento mesiac";
-"statistics.filter.alltime" = "Všetky časy";
 
 // MARK: - History View
 "history.title" = "História";

--- a/app/macos/hyperwhisper/Localizations/sl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sl.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Različica %@";
 "home.recent.updates.new.badge" = "NOVO";
 "home.recent.updates.no.notes" = "Ni dostopnih opomb izdaje";
+"home.stats.words.week" = "Besede ta teden";
+"home.stats.words.month" = "Besede ta mesec";
+"home.stats.speed" = "Povprečna hitrost";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Priporočeno za Mac z 24 GB poenotenega pomnilnika ali več. Hitrost je odvisna od čipa — hitrejše na M3/M4 Pro in novejših.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Besede letos";
+"home.stats.typing.speed.help" = "Prilagodite predvideno hitrost tipkanja (WPM), ki se uporablja za oceno prihranjenega časa.";
+"home.stats.saved.week" = "Prihranjeno ta teden";
+"home.stats.minutes.value" = "%d min";
 "vocabulary.input.placeholder" = "Dodajte besedo ali ustvarite odlomek";
 "vocabulary.action.addWord" = "Dodaj besedo";
 "vocabulary.action.replaceWith" = "Zamenjaj z…";
@@ -671,8 +677,13 @@ Uredi te načine, da izbereš drug model pred odstranitvijo.";
 "modes.cloudAccuracy.groqWhisper.description" = "Hitro in prihodljivo. Najbolje za hitre prepise.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Uravnotežena hitrost in natančnost. Priporočljivo za večino uporabnikov.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Najvišja natančnost s počasnejšo obdelavo. Najbolje za pomembne prepise.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kreditov/min";
 "modes.cloudAccuracy.grokStt.label" = "Najvišja (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Najvišja natančnost s počasnejšo obdelavo. Najbolje za pomembne prepise.";
+"modes.cloudAccuracy.googleChirp3.label" = "Visoka (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 s Chirp 3. Večjezično s prilagajanjem fraz.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Visoka (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 prek Azure Speech. 43 jezikov s kontekstnim usmerjanjem.";
 
 "modes.create.title" = "Ustvari novi način";
 "modes.create.subtitle" = "Nastavi prilagojeni profil prepisa";
@@ -883,6 +894,15 @@ Pred brisanjem posodobite te načine delovanja, da bodo uporabljali drug model."
 "transcription.guidance.timeout" = "Zahteva je trajala predolgo. Preveri hitrost svojega interneta in poskusi znova.";
 "transcription.error.noSpeechDetected" = "V posnetku ni bil zaznan glas.";
 "transcription.guidance.noSpeechDetected" = "Namigi:\n• Jasno govori v mikrofon\n• Drži tipko dlje, preden govoriš\n• Preveri, da tvoj mikrofon deluje\n• Poskupi, da je izbrana pravilna vhodna naprava";
+"transcription.guidance.needsNativeRelaunch" = "Zaprite in znova odprite HyperWhisper kot izvorno aplikacijo, da boste lahko uporabljali lokalno naknadno obdelavo.";
+"transcription.guidance.localRuntimeUnavailable" = "Poskusite znova ali v nastavitvah načina izberite manjši lokalni model.";
+"transcription.error.localRuntimeUnavailable" = "Lokalna umetna inteligenca ni mogla dokončati obdelave — vaš neobdelan prepis je ohranjen.";
+"settings.backup.localDownload.title" = "Ali želite prenesti lokalne modele?";
+"settings.backup.localDownload.message" = "%d obnovljenih načinov uporablja modele umetne inteligence v napravi, ki še niso preneseni.";
+"settings.backup.localDownload.downloadAll" = "Prenesi vse";
+"settings.backup.localDownload.dismiss" = "Opusti";
+"modelLibrary.local.requiresAppleSilicon" = "Zahteva Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Znova zaženi izvorno";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Nezadostno število kreditov. Dodaj več kreditov v Nastavitvah.";

--- a/app/macos/hyperwhisper/Localizations/sl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sl.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Domov";
-"sidebar.statistics" = "Statistika";
 "sidebar.modes" = "Načini";
 "sidebar.vocabulary" = "Besednjak";
 "sidebar.streaming" = "Pretakanje";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Začni s HyperWhisper";
-"sidebar.statistics.help" = "Ogled uporabniške statistike in analitike";
 "sidebar.modes.help" = "Upravljaj načine prepisa za različne kontekste";
 "sidebar.vocabulary.help" = "Dodaj prilagojene besede in fraze za boljše prepoznavanje";
 "sidebar.streaming.help" = "Nastavitve pretakanja v realnem času (zahteva internet)";
@@ -553,22 +551,6 @@ Uredi te načine, da izbereš drug model pred odstranitvijo.";
 "models.error.checksumFailed" = "Neuspešna preverka vsote modela. Prenos je morda poškodovan.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistika";
-"statistics.header.title" = "Tvoja statistika uporabe";
-"statistics.header.subtitle" = "Spremljaj svojo aktivnost prepisa in delovanje";
-"statistics.card.recordings" = "Skupni posnetki";
-"statistics.card.recordings.subtitle" = "Zaključeni prepisi";
-"statistics.card.duration" = "Skupni čas";
-"statistics.card.duration.subtitle" = "Čas za snemanje";
-"statistics.card.words" = "Skupne besede";
-"statistics.card.words.subtitle" = "Prepisane besede";
-"statistics.card.average" = "Povprečna trajanja";
-"statistics.card.average.subtitle" = "Na posnetek";
-"statistics.graph.title" = "Aktivnost skozi čas";
-"statistics.daily.empty" = "Še ni posnetkov";
-"statistics.filter.week" = "To sedo";
-"statistics.filter.month" = "Ta mesec";
-"statistics.filter.alltime" = "Vse čase";
 
 // MARK: - History View
 "history.title" = "Zgodovina";

--- a/app/macos/hyperwhisper/Localizations/sr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sr.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Верзија %@";
 "home.recent.updates.new.badge" = "НОВО";
 "home.recent.updates.no.notes" = "Нема доступних напомена при издању";
+"home.stats.words.week" = "Reči ove nedelje";
+"home.stats.words.month" = "Reči ovog meseca";
+"home.stats.speed" = "Prosečna brzina";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Препоручено за Mac са 24 GB обједињене меморије или више. Брзина зависи од чипа — брже на M3/M4 Pro и новијим.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Речи ове године";
+"home.stats.typing.speed.help" = "Podesite pretpostavljenu brzinu kucanja (WPM) koja se koristi za procenu uštede vremena.";
+"home.stats.saved.week" = "Ušteđeno ove nedelje";
+"home.stats.minutes.value" = "%d minuta";
 "vocabulary.input.placeholder" = "Додај реч или направи исечак";
 "vocabulary.action.addWord" = "Додај реч";
 "vocabulary.action.replaceWith" = "Замени са…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "Брза и приступачна. Најбоља за брзе транскрипције.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Уравнотежена брзина и тачност. Препоручена за већину корисника.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Највећа тачност са споријом обработком. Најбоља за важне транскрипције.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredita/min";
 "modes.cloudAccuracy.grokStt.label" = "Највиша (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Највећа тачност са споријом обработком. Најбоља за важне транскрипције.";
+"modes.cloudAccuracy.googleChirp3.label" = "Visoka (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 sa Chirp 3. Višejezično uz prilagođavanje fraza.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Visoka (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 preko Azure Speech. 43 jezika uz kontekstualno prilagođavanje.";
 
 "modes.create.title" = "Направи Нови Режим";
 "modes.create.subtitle" = "Конфигуриши прилагођени профил транскрипције";
@@ -883,6 +894,15 @@ Pre brisanja ažurirajte ove režime da koriste drugi model.";
 "transcription.guidance.timeout" = "Захтев је трајао превише дуго. Провери брзину своје интернетске повезе и покушај поново.";
 "transcription.error.noSpeechDetected" = "Нема детектованог говора у снимању.";
 "transcription.guidance.noSpeechDetected" = "Савети:\n• Јасно говори у микрофон\n• Держи тастер дуже пре него што почнеш говорити\n• Провери да твој микрофон ради\n• Обезбеди да је изабран исправан уређај за унос";
+"transcription.guidance.needsNativeRelaunch" = "Zatvorite i ponovo otvorite HyperWhisper izvorno da biste koristili lokalnu naknadnu obradu.";
+"transcription.guidance.localRuntimeUnavailable" = "Pokušajte ponovo ili izaberite manji lokalni model u podešavanjima režima.";
+"transcription.error.localRuntimeUnavailable" = "Lokalni AI nije uspeo da završi — sačuvan je vaš neobrađeni transkript.";
+"settings.backup.localDownload.title" = "Preuzeti lokalne modele?";
+"settings.backup.localDownload.message" = "%d vaših vraćenih režima koristi AI modele na uređaju koji još nisu preuzeti.";
+"settings.backup.localDownload.downloadAll" = "Preuzmi sve";
+"settings.backup.localDownload.dismiss" = "Odbaci";
+"modelLibrary.local.requiresAppleSilicon" = "Zahteva Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Ponovo pokreni izvorno";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Недовољно кредита. Додај више кредита у Поставкама.";

--- a/app/macos/hyperwhisper/Localizations/sr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sr.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Почетна";
-"sidebar.statistics" = "Статистика";
 "sidebar.modes" = "Режими";
 "sidebar.vocabulary" = "Речник";
 "sidebar.streaming" = "Стриминг";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Почни са HyperWhisper";
-"sidebar.statistics.help" = "Преглед статистике употребе и аналитике";
 "sidebar.modes.help" = "Управљај режимима транскрипције за различите контексте";
 "sidebar.vocabulary.help" = "Додај прилагођене речи и фразе за бољу препознаву";
 "sidebar.streaming.help" = "Поставке стриминга транскрипције у стварном времену (захтева интернет)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "Провера суме модела неуспешна. Преузимање може бити корупирано.";
 
 // MARK: - Statistics View
-"statistics.title" = "Статистика";
-"statistics.header.title" = "Твоја Статистика Употребе";
-"statistics.header.subtitle" = "Праћење твоје активности транскрипције и перформанси";
-"statistics.card.recordings" = "Укупна Снимања";
-"statistics.card.recordings.subtitle" = "Завршене транскрипције";
-"statistics.card.duration" = "Укупно Време";
-"statistics.card.duration.subtitle" = "Време проведено снимањем";
-"statistics.card.words" = "Укупне Речи";
-"statistics.card.words.subtitle" = "Речи транскрибоване";
-"statistics.card.average" = "Просечно Трајање";
-"statistics.card.average.subtitle" = "По снимању";
-"statistics.graph.title" = "Активност Кроз Време";
-"statistics.daily.empty" = "Нема снимања";
-"statistics.filter.week" = "Ове Недеље";
-"statistics.filter.month" = "Овог Месеца";
-"statistics.filter.alltime" = "Од Почетка";
 
 // MARK: - History View
 "history.title" = "Историја";

--- a/app/macos/hyperwhisper/Localizations/sv.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sv.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Version %@";
 "home.recent.updates.new.badge" = "NY";
 "home.recent.updates.no.notes" = "Inga versionsinformation tillgängliga";
+"home.stats.words.week" = "Ord den här veckan";
+"home.stats.words.month" = "Ord den här månaden";
+"home.stats.speed" = "Genomsnittlig hastighet";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Rekommenderas för Mac med 24 GB unified memory eller mer. Hastigheten beror på ditt chip — snabbare på M3/M4 Pro och högre.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Ord i år";
+"home.stats.typing.speed.help" = "Justera den antagna skrivhastigheten (WPM) som används för att beräkna sparad tid.";
+"home.stats.saved.week" = "Sparat den här veckan";
+"home.stats.minutes.value" = "%d minuter";
 "vocabulary.input.placeholder" = "Lägg till ett ord eller skapa ett utdrag";
 "vocabulary.action.addWord" = "Lägg till ord";
 "vocabulary.action.replaceWith" = "Ersätt med…";
@@ -671,8 +677,13 @@ Redigera dessa lägen för att välja en annan modell innan du tar bort den.";
 "modes.cloudAccuracy.groqWhisper.description" = "Snabb och prisvärd. Bäst för snabba transkriptioner.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Balanserad hastighet och noggrannhet. Rekommenderas för de flesta användare.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Högsta noggrannhet med långsammare bearbetning. Bäst för viktiga transkriptioner.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ krediter/min";
 "modes.cloudAccuracy.grokStt.label" = "Högsta (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Högsta noggrannhet med långsammare bearbetning. Bäst för viktiga transkriptioner.";
+"modes.cloudAccuracy.googleChirp3.label" = "Hög (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 med Chirp 3. Flerspråkig med frasanpassning.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Hög (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 via Azure Speech. 43 språk med kontextuell anpassning.";
 
 "modes.create.title" = "Skapa nytt läge";
 "modes.create.subtitle" = "Konfigurera en anpassad transkriptionsprofil";
@@ -883,6 +894,15 @@ Uppdatera dessa lägen för att använda en annan modell innan du raderar.";
 "transcription.guidance.timeout" = "Förfrågan tog för lång tid. Kontrollera din internethastighet och försök igen.";
 "transcription.error.noSpeechDetected" = "Inget tal upptäcktes i inspelningen.";
 "transcription.guidance.noSpeechDetected" = "Tips:\n• Tala tydligt in i mikrofonen\n• Håll tangenten längre innan du talar\n• Kontrollera att din mikrofon fungerar\n• Se till att rätt ingångsenhet är vald";
+"transcription.guidance.needsNativeRelaunch" = "Avsluta och öppna HyperWhisper nativt igen för att använda lokal efterbearbetning.";
+"transcription.guidance.localRuntimeUnavailable" = "Försök igen eller välj en mindre lokal modell i lägesinställningarna.";
+"transcription.error.localRuntimeUnavailable" = "Den lokala AI:n kunde inte slutföra — din obearbetade transkribering sparades.";
+"settings.backup.localDownload.title" = "Hämta lokala modeller?";
+"settings.backup.localDownload.message" = "%d av dina återställda lägen använder lokala AI-modeller som inte har hämtats än.";
+"settings.backup.localDownload.downloadAll" = "Hämta alla";
+"settings.backup.localDownload.dismiss" = "Ignorera";
+"modelLibrary.local.requiresAppleSilicon" = "Kräver Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Starta om nativt";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Otillräckliga krediter. Lägg till mer krediter i inställningar.";

--- a/app/macos/hyperwhisper/Localizations/sv.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sv.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Hem";
-"sidebar.statistics" = "Statistik";
 "sidebar.modes" = "Lägen";
 "sidebar.vocabulary" = "Ordförråd";
 "sidebar.streaming" = "Streaming";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Kom igång med HyperWhisper";
-"sidebar.statistics.help" = "Visa användningsstatistik och analys";
 "sidebar.modes.help" = "Hantera transkriptionslägen för olika sammanhang";
 "sidebar.vocabulary.help" = "Lägg till anpassade ord och fraser för bättre igenkänning";
 "sidebar.streaming.help" = "Inställningar för transkription i realtid (kräver Internet)";
@@ -553,22 +551,6 @@ Redigera dessa lägen för att välja en annan modell innan du tar bort den.";
 "models.error.checksumFailed" = "Modellkontrollsummaverifiering misslyckades. Nedladdningen kan vara skadad.";
 
 // MARK: - Statistics View
-"statistics.title" = "Statistik";
-"statistics.header.title" = "Din användningsstatistik";
-"statistics.header.subtitle" = "Spåra din transkriptionsaktivitet och prestanda";
-"statistics.card.recordings" = "Totala inspelningar";
-"statistics.card.recordings.subtitle" = "Slutförda transkriptioner";
-"statistics.card.duration" = "Total tid";
-"statistics.card.duration.subtitle" = "Tid använd för inspelning";
-"statistics.card.words" = "Totala ord";
-"statistics.card.words.subtitle" = "Ord transkriberade";
-"statistics.card.average" = "Genomsnittlig varaktighet";
-"statistics.card.average.subtitle" = "Per inspelning";
-"statistics.graph.title" = "Aktivitet över tid";
-"statistics.daily.empty" = "Inga inspelningar än";
-"statistics.filter.week" = "Denna vecka";
-"statistics.filter.month" = "Denna månad";
-"statistics.filter.alltime" = "All tid";
 
 // MARK: - History View
 "history.title" = "Historik";

--- a/app/macos/hyperwhisper/Localizations/th.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/th.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "หน้าแรก";
-"sidebar.statistics" = "สถิติ";
 "sidebar.modes" = "โหมด";
 "sidebar.vocabulary" = "ศัพท์เฉพาะ";
 "sidebar.streaming" = "สตรีมมิง";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "เริ่มต้นใช้งาน HyperWhisper";
-"sidebar.statistics.help" = "ดูสถิติการใช้งานและการวิเคราะห์";
 "sidebar.modes.help" = "จัดการโหมดการสัญลักษณ์สำหรับบริบทต่างๆ";
 "sidebar.vocabulary.help" = "เพิ่มคำศัพท์และวลีที่กำหนดเองเพื่อการรู้จำที่ดีขึ้น";
 "sidebar.streaming.help" = "การตั้งค่าการสัญลักษณ์สตรีมมิงแบบเรียลไทม์ (ต้องเชื่อมต่ออินเทอร์เน็ต)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "การตรวจสอบ checksum โมเดลล้มเหลว การดาวน์โหลดอาจเสียหาย";
 
 // MARK: - Statistics View
-"statistics.title" = "สถิติ";
-"statistics.header.title" = "สถิติการใช้งานของคุณ";
-"statistics.header.subtitle" = "ติดตามกิจกรรมการสัญลักษณ์และประสิทธิภาพ";
-"statistics.card.recordings" = "การบันทึกทั้งหมด";
-"statistics.card.recordings.subtitle" = "การสัญลักษณ์ที่เสร็จสิ้น";
-"statistics.card.duration" = "เวลาทั้งหมด";
-"statistics.card.duration.subtitle" = "เวลาที่ใช้บันทึก";
-"statistics.card.words" = "คำทั้งหมด";
-"statistics.card.words.subtitle" = "คำที่สัญลักษณ์";
-"statistics.card.average" = "ระยะเวลาเฉลี่ย";
-"statistics.card.average.subtitle" = "ต่อการบันทึก";
-"statistics.graph.title" = "กิจกรรมเมื่อเวลาผ่านไป";
-"statistics.daily.empty" = "ยังไม่มีการบันทึก";
-"statistics.filter.week" = "สัปดาห์นี้";
-"statistics.filter.month" = "เดือนนี้";
-"statistics.filter.alltime" = "ทั้งหมด";
 
 // MARK: - History View
 "history.title" = "ประวัติ";

--- a/app/macos/hyperwhisper/Localizations/th.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/th.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "เวอร์ชัน %@";
 "home.recent.updates.new.badge" = "ใหม่";
 "home.recent.updates.no.notes" = "ไม่มีหมายเหตุการเปิดตัวที่พร้อมใช้งาน";
+"home.stats.words.week" = "จำนวนคำสัปดาห์นี้";
+"home.stats.words.month" = "จำนวนคำเดือนนี้";
+"home.stats.speed" = "ความเร็วเฉลี่ย";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "แนะนำสำหรับ Mac ที่มี unified memory 24 GB ขึ้นไป ความเร็วขึ้นอยู่กับชิป — เร็วขึ้นบน M3/M4 Pro และสูงกว่า";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "คำในปีนี้";
+"home.stats.typing.speed.help" = "ปรับความเร็วในการพิมพ์ที่ใช้อ้างอิง (WPM) สำหรับประมาณเวลาที่ประหยัดได้";
+"home.stats.saved.week" = "ประหยัดได้สัปดาห์นี้";
+"home.stats.minutes.value" = "%d นาที";
 "vocabulary.input.placeholder" = "เพิ่มคำหรือสร้างตัวอย่าง";
 "vocabulary.action.addWord" = "เพิ่มคำ";
 "vocabulary.action.replaceWith" = "แทนที่ด้วย…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "เร็วและราคาไม่แพง ดีที่สุดสำหรับการสัญลักษณ์อย่างรวดเร็ว";
 "modes.cloudAccuracy.deepgramNova3.description" = "ความเร็วและความแม่นยำที่สมดุล แนะนำสำหรับผู้ใช้ส่วนใหญ่";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - ความแม่นยำสูงสุดพร้อมการประมวลผลที่ช้าลง ดีที่สุดสำหรับการสัญลักษณ์ที่สำคัญ";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ เครดิต/นาที";
 "modes.cloudAccuracy.grokStt.label" = "สูงสุด (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - ความแม่นยำสูงสุดพร้อมการประมวลผลที่ช้าลง ดีที่สุดสำหรับการสัญลักษณ์ที่สำคัญ";
+"modes.cloudAccuracy.googleChirp3.label" = "สูง (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 พร้อม Chirp 3 รองรับหลายภาษา พร้อมการปรับตามวลี";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "สูง (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 ผ่าน Azure Speech รองรับ 43 ภาษา พร้อมการปรับตามบริบท";
 
 "modes.create.title" = "สร้างโหมดใหม่";
 "modes.create.subtitle" = "กำหนดค่าโปรไฟล์การสัญลักษณ์ที่กำหนดเอง";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "คำขอใช้เวลานานเกินไป ตรวจสอบความเร็วอินเทอร์เน็ตและลองใหม่";
 "transcription.error.noSpeechDetected" = "ไม่พบเสียงพูดในการบันทึก";
 "transcription.guidance.noSpeechDetected" = "เคล็ดลับ:\n• พูดชัดเจนลงในไมโครโฟน\n• ค้างคีย์นานขึ้นก่อนพูด\n• ตรวจสอบว่าไมโครโฟนของคุณใช้งานได้\n• ตรวจสอบให้แน่ใจว่าอุปกรณ์อินพุตที่ถูกต้องได้รับการเลือก";
+"transcription.guidance.needsNativeRelaunch" = "ออกจาก HyperWhisper แล้วเปิดใหม่แบบเนทีฟ เพื่อใช้การประมวลผลหลังถอดเสียงในเครื่อง";
+"transcription.guidance.localRuntimeUnavailable" = "ลองอีกครั้ง หรือเลือกโมเดลในเครื่องที่เล็กลงในการตั้งค่าโหมด";
+"transcription.error.localRuntimeUnavailable" = "AI ในเครื่องทำงานไม่สำเร็จ — ระบบเก็บข้อความถอดเสียงต้นฉบับไว้ให้แล้ว";
+"settings.backup.localDownload.title" = "ดาวน์โหลดโมเดลในเครื่องหรือไม่?";
+"settings.backup.localDownload.message" = "โหมดที่กู้คืนมา %d โหมดใช้โมเดล AI บนอุปกรณ์ที่ยังไม่ได้ดาวน์โหลด";
+"settings.backup.localDownload.downloadAll" = "ดาวน์โหลดทั้งหมด";
+"settings.backup.localDownload.dismiss" = "ปิด";
+"modelLibrary.local.requiresAppleSilicon" = "ต้องใช้ Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "เปิดใหม่แบบเนทีฟ";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "เครดิตไม่เพียงพอ เพิ่มเครดิตในการตั้งค่า";

--- a/app/macos/hyperwhisper/Localizations/tr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/tr.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Ana Sayfa";
-"sidebar.statistics" = "İstatistikler";
 "sidebar.modes" = "Modlar";
 "sidebar.vocabulary" = "Kelime Hazinesi";
 "sidebar.streaming" = "Akış";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "HyperWhisper'ı kullanmaya başlayın";
-"sidebar.statistics.help" = "Kullanım istatistiklerini ve analizlerini görüntüleyin";
 "sidebar.modes.help" = "Farklı bağlamlar için transkripsiyon modlarını yönet";
 "sidebar.vocabulary.help" = "Daha iyi tanıma için özel kelimeler ve ifadeler ekleyin";
 "sidebar.streaming.help" = "Gerçek zamanlı akış transkripsiyon ayarları (İnternet gerekir)";
@@ -553,22 +551,6 @@ Kaldırmadan önce farklı bir model seçmek için o modları düzenleyin.";
 "models.error.checksumFailed" = "Model sağlama toplamı doğrulaması başarısız oldu. İndirme bozulmuş olabilir.";
 
 // MARK: - Statistics View
-"statistics.title" = "İstatistikler";
-"statistics.header.title" = "Kullanım İstatistikleriniz";
-"statistics.header.subtitle" = "Transkripsiyon aktivitenizi ve performansını izleyin";
-"statistics.card.recordings" = "Toplam Kayıtlar";
-"statistics.card.recordings.subtitle" = "Tamamlanan transkripsiyon";
-"statistics.card.duration" = "Toplam Zaman";
-"statistics.card.duration.subtitle" = "Kaydı yapılan zaman";
-"statistics.card.words" = "Toplam Kelimeler";
-"statistics.card.words.subtitle" = "Transkribe edilen kelimeler";
-"statistics.card.average" = "Ortalama Süre";
-"statistics.card.average.subtitle" = "Kayıt başına";
-"statistics.graph.title" = "Zaman İçinde Aktivite";
-"statistics.daily.empty" = "Henüz kayıt yok";
-"statistics.filter.week" = "Bu Hafta";
-"statistics.filter.month" = "Bu Ay";
-"statistics.filter.alltime" = "Tüm Zaman";
 
 // MARK: - History View
 "history.title" = "Geçmiş";

--- a/app/macos/hyperwhisper/Localizations/tr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/tr.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Sürüm %@";
 "home.recent.updates.new.badge" = "YENİ";
 "home.recent.updates.no.notes" = "Sürüm notları yok";
+"home.stats.words.week" = "Bu haftaki kelimeler";
+"home.stats.words.month" = "Bu ayki kelimeler";
+"home.stats.speed" = "Ortalama hız";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "24 GB birleşik belleğe veya daha fazlasına sahip Mac için önerilir. Hız çipe bağlıdır — M3/M4 Pro ve üstünde daha hızlı.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Bu yılki kelimeler";
+"home.stats.typing.speed.help" = "Kazanılan süreyi hesaplamak için kullanılan varsayılan yazma hızını (WPM) ayarlayın.";
+"home.stats.saved.week" = "Bu hafta kazanılan süre";
+"home.stats.minutes.value" = "%d dakika";
 "vocabulary.input.placeholder" = "Bir kelime ekleyin veya kod parçası oluşturun";
 "vocabulary.action.addWord" = "Kelime ekle";
 "vocabulary.action.replaceWith" = "Şununla değiştir…";
@@ -671,8 +677,13 @@ Kaldırmadan önce farklı bir model seçmek için o modları düzenleyin.";
 "modes.cloudAccuracy.groqWhisper.description" = "Hızlı ve uygun fiyatlı. Hızlı transkripsiyon için en iyisi.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Dengeli hız ve doğruluk. Çoğu kullanıcı için önerilir.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Daha yavaş işlenmeyle birlikte en yüksek doğruluk. Önemli transkripsiyon'lar için en iyisi.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ kredi/dk";
 "modes.cloudAccuracy.grokStt.label" = "En Yüksek (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Daha yavaş işlenmeyle birlikte en yüksek doğruluk. Önemli transkripsiyon'lar için en iyisi.";
+"modes.cloudAccuracy.googleChirp3.label" = "Yüksek (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Chirp 3 ile Google Cloud Speech-to-Text V2. İfade uyarlamalı, çok dilli.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Yüksek (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Azure Speech üzerinden Microsoft MAI-Transcribe 1.5. Bağlamsal yönlendirme ile 43 dil.";
 
 "modes.create.title" = "Yeni Mod Oluştur";
 "modes.create.subtitle" = "Özel transkripsiyon profilini yapılandır";
@@ -883,6 +894,15 @@ Silmeden önce bu modları farklı bir model kullanacak şekilde güncelleyin.";
 "transcription.guidance.timeout" = "İstek çok uzun sürdü. İnternet hızınızı kontrol edin ve tekrar deneyin.";
 "transcription.error.noSpeechDetected" = "Kayıtta konuşma algılanmadı.";
 "transcription.guidance.noSpeechDetected" = "İpuçları:\n• Mikrofonun içine açıkça konuş\n• Konuşmadan önce tuşu daha uzun basın\n• Mikrofonunuzun çalıştığını kontrol edin\n• Doğru giriş cihazının seçildiğinden emin olun";
+"transcription.guidance.needsNativeRelaunch" = "Yerel son işlemeyi kullanmak için HyperWhisper'dan çıkıp uygulamayı yerel mimaride yeniden açın.";
+"transcription.guidance.localRuntimeUnavailable" = "Tekrar deneyin veya Mod ayarlarınızda daha küçük bir yerel model seçin.";
+"transcription.error.localRuntimeUnavailable" = "Yerel yapay zeka işlemi tamamlayamadı — ham metniniz korundu.";
+"settings.backup.localDownload.title" = "Yerel modeller indirilsin mi?";
+"settings.backup.localDownload.message" = "Geri yüklenen modlarınızdan %d tanesi henüz indirilmemiş, cihaz üzerinde çalışan yapay zeka modellerini kullanıyor.";
+"settings.backup.localDownload.downloadAll" = "Tümünü İndir";
+"settings.backup.localDownload.dismiss" = "Kapat";
+"modelLibrary.local.requiresAppleSilicon" = "Apple Silicon gerektirir";
+"modelLibrary.local.needsNativeRelaunch" = "Yerel mimaride yeniden başlat";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Yetersiz krediler. Ayarlar'dan daha fazla kredi ekleyin.";

--- a/app/macos/hyperwhisper/Localizations/uk.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/uk.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Головна";
-"sidebar.statistics" = "Статистика";
 "sidebar.modes" = "Режими";
 "sidebar.vocabulary" = "Словник";
 "sidebar.streaming" = "Потокова передача";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Розпочніть роботу з HyperWhisper";
-"sidebar.statistics.help" = "Переглянути статистику використання та аналітику";
 "sidebar.modes.help" = "Керуйте режимами транскрипції для різних контекстів";
 "sidebar.vocabulary.help" = "Додайте спеціальні слова та фрази для кращого розпізнавання";
 "sidebar.streaming.help" = "Параметри потокової транскрипції в реальному часі (потребує інтернету)";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "Перевірка контрольної суми моделі не вдалася. Завантаження може бути пошкоджено.";
 
 // MARK: - Statistics View
-"statistics.title" = "Статистика";
-"statistics.header.title" = "Ваша статистика використання";
-"statistics.header.subtitle" = "Стежте за своєю активністю транскрипції та продуктивністю";
-"statistics.card.recordings" = "Усього записів";
-"statistics.card.recordings.subtitle" = "Завершено транскрипцій";
-"statistics.card.duration" = "Загальний час";
-"statistics.card.duration.subtitle" = "Час, проведений на записуванні";
-"statistics.card.words" = "Усього слів";
-"statistics.card.words.subtitle" = "Слів транскрибовано";
-"statistics.card.average" = "Середня тривалість";
-"statistics.card.average.subtitle" = "На запис";
-"statistics.graph.title" = "Активність з часом";
-"statistics.daily.empty" = "Нема записів";
-"statistics.filter.week" = "На цьому тижні";
-"statistics.filter.month" = "У цьому місяці";
-"statistics.filter.alltime" = "За весь час";
 
 // MARK: - History View
 "history.title" = "Історія";

--- a/app/macos/hyperwhisper/Localizations/uk.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/uk.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Версія %@";
 "home.recent.updates.new.badge" = "НОВЕ";
 "home.recent.updates.no.notes" = "Нема приміток до випуску";
+"home.stats.words.week" = "Слів цього тижня";
+"home.stats.words.month" = "Слів цього місяця";
+"home.stats.speed" = "Середня швидкість";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Рекомендовано для Mac з 24 GB об'єднаної пам'яті або більше. Швидкість залежить від чипа — швидше на M3/M4 Pro та новіших.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Слів цього року";
+"home.stats.typing.speed.help" = "Налаштуйте орієнтовну швидкість набору (WPM), яка використовується для оцінки заощадженого часу.";
+"home.stats.saved.week" = "Заощаджено цього тижня";
+"home.stats.minutes.value" = "%d хв";
 "vocabulary.input.placeholder" = "Додайте слово або створіть фрагмент";
 "vocabulary.action.addWord" = "Додати слово";
 "vocabulary.action.replaceWith" = "Замінити на…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "Швидка та доступна. Найкраще для швидких транскрипцій.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Збалансована швидкість та точність. Рекомендовано для більшості користувачів.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Найвища точність з повільнішою обробкою. Найкраще для важливих транскрипцій.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ кредитів/хв";
 "modes.cloudAccuracy.grokStt.label" = "Найвища (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Найвища точність з повільнішою обробкою. Найкраще для важливих транскрипцій.";
+"modes.cloudAccuracy.googleChirp3.label" = "Висока (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 з Chirp 3. Багатомовна модель з адаптацією фраз.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Висока (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 через Azure Speech. 43 мови з контекстним підлаштуванням.";
 
 "modes.create.title" = "Створити новий режим";
 "modes.create.subtitle" = "Налаштуйте спеціальний профіль транскрипції";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "Запит тривав занадто довго. Перевірте швидкість інтернету та спробуйте ще раз.";
 "transcription.error.noSpeechDetected" = "У записі не виявлено мовлення.";
 "transcription.guidance.noSpeechDetected" = "Поради:\n• Говоріть ясно в мікрофон\n• Утримуйте клавішу довше перед тим, як говорити\n• Переконайтеся, що ваш мікрофон працює\n• Переконайтеся, що вибраний правильний пристрій введення";
+"transcription.guidance.needsNativeRelaunch" = "Закрийте та знову відкрийте HyperWhisper у нативному режимі, щоб використовувати локальну постобробку.";
+"transcription.guidance.localRuntimeUnavailable" = "Спробуйте ще раз або виберіть меншу локальну модель у параметрах режиму.";
+"transcription.error.localRuntimeUnavailable" = "Локальний ШІ не зміг завершити обробку — вихідний транскрипт збережено.";
+"settings.backup.localDownload.title" = "Завантажити локальні моделі?";
+"settings.backup.localDownload.message" = "%d з ваших відновлених режимів використовують локальні моделі ШІ, які ще не завантажено.";
+"settings.backup.localDownload.downloadAll" = "Завантажити всі";
+"settings.backup.localDownload.dismiss" = "Закрити";
+"modelLibrary.local.requiresAppleSilicon" = "Потрібен Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Перезапустити нативно";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Недостатньо кредитів. Додайте більше кредитів у Налаштуваннях.";

--- a/app/macos/hyperwhisper/Localizations/vi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/vi.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "Phiên bản %@";
 "home.recent.updates.new.badge" = "MỚI";
 "home.recent.updates.no.notes" = "Không có ghi chú phát hành";
+"home.stats.words.week" = "Số từ tuần này";
+"home.stats.words.month" = "Số từ tháng này";
+"home.stats.speed" = "Tốc độ trung bình";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "Được khuyến nghị cho Mac có 24 GB bộ nhớ hợp nhất trở lên. Tốc độ phụ thuộc vào chip — nhanh hơn trên M3/M4 Pro trở lên.";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "Từ trong năm nay";
+"home.stats.typing.speed.help" = "Điều chỉnh tốc độ gõ phím giả định (WPM) dùng để ước tính thời gian tiết kiệm được.";
+"home.stats.saved.week" = "Tiết kiệm được tuần này";
+"home.stats.minutes.value" = "%d phút";
 "vocabulary.input.placeholder" = "Thêm từ hoặc tạo đoạn trích";
 "vocabulary.action.addWord" = "Thêm từ";
 "vocabulary.action.replaceWith" = "Thay thế bằng…";
@@ -671,8 +677,13 @@ Chỉnh sửa các chế độ đó để chọn mô hình khác trước khi x�
 "modes.cloudAccuracy.groqWhisper.description" = "Nhanh và giá cả phải chăng. Tốt nhất cho chuyển đổi nhanh.";
 "modes.cloudAccuracy.deepgramNova3.description" = "Cân bằng tốc độ và độ chính xác. Được đề xuất cho hầu hết người dùng.";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - Độ chính xác cao nhất với xử lý chậm hơn. Tốt nhất cho chuyển đổi quan trọng.";
+"modes.cloudAccuracy.creditsPerMinute" = "~%@ tín dụng/phút";
 "modes.cloudAccuracy.grokStt.label" = "Cao nhất (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - Độ chính xác cao nhất với xử lý chậm hơn. Tốt nhất cho chuyển đổi quan trọng.";
+"modes.cloudAccuracy.googleChirp3.label" = "Cao (Google Chirp 3)";
+"modes.cloudAccuracy.googleChirp3.description" = "Google Cloud Speech-to-Text V2 với Chirp 3. Đa ngôn ngữ, có thích ứng cụm từ.";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "Cao (Microsoft MAI-Transcribe 1.5)";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "Microsoft MAI-Transcribe 1.5 qua Azure Speech. 43 ngôn ngữ, có điều chỉnh theo ngữ cảnh.";
 
 "modes.create.title" = "Tạo Chế độ Mới";
 "modes.create.subtitle" = "Cấu hình hồ sơ chuyển đổi tùy chỉnh";
@@ -883,6 +894,15 @@ Cập nhật các chế độ này để sử dụng mô hình khác trước kh
 "transcription.guidance.timeout" = "Yêu cầu mất quá lâu. Kiểm tra tốc độ internet của bạn và thử lại.";
 "transcription.error.noSpeechDetected" = "Không phát hiện lời nói trong bản ghi âm.";
 "transcription.guidance.noSpeechDetected" = "Mẹo:\n• Nói rõ ràng vào micrô\n• Giữ chìa khóa lâu hơn trước khi nói\n• Kiểm tra micrô của bạn đang hoạt động\n• Đảm bảo thiết bị đầu vào chính xác được chọn";
+"transcription.guidance.needsNativeRelaunch" = "Hãy thoát và mở lại HyperWhisper ở chế độ gốc để dùng hậu xử lý cục bộ.";
+"transcription.guidance.localRuntimeUnavailable" = "Hãy thử lại hoặc chọn một mô hình cục bộ nhỏ hơn trong cài đặt Chế độ.";
+"transcription.error.localRuntimeUnavailable" = "AI cục bộ không thể hoàn tất — bản chép lời gốc của bạn đã được giữ lại.";
+"settings.backup.localDownload.title" = "Tải xuống mô hình cục bộ?";
+"settings.backup.localDownload.message" = "%d chế độ đã khôi phục của bạn dùng mô hình AI trên thiết bị nhưng chưa được tải xuống.";
+"settings.backup.localDownload.downloadAll" = "Tải xuống tất cả";
+"settings.backup.localDownload.dismiss" = "Bỏ qua";
+"modelLibrary.local.requiresAppleSilicon" = "Yêu cầu Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "Khởi động lại ở chế độ gốc";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "Tín dụng không đủ. Thêm tín dụng trong Cài đặt.";

--- a/app/macos/hyperwhisper/Localizations/vi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/vi.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "Trang chủ";
-"sidebar.statistics" = "Thống kê";
 "sidebar.modes" = "Chế độ";
 "sidebar.vocabulary" = "Từ vựng";
 "sidebar.streaming" = "Luồng phát";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "Bắt đầu với HyperWhisper";
-"sidebar.statistics.help" = "Xem thống kê sử dụng và phân tích";
 "sidebar.modes.help" = "Quản lý chế độ phiên bản chuyển đổi cho các bối cảnh khác nhau";
 "sidebar.vocabulary.help" = "Thêm các từ và cụm từ tùy chỉnh để nhận dạng tốt hơn";
 "sidebar.streaming.help" = "Cài đặt phiên bản chuyển đổi luồng phát thực tế (yêu cầu Internet)";
@@ -553,22 +551,6 @@ Chỉnh sửa các chế độ đó để chọn mô hình khác trước khi x�
 "models.error.checksumFailed" = "Xác minh tổng kiểm tra mô hình không thành công. Bản tải xuống có thể bị hỏng.";
 
 // MARK: - Statistics View
-"statistics.title" = "Thống kê";
-"statistics.header.title" = "Thống kê Sử dụng của Bạn";
-"statistics.header.subtitle" = "Theo dõi hoạt động và hiệu suất chuyển đổi của bạn";
-"statistics.card.recordings" = "Tổng số Bản ghi âm";
-"statistics.card.recordings.subtitle" = "Bản chuyển đổi hoàn tất";
-"statistics.card.duration" = "Tổng Thời gian";
-"statistics.card.duration.subtitle" = "Thời gian dành cho ghi âm";
-"statistics.card.words" = "Tổng số Từ";
-"statistics.card.words.subtitle" = "Từ được chuyển đổi";
-"statistics.card.average" = "Thời lượng Trung bình";
-"statistics.card.average.subtitle" = "Mỗi bản ghi âm";
-"statistics.graph.title" = "Hoạt động Theo Thời gian";
-"statistics.daily.empty" = "Chưa có bản ghi âm nào";
-"statistics.filter.week" = "Tuần Này";
-"statistics.filter.month" = "Tháng Này";
-"statistics.filter.alltime" = "Toàn thời gian";
 
 // MARK: - History View
 "history.title" = "Lịch sử";

--- a/app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "版本 %@";
 "home.recent.updates.new.badge" = "新";
 "home.recent.updates.no.notes" = "暂无版本说明";
+"home.stats.words.week" = "本周字数";
+"home.stats.words.month" = "本月字数";
+"home.stats.speed" = "平均语速";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "建议配备 24 GB 统一内存或更多的 Mac 使用。速度取决于芯片 — 在 M3/M4 Pro 及以上机型上更快。";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "今年的字数";
+"home.stats.typing.speed.help" = "调整用于估算节省时间的假定打字速度（WPM）。";
+"home.stats.saved.week" = "本周节省时间";
+"home.stats.minutes.value" = "%d 分钟";
 "vocabulary.input.placeholder" = "添加单词或创建片段";
 "vocabulary.action.addWord" = "添加单词";
 "vocabulary.action.replaceWith" = "替换为…";
@@ -677,8 +683,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "快速且经济，适合快速转写。";
 "modes.cloudAccuracy.deepgramNova3.description" = "速度与准确度平衡，推荐给大多数用户。";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - 最高准确度但更慢，适合重要转写。";
+"modes.cloudAccuracy.creditsPerMinute" = "约 %@ 积分/分钟";
 "modes.cloudAccuracy.grokStt.label" = "最高 (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - 最高准确度但更慢，适合重要转写。";
+"modes.cloudAccuracy.googleChirp3.label" = "高（Google Chirp 3）";
+"modes.cloudAccuracy.googleChirp3.description" = "采用 Chirp 3 的 Google Cloud Speech-to-Text V2。支持多语言，并具备短语自适应。";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "高（Microsoft MAI-Transcribe 1.5）";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "通过 Azure Speech 使用 Microsoft MAI-Transcribe 1.5。支持 43 种语言，并具备上下文偏置。";
 
 "modes.create.title" = "创建新模式";
 "modes.create.subtitle" = "配置自定义转写档案";
@@ -884,6 +895,15 @@
 "transcription.guidance.timeout" = "请求时间过长。检查网络速度后重试。";
 "transcription.error.noSpeechDetected" = "录音中未检测到语音。";
 "transcription.guidance.noSpeechDetected" = "提示：\n• 请清晰地对着麦克风说话\n• 说话前按住按键更久一些\n• 检查麦克风是否正常工作\n• 确认已选择正确的输入设备";
+"transcription.guidance.needsNativeRelaunch" = "请退出并以原生方式重新打开 HyperWhisper，以使用本地后处理。";
+"transcription.guidance.localRuntimeUnavailable" = "请重试，或在模式设置中选择更小的本地模型。";
+"transcription.error.localRuntimeUnavailable" = "本地 AI 未能完成处理 — 已为你保留原始转写文本。";
+"settings.backup.localDownload.title" = "要下载本地模型吗？";
+"settings.backup.localDownload.message" = "在已恢复的模式中，有 %d 个使用了尚未下载的设备端 AI 模型。";
+"settings.backup.localDownload.downloadAll" = "全部下载";
+"settings.backup.localDownload.dismiss" = "忽略";
+"modelLibrary.local.requiresAppleSilicon" = "需要 Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "以原生方式重新启动";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "额度不足。请在设置中添加更多额度。";

--- a/app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "主页";
-"sidebar.statistics" = "统计";
 "sidebar.modes" = "模式";
 "sidebar.vocabulary" = "词汇";
 "sidebar.streaming" = "流式转写";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "开始使用 HyperWhisper";
-"sidebar.statistics.help" = "查看使用统计和分析";
 "sidebar.modes.help" = "为不同场景管理转写模式";
 "sidebar.vocabulary.help" = "添加自定义词语和短语以提升识别";
 "sidebar.streaming.help" = "流式转写设置（需互联网）";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "模型校验和验证失败。下载可能已损坏。";
 
 // MARK: - Statistics View
-"statistics.title" = "统计";
-"statistics.header.title" = "你的使用统计";
-"statistics.header.subtitle" = "跟踪转写活动与表现";
-"statistics.card.recordings" = "总录音数";
-"statistics.card.recordings.subtitle" = "已完成的转写";
-"statistics.card.duration" = "总时长";
-"statistics.card.duration.subtitle" = "录音时间";
-"statistics.card.words" = "总字数";
-"statistics.card.words.subtitle" = "已转写的字数";
-"statistics.card.average" = "平均时长";
-"statistics.card.average.subtitle" = "每次录音";
-"statistics.graph.title" = "活动趋势";
-"statistics.daily.empty" = "还没有录音";
-"statistics.filter.week" = "本周";
-"statistics.filter.month" = "本月";
-"statistics.filter.alltime" = "全部";
 
 // MARK: - History View
 "history.title" = "历史记录";

--- a/app/macos/hyperwhisper/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/zh-Hant.lproj/Localizable.strings
@@ -132,6 +132,9 @@
 "home.recent.updates.version" = "版本 %@";
 "home.recent.updates.new.badge" = "新";
 "home.recent.updates.no.notes" = "沒有可用的發行說明";
+"home.stats.words.week" = "本週字數";
+"home.stats.words.month" = "本月字數";
+"home.stats.speed" = "平均速度";
 
 // MARK: - Keyboard Labels
 "keyboard.escape" = "Esc";
@@ -490,6 +493,9 @@
 "settings.models.localPostProcessing.memoryWarning" = "建議配備 24 GB 統一記憶體或更多的 Mac 使用。速度取決於晶片 — 在 M3/M4 Pro 及以上機型上更快。";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "home.stats.words.year" = "今年的字數";
+"home.stats.typing.speed.help" = "調整用來估算節省時間的預設打字速度（WPM）。";
+"home.stats.saved.week" = "本週節省時間";
+"home.stats.minutes.value" = "%d 分鐘";
 "vocabulary.input.placeholder" = "新增單詞或建立片段";
 "vocabulary.action.addWord" = "新增單詞";
 "vocabulary.action.replaceWith" = "取代為…";
@@ -671,8 +677,13 @@
 "modes.cloudAccuracy.groqWhisper.description" = "快速且價廉。最適合快速轉錄。";
 "modes.cloudAccuracy.deepgramNova3.description" = "速度和準確性平衡。為大多數用戶推薦。";
 "modes.cloudAccuracy.elevenLabsScribeV2.description" = "ElevenLabs Scribe v2 - 最高準確性，處理較慢。最適合重要轉錄。";
+"modes.cloudAccuracy.creditsPerMinute" = "約 %@ 點數/分鐘";
 "modes.cloudAccuracy.grokStt.label" = "最高 (Grok SST)";
 "modes.cloudAccuracy.grokStt.description" = "xAI Grok STT - 最高準確性，處理較慢。最適合重要轉錄。";
+"modes.cloudAccuracy.googleChirp3.label" = "高（Google Chirp 3）";
+"modes.cloudAccuracy.googleChirp3.description" = "採用 Chirp 3 的 Google Cloud Speech-to-Text V2。支援多語言與詞組調適。";
+"modes.cloudAccuracy.azureMaiTranscribe.label" = "高（Microsoft MAI-Transcribe 1.5）";
+"modes.cloudAccuracy.azureMaiTranscribe.description" = "透過 Azure Speech 使用 Microsoft MAI-Transcribe 1.5。支援 43 種語言，並具備上下文偏詞功能。";
 
 "modes.create.title" = "建立新模式";
 "modes.create.subtitle" = "設定自訂轉錄設定檔";
@@ -883,6 +894,15 @@
 "transcription.guidance.timeout" = "請求耗時過長。檢查您的網際網路速度並重試。";
 "transcription.error.noSpeechDetected" = "在錄音中未偵測到語音。";
 "transcription.guidance.noSpeechDetected" = "提示：\n• 清楚地對著麥克風說話\n• 在說話前按住按鍵較長時間\n• 檢查您的麥克風是否運作正常\n• 確保選擇了正確的輸入裝置";
+"transcription.guidance.needsNativeRelaunch" = "請結束並以原生模式重新開啟 HyperWhisper，才能使用本機後處理。";
+"transcription.guidance.localRuntimeUnavailable" = "請再試一次，或在模式設定中選擇較小的本機模型。";
+"transcription.error.localRuntimeUnavailable" = "本機 AI 無法完成處理 — 已保留你的原始逐字稿。";
+"settings.backup.localDownload.title" = "要下載本機模型嗎？";
+"settings.backup.localDownload.message" = "你還原的模式中有 %d 個使用尚未下載的裝置端 AI 模型。";
+"settings.backup.localDownload.downloadAll" = "全部下載";
+"settings.backup.localDownload.dismiss" = "關閉";
+"modelLibrary.local.requiresAppleSilicon" = "需要 Apple Silicon";
+"modelLibrary.local.needsNativeRelaunch" = "以原生模式重新啟動";
 
 // MARK: - HyperWhisper Cloud Errors
 "hyperwhisperCloud.error.insufficientCredits" = "額度不足。請在設定中新增更多額度。";

--- a/app/macos/hyperwhisper/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/zh-Hant.lproj/Localizable.strings
@@ -81,7 +81,6 @@
 
 // MARK: - Sidebar Navigation
 "sidebar.home" = "主頁";
-"sidebar.statistics" = "統計";
 "sidebar.modes" = "模式";
 "sidebar.vocabulary" = "詞彙";
 "sidebar.streaming" = "串流";
@@ -169,7 +168,6 @@
 
 // MARK: - Sidebar Help Text
 "sidebar.home.help" = "開始使用 HyperWhisper";
-"sidebar.statistics.help" = "檢視使用統計和分析";
 "sidebar.modes.help" = "管理不同內容的轉錄模式";
 "sidebar.vocabulary.help" = "新增自訂詞語和短語以提高識別率";
 "sidebar.streaming.help" = "即時串流轉錄設定（需要網際網路）";
@@ -553,22 +551,6 @@
 "models.error.checksumFailed" = "模型校驗和驗證失敗。下載可能已損毀。";
 
 // MARK: - Statistics View
-"statistics.title" = "統計";
-"statistics.header.title" = "您的使用統計";
-"statistics.header.subtitle" = "追蹤您的轉錄活動和效能";
-"statistics.card.recordings" = "總錄音數";
-"statistics.card.recordings.subtitle" = "已完成的轉錄";
-"statistics.card.duration" = "總時間";
-"statistics.card.duration.subtitle" = "錄音花費時間";
-"statistics.card.words" = "總詞數";
-"statistics.card.words.subtitle" = "轉錄的詞";
-"statistics.card.average" = "平均時長";
-"statistics.card.average.subtitle" = "每次錄音";
-"statistics.graph.title" = "一段時間內的活動";
-"statistics.daily.empty" = "還沒有錄音";
-"statistics.filter.week" = "本週";
-"statistics.filter.month" = "本月";
-"statistics.filter.alltime" = "全部時間";
 
 // MARK: - History View
 "history.title" = "歷史記錄";

--- a/app/windows/HyperWhisper/Resources/Strings.ar.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ar.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>تعذّر تحميل ملف الصوت</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>الاستبدال</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>المصدر</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>لا توجد كلمات مفردات حتى الآن</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>إعادة التشغيل مطلوبة</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>يجب إعادة تشغيل التطبيق لتطبيق تغيير المظهر.\n\nهل تريد إعادة التشغيل الآن؟</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>تعذّر فتح مجلد التسجيلات. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>فشل التنظيف</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>تعذّر حذف التسجيلات القديمة. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>يدوي</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 لغة، توجيه سياقي</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 لغة، توجيه سياقي</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - نسخ عبر نموذج لغوي متعدد الوسائط</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - توجيه بالمصطلحات الرئيسية، وضع طبي</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (معاينة)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>معاينة</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (بدون مفردات مخصصة)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>بدون مفردات مخصصة</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (موصى به)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>المفردات الطبية (إضافة الوضع الطبي)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>الرمز المميز غير متاح بعد.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>تم إنشاء رمز مميز جديد.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>تم فتح موقع ملف الاكتشاف.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>تعذّر فتح موقع ملف الاكتشاف: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>المنفذ غير متاح حتى يتم تشغيل الخادم.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>تعذّر فتح الوثائق: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>ملف الاكتشاف غير متاح بعد. شغّل الخادم وانتظر حتى يكتمل بدء التشغيل.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>تعذّر النسخ إلى الحافظة: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>تم النسخ إلى الحافظة.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.bg.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.bg.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Аудио файлът не може да бъде зареден</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Заместване</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Източник</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Все още няма думи в речника</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Необходимо е рестартиране</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Приложението трябва да се рестартира, за да влезе в сила промяната на темата.\n\nИскате ли да го рестартирате сега?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Папката със записите не може да бъде отворена. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Неуспешно почистване</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Старите записи не могат да бъдат изтрити. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ръчно</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 езика, контекстно насочване</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 езика, контекстно насочване</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - мултимодална LLM транскрипция</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - подсказване с ключови термини, медицински режим</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Предварителна версия)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Предварителна версия</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Без потребителски речник)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Без потребителски речник</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Препоръчан)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Медицински речник (добавка Медицински режим)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Токенът още не е наличен.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Токенът е генериран наново.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Местоположението на файла за откриване е отворено.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Местоположението на файла за откриване не може да бъде отворено: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Портът не е наличен, докато сървърът не работи.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Документацията не може да бъде отворена: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Файлът за откриване още не е наличен. Включете сървъра и изчакайте да стартира напълно.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Копирането в клипборда е неуспешно: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Копирано в клипборда.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.ca.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ca.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>No s'ha pogut carregar el fitxer d'àudio</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Substitució</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Origen</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Encara no hi ha paraules al vocabulari</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Cal reiniciar</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Cal reiniciar l'aplicació perquè el canvi de tema tingui efecte.\n\nVols reiniciar-la ara?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>No s'ha pogut obrir la carpeta d'enregistraments. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Ha fallat la neteja</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>No s'han pogut eliminar els enregistraments antics. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manual</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 idiomes, adaptació contextual</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 idiomes, adaptació contextual</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transcripció amb LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - indicació de termes clau, mode mèdic</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Versió preliminar)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Versió preliminar</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Sense vocabulari personalitzat)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Sense vocabulari personalitzat</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Recomanat)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Vocabulari mèdic (complement del mode mèdic)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>El token encara no està disponible.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>S'ha regenerat el token.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>S'ha obert la ubicació del fitxer de descobriment.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>No s'ha pogut obrir la ubicació del fitxer de descobriment: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>El port no està disponible fins que el servidor no s'estigui executant.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>No s'ha pogut obrir la documentació: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>El fitxer de descobriment encara no està disponible. Activa el servidor i espera que acabi d'iniciar-se.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>No s'ha pogut copiar al porta-retalls: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>S'ha copiat al porta-retalls.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.cs.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.cs.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Zvukový soubor se nepodařilo načíst</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Nahrada</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Zdroj</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Zatim zadna slova ve slovniku</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Je vyžadován restart</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aby se změna motivu projevila, je nutné aplikaci restartovat.\n\nChcete ji restartovat nyní?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Složku s nahrávkami se nepodařilo otevřít. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Vyčištění se nezdařilo</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Staré nahrávky se nepodařilo odstranit. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ručně</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 jazyků, kontextové přizpůsobení</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 jazyků, kontextové přizpůsobení</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodální přepis pomocí LLM</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - podpora klíčových termínů, lékařský režim</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Preview)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (bez vlastního slovníku)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Bez vlastního slovníku</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (doporučeno)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Lékařský slovník (doplněk Medical Mode)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token zatím není k dispozici.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token byl znovu vygenerován.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Umístění zjišťovacího souboru bylo otevřeno.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Nepodařilo se otevřít umístění zjišťovacího souboru: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port je k dispozici až po spuštění serveru.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Nepodařilo se otevřít dokumentaci: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Zjišťovací soubor zatím není k dispozici. Zapněte server a počkejte, než se spustí.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Nepodařilo se zkopírovat do schránky: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Zkopírováno do schránky.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.da.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.da.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Lydfilen kunne ikke indlæses</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Erstatning</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Kilde</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Ingen ordforrådsord endnu</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Genstart påkrævet</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Programmet skal genstartes, før ændringen af temaet træder i kraft.\n\nVil du genstarte nu?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Optagelsesmappen kunne ikke åbnes. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Oprydning mislykkedes</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Gamle optagelser kunne ikke slettes. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuel</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 sprog, kontekstuel tilpasning</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 sprog, kontekstuel tilpasning</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodal LLM-transskription</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - prompting med nøgletermer, medicinsk tilstand</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Prøveversion)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Prøveversion</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Intet brugerdefineret ordforråd)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Intet brugerdefineret ordforråd</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Anbefalet)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicinsk ordforråd (Medical Mode-tilvalg)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token er ikke tilgængeligt endnu.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token genereret på ny.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Åbnede placeringen af discovery-filen.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Kunne ikke åbne placeringen af discovery-filen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Porten er ikke tilgængelig, før serveren kører.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Kunne ikke åbne dokumentationen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Discovery-filen er ikke tilgængelig endnu. Slå serveren til, og vent, til den er startet helt op.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kunne ikke kopiere til udklipsholderen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopieret til udklipsholderen.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.de.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.de.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Audiodatei konnte nicht geladen werden</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Ersatz</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Quelle</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Noch keine Vokabeln</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Neustart erforderlich</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Die Anwendung muss neu gestartet werden, damit die Theme-Änderung wirksam wird.\n\nMöchten Sie jetzt neu starten?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Der Aufnahmeordner konnte nicht geöffnet werden. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Bereinigung fehlgeschlagen</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Alte Aufnahmen konnten nicht gelöscht werden. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuell</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 Sprachen, Kontextgewichtung</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 Sprachen, Kontextgewichtung</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodale LLM-Transkription</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - Keyterm-Prompting, Medizin-Modus</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Vorschau)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Vorschau</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Kein benutzerdefiniertes Vokabular)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Kein benutzerdefiniertes Vokabular</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Empfohlen)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medizinisches Vokabular (Add-on Medizin-Modus)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token ist noch nicht verfügbar.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token neu generiert.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Speicherort der Discovery-Datei geöffnet.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Speicherort der Discovery-Datei konnte nicht geöffnet werden: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Der Port ist erst verfügbar, wenn der Server läuft.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Dokumentation konnte nicht geöffnet werden: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Die Discovery-Datei ist noch nicht verfügbar. Schalten Sie den Server ein und warten Sie, bis er vollständig gestartet ist.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kopieren in die Zwischenablage nicht möglich: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>In die Zwischenablage kopiert.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.el.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.el.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Δεν ήταν δυνατή η φόρτωση του αρχείου ήχου</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Αντικατάσταση</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Προέλευση</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Καμία λέξη λεξιλογίου ακόμα</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Απαιτείται επανεκκίνηση</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Η εφαρμογή πρέπει να επανεκκινήσει για να εφαρμοστεί η αλλαγή θέματος.\n\nΘέλετε να γίνει επανεκκίνηση τώρα;</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Δεν είναι δυνατό το άνοιγμα του φακέλου εγγραφών. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Η εκκαθάριση απέτυχε</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Δεν είναι δυνατή η διαγραφή των παλιών εγγραφών. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Χειροκίνητη</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 γλώσσες, προσαρμογή βάσει συμφραζομένων</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 γλώσσες, προσαρμογή βάσει συμφραζομένων</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - πολυτροπική απομαγνητοφώνηση με LLM</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - προτροπή με όρους-κλειδιά, ιατρική λειτουργία</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Προεπισκόπηση)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Προεπισκόπηση</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Χωρίς προσαρμοσμένο λεξιλόγιο)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Χωρίς προσαρμοσμένο λεξιλόγιο</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Συνιστάται)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Ιατρικό λεξιλόγιο (πρόσθετο Ιατρικής Λειτουργίας)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Το διακριτικό δεν είναι ακόμη διαθέσιμο.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Το διακριτικό δημιουργήθηκε ξανά.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Άνοιξε η τοποθεσία του αρχείου εντοπισμού.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Δεν ήταν δυνατό το άνοιγμα της τοποθεσίας του αρχείου εντοπισμού: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Η θύρα δεν είναι διαθέσιμη μέχρι να ξεκινήσει ο διακομιστής.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Δεν ήταν δυνατό το άνοιγμα της τεκμηρίωσης: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Το αρχείο εντοπισμού δεν είναι ακόμη διαθέσιμο. Ενεργοποιήστε τον διακομιστή και περιμένετε να ολοκληρωθεί η εκκίνησή του.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Δεν ήταν δυνατή η αντιγραφή στο πρόχειρο: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Αντιγράφηκε στο πρόχειρο.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.es.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.es.resx
@@ -2099,6 +2099,54 @@ Puede volver a descargarlo más tarde.</value>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
   </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 idiomas, adaptación contextual</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 idiomas, adaptación contextual</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transcripción con LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - sugerencia de términos clave, modo médico</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Versión preliminar)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Versión preliminar</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Sin vocabulario personalizado)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Sin vocabulario personalizado</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Recomendado)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Vocabulario médico (complemento Modo Médico)</value>
+  </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
   </data>
@@ -2229,31 +2277,31 @@ Puede volver a descargarlo más tarde.</value>
     <value>Pre-filled with your port and token.</value>
   </data>
   <data name="settings.localApi.action.copied" xml:space="preserve">
-    <value>Copied to clipboard.</value>
+    <value>Copiado en el portapapeles.</value>
   </data>
   <data name="settings.localApi.action.copyFailed" xml:space="preserve">
-    <value>Could not copy to clipboard: {0}</value>
+    <value>No se pudo copiar en el portapapeles: {0}</value>
   </data>
   <data name="settings.localApi.action.openFailed" xml:space="preserve">
-    <value>Could not open docs: {0}</value>
+    <value>No se pudo abrir la documentación: {0}</value>
   </data>
   <data name="settings.localApi.action.fileMissing" xml:space="preserve">
-    <value>Discovery file is not available yet. Turn on the server and wait for it to finish starting.</value>
+    <value>El archivo de detección aún no está disponible. Activa el servidor y espera a que termine de iniciarse.</value>
   </data>
   <data name="settings.localApi.action.revealed" xml:space="preserve">
-    <value>Opened the discovery file location.</value>
+    <value>Se ha abierto la ubicación del archivo de detección.</value>
   </data>
   <data name="settings.localApi.action.revealFailed" xml:space="preserve">
-    <value>Could not open the discovery file location: {0}</value>
+    <value>No se pudo abrir la ubicación del archivo de detección: {0}</value>
   </data>
   <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
-    <value>Port is not available until the server is running.</value>
+    <value>El puerto no estará disponible hasta que el servidor esté en marcha.</value>
   </data>
   <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
-    <value>Token is not available yet.</value>
+    <value>El token aún no está disponible.</value>
   </data>
   <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
-    <value>Token regenerated.</value>
+    <value>Token regenerado.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>
@@ -2265,27 +2313,25 @@ Puede volver a descargarlo más tarde.</value>
     <value>127.0.0.1:{0} · token ••••{1}</value>
   </data>
   <data name="history.audio.loadFailed" xml:space="preserve">
-    <value>Audio file could not be loaded</value>
+    <value>No se pudo cargar el archivo de audio</value>
   </data>
   <data name="settings.appearance.theme.restart.title" xml:space="preserve">
-    <value>Restart Required</value>
+    <value>Es necesario reiniciar</value>
   </data>
   <data name="settings.appearance.theme.restart.message" xml:space="preserve">
-    <value>The application needs to restart for the theme change to take effect.
-
-Do you want to restart now?</value>
+    <value>La aplicación debe reiniciarse para que se aplique el cambio de tema.\n\n¿Quieres reiniciarla ahora?</value>
   </data>
   <data name="settings.storage.error.openFolder" xml:space="preserve">
-    <value>Unable to open the recordings folder. {0}</value>
+    <value>No se ha podido abrir la carpeta de grabaciones. {0}</value>
   </data>
   <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
-    <value>Cleanup Failed</value>
+    <value>Error en la limpieza</value>
   </data>
   <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
-    <value>Unable to delete old recordings. {0}</value>
+    <value>No se han podido eliminar las grabaciones antiguas. {0}</value>
   </data>
   <data name="vocabulary.source.column" xml:space="preserve">
-    <value>Source</value>
+    <value>Origen</value>
   </data>
   <data name="vocabulary.manual.badge" xml:space="preserve">
     <value>Manual</value>

--- a/app/windows/HyperWhisper/Resources/Strings.et.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.et.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Helifaili ei õnnestunud laadida</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Asendus</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Allikas</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Sõnavara sõnu veel pole</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Vajalik on taaskäivitus</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Kujunduse muudatuse rakendumiseks tuleb rakendus taaskäivitada.\n\nKas soovid selle kohe taaskäivitada?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Salvestiste kausta avamine ebaõnnestus. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Puhastamine ebaõnnestus</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Vanade salvestiste kustutamine ebaõnnestus. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Käsitsi</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 keelt, kontekstipõhine kohandus</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 keelt, kontekstipõhine kohandus</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodaalne LLM-transkriptsioon</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - võtmeterminite viiped, meditsiinirežiim</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (eelversioon)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Eelversioon</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (kohandatud sõnavara puudub)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Kohandatud sõnavara puudub</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (soovitatud)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Meditsiinisõnavara (meditsiinirežiimi lisa)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token pole veel saadaval.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token loodi uuesti.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Tuvastusfaili asukoht avati.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Tuvastusfaili asukoha avamine ebaõnnestus: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port pole saadaval enne, kui server töötab.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Dokumentatsiooni avamine ebaõnnestus: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Tuvastusfail pole veel saadaval. Lülita server sisse ja oota, kuni see käivitub.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Lõikelauale kopeerimine ebaõnnestus: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopeeritud lõikelauale.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.fi.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.fi.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Äänitiedostoa ei voitu ladata</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Korvaus</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Lähde</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Ei sanastosanoja vielä</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Uudelleenkäynnistys vaaditaan</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Sovellus on käynnistettävä uudelleen, jotta teeman vaihto tulee voimaan.\n\nHaluatko käynnistää sen uudelleen nyt?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Tallennekansiota ei voitu avata. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Siivous epäonnistui</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Vanhoja tallenteita ei voitu poistaa. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuaalinen</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 kieltä, kontekstipainotus</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 kieltä, kontekstipainotus</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodaalinen LLM-litterointi</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - avaintermien kehotteet, lääketieteellinen tila</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Esiversio)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Esiversio</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Ei mukautettua sanastoa)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Ei mukautettua sanastoa</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Suositeltu)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Lääketieteellinen sanasto (Medical Mode -lisäosa)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Tunnus ei ole vielä käytettävissä.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Tunnus luotiin uudelleen.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Etsintätiedoston sijainti avattiin.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Etsintätiedoston sijainnin avaaminen epäonnistui: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Portti on käytettävissä vasta, kun palvelin on käynnissä.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Dokumentaation avaaminen epäonnistui: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Etsintätiedosto ei ole vielä käytettävissä. Käynnistä palvelin ja odota, että se on käynnistynyt kokonaan.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Leikepöydälle kopiointi epäonnistui: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopioitu leikepöydälle.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.fr.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.fr.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Impossible de charger le fichier audio</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Remplacement</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Source</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Aucun mot dans le vocabulaire pour l’instant</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Redémarrage requis</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>L'application doit redémarrer pour que le changement de thème prenne effet.\n\nVoulez-vous redémarrer maintenant ?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Impossible d'ouvrir le dossier des enregistrements. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Échec du nettoyage</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Impossible de supprimer les anciens enregistrements. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuel</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 langues, adaptation contextuelle</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 langues, adaptation contextuelle</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transcription par LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - suggestion de termes clés, mode médical</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (préversion)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Préversion</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (aucun vocabulaire personnalisé)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Aucun vocabulaire personnalisé</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (recommandé)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Vocabulaire médical (module Mode médical)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Le jeton n'est pas encore disponible.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Jeton régénéré.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Emplacement du fichier de découverte ouvert.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Impossible d'ouvrir l'emplacement du fichier de découverte : {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Le port n'est pas disponible tant que le serveur n'est pas en cours d'exécution.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Impossible d'ouvrir la documentation : {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Le fichier de découverte n'est pas encore disponible. Activez le serveur et attendez la fin de son démarrage.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Impossible de copier dans le presse-papiers : {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Copié dans le presse-papiers.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.he.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.he.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>לא ניתן לטעון את קובץ השמע</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>החלפה</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>מקור</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>אין עדיין מילים באוצר המילים</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>נדרשת הפעלה מחדש</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>יש להפעיל מחדש את היישום כדי שהשינוי בערכת הנושא ייכנס לתוקף.\n\nלהפעיל מחדש עכשיו?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>לא ניתן לפתוח את תיקיית ההקלטות. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>הניקוי נכשל</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>לא ניתן למחוק הקלטות ישנות. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>ידני</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 שפות, הטיה לפי הקשר</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 שפות, הטיה לפי הקשר</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - תמלול מבוסס LLM רב-מודאלי</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - הנחיית מונחי מפתח, מצב רפואי</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (תצוגה מקדימה)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>תצוגה מקדימה</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (ללא אוצר מילים מותאם אישית)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>אין אוצר מילים מותאם אישית</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (מומלץ)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>אוצר מילים רפואי (תוסף מצב רפואי)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>האסימון אינו זמין עדיין.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>האסימון נוצר מחדש.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>מיקום קובץ הגילוי נפתח.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>לא ניתן לפתוח את מיקום קובץ הגילוי: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>הפורט אינו זמין עד שהשרת יפעל.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>לא ניתן לפתוח את התיעוד: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>קובץ הגילוי אינו זמין עדיין. הפעל את השרת והמתן לסיום ההפעלה.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>לא ניתן להעתיק ללוח: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>הועתק ללוח.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.hi.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.hi.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>ऑडियो फ़ाइल लोड नहीं की जा सकी</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>प्रतिस्थापन</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>स्रोत</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>अभी तक कोई शब्दावली शब्द नहीं</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>पुनरारंभ आवश्यक</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>थीम का बदलाव लागू करने के लिए एप्लिकेशन को फिर से चालू करना होगा।\n\nक्या आप इसे अभी फिर से चालू करना चाहते हैं?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>रिकॉर्डिंग फ़ोल्डर खोला नहीं जा सका। {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>सफ़ाई विफल</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>पुरानी रिकॉर्डिंग हटाई नहीं जा सकीं। {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>मैन्युअल</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 भाषाएँ, संदर्भ बायसिंग</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 भाषाएँ, संदर्भ बायसिंग</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - मल्टीमॉडल LLM ट्रांसक्रिप्शन</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - कीटर्म प्रॉम्प्टिंग, मेडिकल मोड</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (प्रीव्यू)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>प्रीव्यू</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (कोई कस्टम शब्दावली नहीं)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>कोई कस्टम शब्दावली नहीं</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (अनुशंसित)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>मेडिकल शब्दावली (मेडिकल मोड ऐड-ऑन)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>टोकन अभी उपलब्ध नहीं है।</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>टोकन फिर से जनरेट किया गया।</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>डिस्कवरी फ़ाइल का स्थान खोल दिया गया।</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>डिस्कवरी फ़ाइल का स्थान नहीं खोला जा सका: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>सर्वर चलने तक पोर्ट उपलब्ध नहीं होगा।</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>दस्तावेज़ नहीं खोले जा सके: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>डिस्कवरी फ़ाइल अभी उपलब्ध नहीं है। सर्वर चालू करें और उसके पूरी तरह शुरू होने तक प्रतीक्षा करें।</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>क्लिपबोर्ड पर कॉपी नहीं किया जा सका: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>क्लिपबोर्ड पर कॉपी किया गया।</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.hr.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.hr.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Audiodatoteku nije moguće učitati</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Zamjena</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Izvor</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Još nema riječi u rječniku</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Potrebno ponovno pokretanje</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aplikaciju je potrebno ponovno pokrenuti kako bi promjena teme stupila na snagu.\n\nŽelite li je sada ponovno pokrenuti?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Nije moguće otvoriti mapu sa snimkama. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Čišćenje nije uspjelo</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Nije moguće izbrisati stare snimke. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ručno</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 jezika, kontekstualno usmjeravanje</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 jezika, kontekstualno usmjeravanje</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodalni LLM prijepis</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - poticanje ključnim pojmovima, medicinski način rada</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (pretpregled)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Pretpregled</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (bez prilagođenog rječnika)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Bez prilagođenog rječnika</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (preporučeno)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicinski rječnik (dodatak za medicinski način rada)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token još nije dostupan.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token je ponovno generiran.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Otvorena je lokacija datoteke za otkrivanje.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Otvaranje lokacije datoteke za otkrivanje nije uspjelo: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Priključak nije dostupan dok poslužitelj nije pokrenut.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Otvaranje dokumentacije nije uspjelo: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Datoteka za otkrivanje još nije dostupna. Uključite poslužitelj i pričekajte da se pokrene.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kopiranje u međuspremnik nije uspjelo: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopirano u međuspremnik.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.hu.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.hu.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>A hangfájlt nem sikerült betölteni</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Csere</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Forrás</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Még nincsenek szókincs szavak</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Újraindítás szükséges</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>A téma módosításának érvénybe lépéséhez újra kell indítani az alkalmazást.\n\nSzeretné most újraindítani?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Nem sikerült megnyitni a felvételek mappáját. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>A tisztítás sikertelen</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Nem sikerült törölni a régi felvételeket. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Kézi</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 nyelv, kontextusalapú súlyozás</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 nyelv, kontextusalapú súlyozás</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodális LLM-alapú átírás</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - kulcskifejezések megadása, orvosi mód</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Előzetes)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Előzetes</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Nincs egyéni szókincs)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Nincs egyéni szókincs</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Ajánlott)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Orvosi szókincs (Orvosi mód kiegészítő)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>A token még nem érhető el.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>A token újragenerálva.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>A felderítési fájl helye megnyitva.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Nem sikerült megnyitni a felderítési fájl helyét: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>A port csak akkor érhető el, ha a kiszolgáló fut.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Nem sikerült megnyitni a dokumentációt: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>A felderítési fájl még nem érhető el. Kapcsolja be a kiszolgálót, és várja meg, amíg elindul.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Nem sikerült a vágólapra másolni: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Vágólapra másolva.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.id.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.id.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>File audio tidak dapat dimuat</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Pengganti</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Sumber</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Belum ada kata kosakata</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Perlu Dimulai Ulang</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aplikasi perlu dimulai ulang agar perubahan tema diterapkan.\n\nApakah Anda ingin memulai ulang sekarang?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Tidak dapat membuka folder rekaman. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Pembersihan Gagal</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Tidak dapat menghapus rekaman lama. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manual</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 bahasa, bias konteks</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 bahasa, bias konteks</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transkripsi LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - prompt istilah kunci, mode medis</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Pratinjau)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Pratinjau</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Tanpa kosakata khusus)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Tanpa kosakata khusus</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Direkomendasikan)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Kosakata medis (add-on Mode Medis)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token belum tersedia.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token dibuat ulang.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Lokasi file discovery telah dibuka.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Tidak dapat membuka lokasi file discovery: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port tidak tersedia sampai server berjalan.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Tidak dapat membuka dokumentasi: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>File discovery belum tersedia. Nyalakan server dan tunggu hingga proses startup selesai.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Tidak dapat menyalin ke papan klip: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Disalin ke papan klip.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.is.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.is.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Ekki tókst að hlaða hljóðskránni</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Skipti</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Uppruni</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Engin orðaforðaorð ennþá</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Endurræsing nauðsynleg</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Endurræsa þarf forritið til að breytingin á þemanu taki gildi.\n\nViltu endurræsa núna?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Ekki tókst að opna upptökumöppuna. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Hreinsun mistókst</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Ekki tókst að eyða eldri upptökum. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Handvirkt</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 tungumál, samhengisaðlögun</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 tungumál, samhengisaðlögun</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - fjölþátta LLM-uppskrift</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - ábendingar um lykilhugtök, læknishamur</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Forútgáfa)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Forútgáfa</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Enginn sérsniðinn orðaforði)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Enginn sérsniðinn orðaforði</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Mælt með)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Læknisfræðilegur orðaforði (viðbót við læknisham)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Aðgangslykillinn er ekki tiltækur enn.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Nýr aðgangslykill var búinn til.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Staðsetning uppgötvunarskrárinnar var opnuð.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Ekki tókst að opna staðsetningu uppgötvunarskrárinnar: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Gáttin er ekki tiltæk fyrr en þjónninn er í gangi.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Ekki tókst að opna skjölin: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Uppgötvunarskráin er ekki tiltæk enn. Kveiktu á þjóninum og bíddu þar til hann hefur lokið ræsingu.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Ekki tókst að afrita á klippiborð: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Afritað á klippiborð.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.it.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.it.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Impossibile caricare il file audio</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Sostituzione</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Origine</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Nessuna parola nel vocabolario</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Riavvio necessario</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>È necessario riavviare l'applicazione per applicare il nuovo tema.\n\nVuoi riavviare ora?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Impossibile aprire la cartella delle registrazioni. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Pulizia non riuscita</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Impossibile eliminare le vecchie registrazioni. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuale</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 lingue, adattamento contestuale</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 lingue, adattamento contestuale</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - trascrizione con LLM multimodale</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - prompt con termini chiave, modalità medica</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Anteprima)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Anteprima</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Nessun vocabolario personalizzato)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Nessun vocabolario personalizzato</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Consigliato)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Vocabolario medico (componente aggiuntivo Medical Mode)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Il token non è ancora disponibile.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token rigenerato.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Posizione del file di discovery aperta.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Impossibile aprire la posizione del file di discovery: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>La porta non è disponibile finché il server non è in esecuzione.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Impossibile aprire la documentazione: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Il file di discovery non è ancora disponibile. Attiva il server e attendi che l'avvio sia completato.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Impossibile copiare negli appunti: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Copiato negli appunti.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.ja.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ja.resx
@@ -2099,6 +2099,54 @@
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
   </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 言語対応、文脈バイアス</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 言語対応、文脈バイアス</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - マルチモーダル LLM による文字起こし</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - キーワードプロンプト、医療モード</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0}（プレビュー）</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>プレビュー</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0}（カスタム語彙なし）</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>カスタム語彙なし</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0}（推奨）</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>医療用語（医療モードアドオン）</value>
+  </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
   </data>
@@ -2229,31 +2277,31 @@
     <value>Pre-filled with your port and token.</value>
   </data>
   <data name="settings.localApi.action.copied" xml:space="preserve">
-    <value>Copied to clipboard.</value>
+    <value>クリップボードにコピーしました。</value>
   </data>
   <data name="settings.localApi.action.copyFailed" xml:space="preserve">
-    <value>Could not copy to clipboard: {0}</value>
+    <value>クリップボードにコピーできませんでした: {0}</value>
   </data>
   <data name="settings.localApi.action.openFailed" xml:space="preserve">
-    <value>Could not open docs: {0}</value>
+    <value>ドキュメントを開けませんでした: {0}</value>
   </data>
   <data name="settings.localApi.action.fileMissing" xml:space="preserve">
-    <value>Discovery file is not available yet. Turn on the server and wait for it to finish starting.</value>
+    <value>ディスカバリファイルはまだ利用できません。サーバーをオンにして、起動が完了するまでお待ちください。</value>
   </data>
   <data name="settings.localApi.action.revealed" xml:space="preserve">
-    <value>Opened the discovery file location.</value>
+    <value>ディスカバリファイルの場所を開きました。</value>
   </data>
   <data name="settings.localApi.action.revealFailed" xml:space="preserve">
-    <value>Could not open the discovery file location: {0}</value>
+    <value>ディスカバリファイルの場所を開けませんでした: {0}</value>
   </data>
   <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
-    <value>Port is not available until the server is running.</value>
+    <value>ポートはサーバーの実行中のみ利用できます。</value>
   </data>
   <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
-    <value>Token is not available yet.</value>
+    <value>トークンはまだ利用できません。</value>
   </data>
   <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
-    <value>Token regenerated.</value>
+    <value>トークンを再生成しました。</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>
@@ -2265,30 +2313,28 @@
     <value>127.0.0.1:{0} · token ••••{1}</value>
   </data>
   <data name="history.audio.loadFailed" xml:space="preserve">
-    <value>Audio file could not be loaded</value>
+    <value>オーディオファイルを読み込めませんでした</value>
   </data>
   <data name="settings.appearance.theme.restart.title" xml:space="preserve">
-    <value>Restart Required</value>
+    <value>再起動が必要です</value>
   </data>
   <data name="settings.appearance.theme.restart.message" xml:space="preserve">
-    <value>The application needs to restart for the theme change to take effect.
-
-Do you want to restart now?</value>
+    <value>テーマの変更を適用するには、アプリケーションを再起動する必要があります。\n\n今すぐ再起動しますか？</value>
   </data>
   <data name="settings.storage.error.openFolder" xml:space="preserve">
-    <value>Unable to open the recordings folder. {0}</value>
+    <value>録音フォルダを開けません。{0}</value>
   </data>
   <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
-    <value>Cleanup Failed</value>
+    <value>クリーンアップに失敗しました</value>
   </data>
   <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
-    <value>Unable to delete old recordings. {0}</value>
+    <value>古い録音を削除できません。{0}</value>
   </data>
   <data name="vocabulary.source.column" xml:space="preserve">
-    <value>Source</value>
+    <value>ソース</value>
   </data>
   <data name="vocabulary.manual.badge" xml:space="preserve">
-    <value>Manual</value>
+    <value>手動</value>
   </data>
   <data name="settings.backup.export.section.modes" xml:space="preserve">
     <value>モード</value>

--- a/app/windows/HyperWhisper/Resources/Strings.ko.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ko.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>오디오 파일을 불러올 수 없습니다</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>교체</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>출처</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>아직 어휘 단어가 없습니다</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>다시 시작 필요</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>테마 변경 사항을 적용하려면 앱을 다시 시작해야 합니다.\n\n지금 다시 시작하시겠습니까?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>녹음 폴더를 열 수 없습니다. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>정리 실패</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>오래된 녹음을 삭제할 수 없습니다. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>수동</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60개 언어, 문맥 기반 보정</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13개 언어, 문맥 기반 보정</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - 멀티모달 LLM 받아쓰기</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - 핵심 용어 프롬프팅, 의료 모드</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (미리 보기)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>미리 보기</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (사용자 지정 어휘 미지원)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>사용자 지정 어휘 미지원</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (권장)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>의료 어휘 (의료 모드 추가 기능)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>토큰이 아직 준비되지 않았습니다.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>토큰을 다시 생성했습니다.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>디스커버리 파일 위치를 열었습니다.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>디스커버리 파일 위치를 열 수 없습니다: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>서버가 실행 중일 때만 포트를 사용할 수 있습니다.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>문서를 열 수 없습니다: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>디스커버리 파일이 아직 준비되지 않았습니다. 서버를 켜고 시작이 완료될 때까지 기다리세요.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>클립보드에 복사할 수 없습니다: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>클립보드에 복사했습니다.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.lt.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.lt.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Nepavyko įkelti garso failo</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Pakeitimas</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Šaltinis</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Nėra žodyno žodžių</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Reikia paleisti iš naujo</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Kad temos pakeitimas įsigaliotų, programą reikia paleisti iš naujo.\n\nAr norite paleisti iš naujo dabar?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Nepavyko atidaryti įrašų aplanko. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Valymas nepavyko</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Nepavyko ištrinti senų įrašų. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Rankinis</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 kalbų, kontekstinis pritaikymas</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 kalbų, kontekstinis pritaikymas</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodalinio LLM transkripcija</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - raktinių terminų nurodymas, medicininis režimas</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (peržiūra)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Peržiūra</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (be pasirinktinio žodyno)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Nėra pasirinktinio žodyno</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (rekomenduojama)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicinos žodynas (medicininio režimo priedas)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Prieigos raktas dar nepasiekiamas.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Prieigos raktas sugeneruotas iš naujo.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Atidaryta aptikimo failo vieta.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Nepavyko atidaryti aptikimo failo vietos: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Prievadas nepasiekiamas, kol serveris neveikia.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Nepavyko atidaryti dokumentacijos: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Aptikimo failas dar nepasiekiamas. Įjunkite serverį ir palaukite, kol jis pasileis.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Nepavyko nukopijuoti į iškarpinę: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Nukopijuota į iškarpinę.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.lv.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.lv.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Neizdevās ielādēt audio failu</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Aizstāšana</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Avots</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Vēl nav vārdu krājuma</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Nepieciešama restartēšana</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Lai motīva maiņa stātos spēkā, lietojumprogramma ir jārestartē.\n\nVai vēlaties restartēt tagad?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Neizdevās atvērt ierakstu mapi. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Tīrīšana neizdevās</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Neizdevās izdzēst vecos ierakstus. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuāli</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 valodas, konteksta pielāgošana</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 valodas, konteksta pielāgošana</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodāla LLM transkripcija</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - atslēgvārdu uzvednes, medicīnas režīms</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (priekšskatījums)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Priekšskatījums</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (nav pielāgotas vārdnīcas)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Nav pielāgotas vārdnīcas</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (ieteicams)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicīnas vārdnīca (medicīnas režīma papildinājums)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Marķieris vēl nav pieejams.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Marķieris ir atkārtoti ģenerēts.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Atklāšanas faila atrašanās vieta ir atvērta.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Neizdevās atvērt atklāšanas faila atrašanās vietu: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Ports nav pieejams, kamēr serveris nedarbojas.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Neizdevās atvērt dokumentāciju: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Atklāšanas fails vēl nav pieejams. Ieslēdziet serveri un uzgaidiet, līdz tas pilnībā startē.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Neizdevās nokopēt starpliktuvē: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Nokopēts starpliktuvē.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.ms.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ms.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Fail audio tidak dapat dimuatkan</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Penggantian</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Sumber</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Tiada perbendaharaan kata lagi</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Perlu Mula Semula</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aplikasi perlu dimulakan semula untuk perubahan tema berkuat kuasa.\n\nAdakah anda mahu memulakannya semula sekarang?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Tidak dapat membuka folder rakaman. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Pembersihan Gagal</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Tidak dapat memadam rakaman lama. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manual</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 bahasa, pemberatan konteks</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 bahasa, pemberatan konteks</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transkripsi LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - gesaan istilah utama, mod perubatan</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Pratonton)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Pratonton</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Tiada perbendaharaan kata tersuai)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Tiada perbendaharaan kata tersuai</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Disyorkan)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Perbendaharaan kata perubatan (tambahan Mod Perubatan)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token belum tersedia.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token telah dijana semula.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Lokasi fail penemuan telah dibuka.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Tidak dapat membuka lokasi fail penemuan: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port tidak tersedia sehingga pelayan berjalan.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Tidak dapat membuka dokumentasi: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Fail penemuan belum tersedia. Hidupkan pelayan dan tunggu sehingga ia selesai dimulakan.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Tidak dapat menyalin ke papan keratan: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Disalin ke papan keratan.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.nb.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.nb.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Lydfilen kunne ikke lastes inn</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Erstatning</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Kilde</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Ingen ordforrådsord ennå</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Omstart kreves</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Appen må startes på nytt for at temaendringen skal tre i kraft.\n\nVil du starte på nytt nå?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Kan ikke åpne opptaksmappen. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Opprydding mislyktes</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Kan ikke slette gamle opptak. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuell</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 språk, kontekstuell tilpasning</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 språk, kontekstuell tilpasning</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodal LLM-transkripsjon</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - nøkkelbegreper som ledetekst, medisinsk modus</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (forhåndsversjon)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Forhåndsversjon</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (ingen egendefinert vokabular)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Ingen egendefinert vokabular</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (anbefalt)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medisinsk vokabular (tillegg for medisinsk modus)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token er ikke tilgjengelig ennå.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Nytt token er generert.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Åpnet plasseringen til discovery-filen.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Kunne ikke åpne plasseringen til discovery-filen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Porten er ikke tilgjengelig før serveren kjører.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Kunne ikke åpne dokumentasjonen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Discovery-filen er ikke tilgjengelig ennå. Slå på serveren og vent til den har startet.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kunne ikke kopiere til utklippstavlen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopiert til utklippstavlen.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.nl.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.nl.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Audiobestand kon niet worden geladen</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Vervanging</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Bron</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Nog geen woordenlijstwoorden</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Opnieuw starten vereist</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>De app moet opnieuw worden gestart om de themawijziging toe te passen.\n\nWil je nu opnieuw starten?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Kan de map met opnamen niet openen. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Opschonen mislukt</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Kan oude opnamen niet verwijderen. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Handmatig</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 talen, contextuele afstemming</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 talen, contextuele afstemming</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodale LLM-transcriptie</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - prompts met sleuteltermen, medische modus</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (preview)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Preview</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (geen aangepaste woordenlijst)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Geen aangepaste woordenlijst</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (aanbevolen)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medische woordenlijst (add-on Medische modus)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token is nog niet beschikbaar.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token opnieuw gegenereerd.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>De locatie van het discovery-bestand is geopend.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Kan de locatie van het discovery-bestand niet openen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>De poort is pas beschikbaar als de server draait.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Kan de documentatie niet openen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Het discovery-bestand is nog niet beschikbaar. Zet de server aan en wacht tot deze volledig is gestart.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kan niet naar het klembord kopiëren: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Gekopieerd naar het klembord.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.pl.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.pl.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Nie można załadować pliku audio</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Zamiennik</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Źródło</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Brak słów w słowniku</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Wymagane ponowne uruchomienie</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aby zmiana motywu zaczęła obowiązywać, aplikacja musi zostać uruchomiona ponownie.\n\nCzy chcesz uruchomić ją ponownie teraz?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Nie można otworzyć folderu nagrań. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Czyszczenie nie powiodło się</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Nie można usunąć starych nagrań. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ręcznie</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 języków, uwzględnianie kontekstu</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 języków, uwzględnianie kontekstu</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodalna transkrypcja LLM</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - podpowiadanie kluczowych terminów, tryb medyczny</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (wersja zapoznawcza)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Wersja zapoznawcza</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (brak własnego słownictwa)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Brak własnego słownictwa</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (zalecany)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Słownictwo medyczne (dodatek trybu medycznego)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token nie jest jeszcze dostępny.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token wygenerowany ponownie.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Otwarto lokalizację pliku wykrywania.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Nie można otworzyć lokalizacji pliku wykrywania: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port będzie dostępny dopiero po uruchomieniu serwera.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Nie można otworzyć dokumentacji: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Plik wykrywania nie jest jeszcze dostępny. Włącz serwer i poczekaj na zakończenie uruchamiania.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Nie można skopiować do schowka: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Skopiowano do schowka.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.pt.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.pt.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Não foi possível carregar o ficheiro de áudio</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Substituição</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Origem</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Nenhuma palavra de vocabulário ainda</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Reinício necessário</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>É necessário reiniciar a aplicação para que a alteração do tema tenha efeito.\n\nPretende reiniciar agora?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Não foi possível abrir a pasta das gravações. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Falha na limpeza</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Não foi possível eliminar as gravações antigas. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manual</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 idiomas, adaptação contextual</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 idiomas, adaptação contextual</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transcrição com LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - sugestão de termos-chave, modo médico</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Pré-visualização)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Pré-visualização</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Sem vocabulário personalizado)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Sem vocabulário personalizado</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Recomendado)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Vocabulário médico (extra do Modo Médico)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>O token ainda não está disponível.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token regenerado.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>A localização do ficheiro de deteção foi aberta.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Não foi possível abrir a localização do ficheiro de deteção: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>A porta só fica disponível quando o servidor estiver em execução.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Não foi possível abrir a documentação: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>O ficheiro de deteção ainda não está disponível. Ative o servidor e aguarde que termine o arranque.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Não foi possível copiar para a área de transferência: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Copiado para a área de transferência.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.ro.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ro.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Fișierul audio nu a putut fi încărcat</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Înlocuire</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Sursă</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Niciun cuvânt de vocabular încă</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Repornire necesară</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aplicația trebuie repornită pentru ca schimbarea temei să aibă efect.\n\nDorești să repornești acum?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Folderul cu înregistrări nu a putut fi deschis. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Curățare eșuată</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Înregistrările vechi nu au putut fi șterse. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manual</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 de limbi, adaptare contextuală</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 limbi, adaptare contextuală</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - transcriere cu LLM multimodal</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - sugestii de termeni-cheie, mod medical</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Versiune preliminară)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Versiune preliminară</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Fără vocabular personalizat)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Fără vocabular personalizat</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Recomandat)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Vocabular medical (supliment Mod medical)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Tokenul nu este încă disponibil.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token regenerat.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Locația fișierului de descoperire a fost deschisă.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Locația fișierului de descoperire nu a putut fi deschisă: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Portul nu este disponibil până când serverul nu rulează.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Documentația nu a putut fi deschisă: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Fișierul de descoperire nu este încă disponibil. Pornește serverul și așteaptă finalizarea pornirii.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Nu s-a putut copia în clipboard: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Copiat în clipboard.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.ru.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.ru.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Не удалось загрузить аудиофайл</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Замена</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Источник</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Словарь пока пуст</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Требуется перезапуск</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Чтобы изменение темы вступило в силу, необходимо перезапустить приложение.\n\nПерезапустить сейчас?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Не удалось открыть папку с записями. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Ошибка очистки</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Не удалось удалить старые записи. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Вручную</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 языков, контекстная адаптация</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 языков, контекстная адаптация</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - мультимодальная расшифровка на основе LLM</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - подсказка ключевых терминов, медицинский режим</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (предварительная версия)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Предварительная версия</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (без пользовательского словаря)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Без пользовательского словаря</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (рекомендуется)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Медицинская лексика (дополнение «Медицинский режим»)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Токен пока недоступен.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Токен создан заново.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Папка с файлом обнаружения открыта.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Не удалось открыть папку с файлом обнаружения: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Порт недоступен, пока сервер не запущен.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Не удалось открыть документацию: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Файл обнаружения пока недоступен. Включите сервер и дождитесь завершения его запуска.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Не удалось скопировать в буфер обмена: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Скопировано в буфер обмена.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.sk.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.sk.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Zvukový súbor sa nepodarilo načítať</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Náhrada</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Zdroj</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Zatiaľ žiadne slová v slovníku</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Vyžaduje sa reštart</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aby sa zmena motívu prejavila, aplikáciu je potrebné reštartovať.\n\nChcete ju reštartovať teraz?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Priečinok s nahrávkami sa nepodarilo otvoriť. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Čistenie zlyhalo</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Staré nahrávky sa nepodarilo odstrániť. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ručne</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 jazykov, kontextové prispôsobenie</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 jazykov, kontextové prispôsobenie</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodálny prepis pomocou LLM</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - navádzanie kľúčovými termínmi, medicínsky režim</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (ukážka)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Ukážka</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (bez vlastnej slovnej zásoby)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Bez vlastnej slovnej zásoby</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (odporúčané)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Lekárska slovná zásoba (doplnok Medical Mode)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token zatiaľ nie je k dispozícii.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token bol vygenerovaný nanovo.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Umiestnenie súboru na zisťovanie bolo otvorené.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Nepodarilo sa otvoriť umiestnenie súboru na zisťovanie: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port nie je k dispozícii, kým server nebeží.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Nepodarilo sa otvoriť dokumentáciu: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Súbor na zisťovanie zatiaľ nie je k dispozícii. Zapnite server a počkajte, kým sa spustí.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Nepodarilo sa skopírovať do schránky: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Skopírované do schránky.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.sl.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.sl.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Zvočne datoteke ni bilo mogoče naložiti</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Zamenjava</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Vir</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Še ni besed v besedniku</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Potreben je ponovni zagon</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Za uveljavitev spremembe teme je treba aplikacijo znova zagnati.\n\nAli jo želite znova zagnati zdaj?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Mape s posnetki ni mogoče odpreti. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Čiščenje ni uspelo</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Starih posnetkov ni mogoče izbrisati. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ročno</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 jezikov, kontekstno usmerjanje</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 jezikov, kontekstno usmerjanje</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - večmodalno prepisovanje z LLM</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - pozivanje s ključnimi izrazi, medicinski način</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (predogled)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Predogled</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (brez besednjaka po meri)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Brez besednjaka po meri</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (priporočeno)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicinski besednjak (dodatek za medicinski način)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Žeton še ni na voljo.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Žeton je znova ustvarjen.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Mesto datoteke za odkrivanje je odprto.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Mesta datoteke za odkrivanje ni bilo mogoče odpreti: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Vrata niso na voljo, dokler strežnik ne teče.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Dokumentacije ni bilo mogoče odpreti: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Datoteka za odkrivanje še ni na voljo. Vklopite strežnik in počakajte, da se zažene.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kopiranje v odložišče ni uspelo: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopirano v odložišče.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.sr.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.sr.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Nije moguće učitati audio datoteku</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Замена</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Izvor</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Нема речи у речнику</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Potrebno je ponovno pokretanje</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Aplikacija mora ponovo da se pokrene da bi promena teme stupila na snagu.\n\nŽelite li da je ponovo pokrenete sada?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Nije moguće otvoriti fasciklu sa snimcima. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Čišćenje nije uspelo</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Nije moguće izbrisati stare snimke. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Ručno</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 jezika, kontekstualno prilagođavanje</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 jezika, kontekstualno prilagođavanje</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodalna LLM transkripcija</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - podsticanje ključnim terminima, medicinski režim</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (pregled)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Pregled</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (nema prilagođenog rečnika)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Nema prilagođenog rečnika</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (preporučeno)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicinski rečnik (dodatak za medicinski režim)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token još nije dostupan.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token je ponovo generisan.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Otvorena je lokacija datoteke za otkrivanje.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Nije moguće otvoriti lokaciju datoteke za otkrivanje: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Port nije dostupan dok se server ne pokrene.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Nije moguće otvoriti dokumentaciju: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Datoteka za otkrivanje još nije dostupna. Uključite server i sačekajte da se pokretanje završi.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Kopiranje u privremenu memoriju nije uspelo: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopirano u privremenu memoriju.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.sv.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.sv.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Ljudfilen kunde inte läsas in</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Ersättning</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Källa</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Inga ordförrådsord än</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Omstart krävs</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Appen måste startas om för att temaändringen ska börja gälla.\n\nVill du starta om nu?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Det gick inte att öppna inspelningsmappen. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Rensningen misslyckades</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Det gick inte att ta bort gamla inspelningar. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuell</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 språk, kontextanpassning</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 språk, kontextanpassning</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - multimodal LLM-transkribering</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - styrning med nyckeltermer, medicinskt läge</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Förhandsversion)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Förhandsversion</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Ingen egen ordlista)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Ingen egen ordlista</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Rekommenderas)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Medicinsk ordlista (tillägget Medicinskt läge)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token är inte tillgänglig än.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token har genererats på nytt.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Öppnade platsen för identifieringsfilen.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Det gick inte att öppna platsen för identifieringsfilen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Porten är inte tillgänglig förrän servern är igång.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Det gick inte att öppna dokumentationen: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Identifieringsfilen är inte tillgänglig än. Slå på servern och vänta tills den har startat klart.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Det gick inte att kopiera till urklipp: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Kopierat till urklipp.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.th.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.th.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>ไม่สามารถโหลดไฟล์เสียงได้</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>การแทนที่</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>แหล่งที่มา</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>ยังไม่มีศัพท์เฉพาะ</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>ต้องเริ่มแอปใหม่</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>ต้องเริ่มแอปพลิเคชันใหม่เพื่อให้การเปลี่ยนธีมมีผล\n\nคุณต้องการเริ่มใหม่ตอนนี้หรือไม่?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>ไม่สามารถเปิดโฟลเดอร์การบันทึกเสียงได้ {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>การล้างข้อมูลล้มเหลว</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>ไม่สามารถลบการบันทึกเสียงเก่าได้ {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>เพิ่มเอง</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 ภาษา, การปรับตามบริบท</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 ภาษา, การปรับตามบริบท</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - การถอดเสียงด้วย LLM แบบมัลติโมดัล</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - การกำหนดคำสำคัญ, โหมดการแพทย์</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (ตัวอย่าง)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>ตัวอย่าง</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (ไม่รองรับคำศัพท์กำหนดเอง)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>ไม่รองรับคำศัพท์กำหนดเอง</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (แนะนำ)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>คำศัพท์ทางการแพทย์ (ส่วนเสริมโหมดการแพทย์)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>ยังไม่มีโทเค็นให้ใช้งาน</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>สร้างโทเค็นใหม่แล้ว</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>เปิดตำแหน่งของไฟล์ discovery แล้ว</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>ไม่สามารถเปิดตำแหน่งของไฟล์ discovery ได้: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>พอร์ตจะใช้งานได้ต่อเมื่อเซิร์ฟเวอร์ทำงานอยู่เท่านั้น</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>ไม่สามารถเปิดเอกสารประกอบได้: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>ไฟล์ discovery ยังไม่พร้อมใช้งาน เปิดเซิร์ฟเวอร์แล้วรอให้เริ่มทำงานจนเสร็จ</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>ไม่สามารถคัดลอกไปยังคลิปบอร์ดได้: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>คัดลอกไปยังคลิปบอร์ดแล้ว</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.tr.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.tr.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Ses dosyası yüklenemedi</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Değiştirme</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Kaynak</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Henüz kelime hazinesi yok</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Yeniden Başlatma Gerekli</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Tema değişikliğinin uygulanabilmesi için uygulamanın yeniden başlatılması gerekiyor.\n\nŞimdi yeniden başlatmak istiyor musunuz?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Kayıtlar klasörü açılamadı. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Temizleme Başarısız</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Eski kayıtlar silinemedi. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1813,6 +1834,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Manuel</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1980,6 +2004,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 dil, bağlamsal yönlendirme</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 dil, bağlamsal yönlendirme</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - çok modlu LLM ile transkripsiyon</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - anahtar terim yönlendirme, tıbbi mod</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Önizleme)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Önizleme</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Özel sözlük yok)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Özel sözlük yok</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Önerilen)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Tıbbi sözlük (Tıbbi Mod eklentisi)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2223,6 +2295,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token henüz kullanılamıyor.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Token yeniden oluşturuldu.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Keşif dosyasının bulunduğu konum açıldı.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Keşif dosyasının bulunduğu konum açılamadı: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Bağlantı noktası, sunucu çalışmaya başlayana kadar kullanılamaz.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Belgeler açılamadı: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Keşif dosyası henüz kullanılamıyor. Sunucuyu açın ve başlatılmasının tamamlanmasını bekleyin.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Panoya kopyalanamadı: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Panoya kopyalandı.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.uk.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.uk.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Не вдалося завантажити аудіофайл</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Заміна</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Джерело</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Нема слів у словнику</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Потрібен перезапуск</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Щоб зміна теми набула чинності, програму потрібно перезапустити.\n\nПерезапустити зараз?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Не вдалося відкрити папку записів. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Не вдалося виконати очищення</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Не вдалося видалити старі записи. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1812,6 +1833,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Вручну</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1979,6 +2003,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 мов, контекстне підлаштування</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 мов, контекстне підлаштування</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - мультимодальна LLM-транскрипція</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - підказки ключових термінів, медичний режим</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (попередня версія)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Попередня версія</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (без власного словника)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Без власного словника</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (рекомендовано)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Медична лексика (доповнення Медичний режим)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2222,6 +2294,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Токен ще недоступний.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Токен створено заново.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Розташування файлу виявлення відкрито.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Не вдалося відкрити розташування файлу виявлення: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Порт недоступний, доки сервер не запущено.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Не вдалося відкрити документацію: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Файл виявлення ще недоступний. Увімкніть сервер і зачекайте, поки він завершить запуск.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Не вдалося скопіювати в буфер обміну: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Скопійовано в буфер обміну.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.vi.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.vi.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>Không thể tải tệp âm thanh</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>Thay thế</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>Nguồn</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>Chưa có từ vựng nào</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>Cần khởi động lại</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>Ứng dụng cần khởi động lại để áp dụng thay đổi về giao diện.\n\nBạn có muốn khởi động lại ngay bây giờ không?</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>Không thể mở thư mục chứa bản ghi. {0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>Dọn dẹp thất bại</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>Không thể xóa các bản ghi cũ. {0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1812,6 +1833,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>Thủ công</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1979,6 +2003,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 ngôn ngữ, điều chỉnh theo ngữ cảnh</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 ngôn ngữ, điều chỉnh theo ngữ cảnh</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - chép lời bằng LLM đa phương thức</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - nhắc thuật ngữ chính, chế độ y khoa</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0} (Bản xem trước)</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>Bản xem trước</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0} (Không hỗ trợ từ vựng tùy chỉnh)</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>Không hỗ trợ từ vựng tùy chỉnh</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0} (Khuyến nghị)</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>Từ vựng y khoa (tiện ích bổ sung Chế độ Y khoa)</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2222,6 +2294,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>Token chưa sẵn sàng.</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>Đã tạo lại token.</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>Đã mở vị trí của tệp khám phá.</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>Không thể mở vị trí của tệp khám phá: {0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>Cổng chỉ khả dụng khi máy chủ đang chạy.</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>Không thể mở tài liệu: {0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>Tệp khám phá chưa sẵn sàng. Hãy bật máy chủ và đợi máy chủ khởi động xong.</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>Không thể sao chép vào bảng nhớ tạm: {0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>Đã sao chép vào bảng nhớ tạm.</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>

--- a/app/windows/HyperWhisper/Resources/Strings.zh-Hans.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.zh-Hans.resx
@@ -2099,6 +2099,54 @@
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
   </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 支持 60 种语言、上下文偏置</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 支持 13 种语言、上下文偏置</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - 多模态 LLM 转写</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - 关键术语提示、医学模式</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0}（预览版）</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>预览版</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0}（不支持自定义词汇）</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>不支持自定义词汇</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0}（推荐）</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>医学词汇（医学模式附加组件）</value>
+  </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
   </data>
@@ -2229,31 +2277,31 @@
     <value>Pre-filled with your port and token.</value>
   </data>
   <data name="settings.localApi.action.copied" xml:space="preserve">
-    <value>Copied to clipboard.</value>
+    <value>已复制到剪贴板。</value>
   </data>
   <data name="settings.localApi.action.copyFailed" xml:space="preserve">
-    <value>Could not copy to clipboard: {0}</value>
+    <value>无法复制到剪贴板：{0}</value>
   </data>
   <data name="settings.localApi.action.openFailed" xml:space="preserve">
-    <value>Could not open docs: {0}</value>
+    <value>无法打开文档：{0}</value>
   </data>
   <data name="settings.localApi.action.fileMissing" xml:space="preserve">
-    <value>Discovery file is not available yet. Turn on the server and wait for it to finish starting.</value>
+    <value>发现文件尚不可用。请开启服务器，并等待其启动完成。</value>
   </data>
   <data name="settings.localApi.action.revealed" xml:space="preserve">
-    <value>Opened the discovery file location.</value>
+    <value>已打开发现文件所在位置。</value>
   </data>
   <data name="settings.localApi.action.revealFailed" xml:space="preserve">
-    <value>Could not open the discovery file location: {0}</value>
+    <value>无法打开发现文件所在位置：{0}</value>
   </data>
   <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
-    <value>Port is not available until the server is running.</value>
+    <value>服务器运行后才能获取端口。</value>
   </data>
   <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
-    <value>Token is not available yet.</value>
+    <value>令牌尚不可用。</value>
   </data>
   <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
-    <value>Token regenerated.</value>
+    <value>令牌已重新生成。</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>
@@ -2265,30 +2313,28 @@
     <value>127.0.0.1:{0} · token ••••{1}</value>
   </data>
   <data name="history.audio.loadFailed" xml:space="preserve">
-    <value>Audio file could not be loaded</value>
+    <value>无法加载音频文件</value>
   </data>
   <data name="settings.appearance.theme.restart.title" xml:space="preserve">
-    <value>Restart Required</value>
+    <value>需要重新启动</value>
   </data>
   <data name="settings.appearance.theme.restart.message" xml:space="preserve">
-    <value>The application needs to restart for the theme change to take effect.
-
-Do you want to restart now?</value>
+    <value>需要重新启动应用，主题更改才能生效。\n\n要立即重新启动吗？</value>
   </data>
   <data name="settings.storage.error.openFolder" xml:space="preserve">
-    <value>Unable to open the recordings folder. {0}</value>
+    <value>无法打开录音文件夹。{0}</value>
   </data>
   <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
-    <value>Cleanup Failed</value>
+    <value>清理失败</value>
   </data>
   <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
-    <value>Unable to delete old recordings. {0}</value>
+    <value>无法删除旧录音。{0}</value>
   </data>
   <data name="vocabulary.source.column" xml:space="preserve">
-    <value>Source</value>
+    <value>来源</value>
   </data>
   <data name="vocabulary.manual.badge" xml:space="preserve">
-    <value>Manual</value>
+    <value>手动添加</value>
   </data>
   <data name="settings.backup.export.section.modes" xml:space="preserve">
     <value>模式</value>

--- a/app/windows/HyperWhisper/Resources/Strings.zh-Hant.resx
+++ b/app/windows/HyperWhisper/Resources/Strings.zh-Hant.resx
@@ -173,6 +173,9 @@
   <data name="history.audio.notAvailable" xml:space="preserve">
     <value>Audio file not available</value>
   </data>
+  <data name="history.audio.loadFailed" xml:space="preserve">
+    <value>無法載入音訊檔案</value>
+  </data>
   <data name="history.badge.originalTranscript" xml:space="preserve">
     <value>Original</value>
   </data>
@@ -286,6 +289,9 @@
   </data>
   <data name="vocabulary.replacement.column" xml:space="preserve">
     <value>替換</value>
+  </data>
+  <data name="vocabulary.source.column" xml:space="preserve">
+    <value>來源</value>
   </data>
   <data name="vocabulary.empty.title" xml:space="preserve">
     <value>還沒有詞彙詞語</value>
@@ -464,6 +470,12 @@
   </data>
   <data name="settings.appearance.theme.dark.subtitle" xml:space="preserve">
     <value>Always use dark theme for reduced eye strain</value>
+  </data>
+  <data name="settings.appearance.theme.restart.title" xml:space="preserve">
+    <value>需要重新啟動</value>
+  </data>
+  <data name="settings.appearance.theme.restart.message" xml:space="preserve">
+    <value>應用程式必須重新啟動，主題變更才會生效。\n\n要立即重新啟動嗎？</value>
   </data>
 
   <!-- Settings - License -->
@@ -1245,6 +1257,9 @@ You can re-download it later.</value>
   <data name="settings.storage.error.invalidFolder" xml:space="preserve">
     <value>Unable to use the selected folder.</value>
   </data>
+  <data name="settings.storage.error.openFolder" xml:space="preserve">
+    <value>無法開啟錄音資料夾。{0}</value>
+  </data>
   <data name="settings.storage.folderBrowser.description" xml:space="preserve">
     <value>Choose a folder for new recordings</value>
   </data>
@@ -1286,6 +1301,12 @@ You can re-download it later.</value>
   </data>
   <data name="settings.storage.autoDelete.deleteComplete.message" xml:space="preserve">
     <value>Deleted {0} recording(s)</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.title" xml:space="preserve">
+    <value>清理失敗</value>
+  </data>
+  <data name="settings.storage.autoDelete.deleteFailed.message" xml:space="preserve">
+    <value>無法刪除舊的錄音。{0}</value>
   </data>
 
   <!-- Provider Names -->
@@ -1812,6 +1833,9 @@ You can re-download it later.</value>
   <data name="vocabulary.autoLearned.badge" xml:space="preserve">
     <value>Auto-learned</value>
   </data>
+  <data name="vocabulary.manual.badge" xml:space="preserve">
+    <value>手動</value>
+  </data>
   <data name="vocabulary.autoLearned.clear" xml:space="preserve">
     <value>Clear auto-learned</value>
   </data>
@@ -1979,6 +2003,54 @@ You can re-download it later.</value>
   </data>
   <data name="modes.cloudAccuracy.creditsPerMinute" xml:space="preserve">
     <value>~{0} credits/min</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.label" xml:space="preserve">
+    <value>Soniox</value>
+  </data>
+  <data name="modes.cloudAccuracy.soniox.description" xml:space="preserve">
+    <value>Soniox - 60 種語言、上下文偏詞</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.label" xml:space="preserve">
+    <value>OpenAI Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.openaiWhisper.description" xml:space="preserve">
+    <value>OpenAI GPT-4o Transcribe / Whisper</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.label" xml:space="preserve">
+    <value>Mistral Voxtral</value>
+  </data>
+  <data name="modes.cloudAccuracy.mistralVoxtral.description" xml:space="preserve">
+    <value>Mistral Voxtral - 13 種語言、上下文偏詞</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.label" xml:space="preserve">
+    <value>Google Gemini</value>
+  </data>
+  <data name="modes.cloudAccuracy.gemini.description" xml:space="preserve">
+    <value>Google Gemini - 多模態 LLM 轉錄</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.label" xml:space="preserve">
+    <value>AssemblyAI</value>
+  </data>
+  <data name="modes.cloudAccuracy.assemblyAI.description" xml:space="preserve">
+    <value>AssemblyAI Universal - 關鍵詞提示、醫療模式</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewLabel" xml:space="preserve">
+    <value>{0}（預覽版）</value>
+  </data>
+  <data name="mode.editor.cloudModel.previewHint" xml:space="preserve">
+    <value>預覽版</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyLabel" xml:space="preserve">
+    <value>{0}（不支援自訂詞彙）</value>
+  </data>
+  <data name="mode.editor.cloudModel.noVocabularyHint" xml:space="preserve">
+    <value>不支援自訂詞彙</value>
+  </data>
+  <data name="mode.editor.cloudModel.defaultLabel" xml:space="preserve">
+    <value>{0}（建議）</value>
+  </data>
+  <data name="mode.editor.cloudDomain.medical" xml:space="preserve">
+    <value>醫療詞彙（醫療模式附加元件）</value>
   </data>
   <data name="mode.editor.postProcessing.appAwareHint" xml:space="preserve">
     <value>AI post-processing can adapt formatting to the active app, such as email, chat, documents, code, or terminal windows. Local API callers can pass applicationContext explicitly; it is not captured automatically for API requests.</value>
@@ -2222,6 +2294,33 @@ You can re-download it later.</value>
   </data>
   <data name="settings.localApi.curl.caption" xml:space="preserve">
     <value>Pre-filled with your port and token.</value>
+  </data>
+  <data name="settings.localApi.action.tokenUnavailable" xml:space="preserve">
+    <value>權杖尚未可用。</value>
+  </data>
+  <data name="settings.localApi.action.tokenRegenerated" xml:space="preserve">
+    <value>已重新產生權杖。</value>
+  </data>
+  <data name="settings.localApi.action.revealed" xml:space="preserve">
+    <value>已開啟探索檔案的位置。</value>
+  </data>
+  <data name="settings.localApi.action.revealFailed" xml:space="preserve">
+    <value>無法開啟探索檔案的位置：{0}</value>
+  </data>
+  <data name="settings.localApi.action.portUnavailable" xml:space="preserve">
+    <value>伺服器執行後才會顯示連接埠。</value>
+  </data>
+  <data name="settings.localApi.action.openFailed" xml:space="preserve">
+    <value>無法開啟說明文件：{0}</value>
+  </data>
+  <data name="settings.localApi.action.fileMissing" xml:space="preserve">
+    <value>探索檔案尚未產生。請開啟伺服器，並等待其啟動完成。</value>
+  </data>
+  <data name="settings.localApi.action.copyFailed" xml:space="preserve">
+    <value>無法複製到剪貼簿：{0}</value>
+  </data>
+  <data name="settings.localApi.action.copied" xml:space="preserve">
+    <value>已複製到剪貼簿。</value>
   </data>
   <data name="settings.localApi.status.idle" xml:space="preserve">
     <value>No network sockets bound.</value>


### PR DESCRIPTION
Runs `localisation-syncer` across all three platforms and closes every gap it found.

## What was out of sync

| Platform | Before | After |
|---|---|---|
| macOS | 1482 issues | **0** |
| Windows | 1236 issues | **0** |
| Next.js | 0 issues | **0** (already in sync, untouched) |

### 1. macOS — 20 keys existed only in `Base.lproj`
Added to all 39 locales: `home.stats.*`, `modes.cloudAccuracy.*` (Azure MAI-Transcribe 1.5, Google Chirp 3), `settings.backup.localDownload.*`, `transcription.*` local-runtime error/guidance, `modelLibrary.local.*`.

### 2. Windows — 33 keys existed only in `Strings.resx`
Added to all 39 locales: `mode.editor.cloudModel.*`, `modes.cloudAccuracy.*` (AssemblyAI, Gemini, Mistral Voxtral, OpenAI Whisper, Soniox), `settings.localApi.action.*`, `settings.storage.*`, `vocabulary.*`.

### 3. macOS — 18 dead keys pruned (separate commit)
`statistics.*` and `sidebar.statistics` were present in all 39 locale files but **never existed in `Base.lproj`** and are referenced nowhere in the Swift source — leftovers from a Statistics view that never shipped. Removed (702 lines).

### 4. English placeholders in `es` / `ja` / `zh-Hans` (the non-obvious one)
17 of the Windows keys were already *present* in these three locales but holding **English values**. Because the compare script checks key *presence*, it reported them as in sync while Spanish, Japanese and Simplified Chinese users were seeing English. These are now properly translated.

## Correctness

Every translation was produced per-locale by a native-voice pass and then machine-validated before being written — the insert script refuses to write if any check fails:

- **Format tokens preserved 1:1** — `%d`, `%@` (macOS) and `{0}` (Windows); exact counts asserted per key.
- **`\n` escapes preserved** — `settings.appearance.theme.restart.message` verified to hold exactly two literal `\n`.
- **No stray double-quotes** in any value (would corrupt `.strings`).
- **Brand names kept verbatim** — HyperWhisper, Microsoft MAI-Transcribe 1.5, Azure Speech, Google Chirp 3, AssemblyAI, Google Gemini, Mistral Voxtral, OpenAI / GPT-4o Transcribe / Whisper, Soniox, Apple Silicon. Pure-brand labels return unchanged; `High (Google Chirp 3)` translates only "High".
- Translators aligned terminology with each locale's **already-shipped** strings (e.g. German keeps "Credits" because the existing file does).

## Verification

```
macOS   compare_localizable.py  -> Total issues: 0
Windows compare_resx.py         -> Total issues: 0
Next.js compare_messages.py     -> Total issues: 0

macOS:   40/40 pass plutil -lint; 39/39 locale files retain CRLF line endings
Windows: 40/40 .resx parse as valid XML
Files changed: 39 macOS + 39 Windows locale files; 0 Base files touched
Per-key coverage: all 20 macOS and all 33 Windows keys present in 40/40 files
```

Base files are deliberately untouched — this only moves locales toward Base.

## Re: #4

Issue #4 asked to sync `settings.cloud.*` to the 39 locales. **Those 10 keys are already present in all 40 files** — that work is already done, so there was nothing to sync there. The drift above is what actually remains, and it is release-blocking in the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NqQjDqS82ikRQkGDm74yhQ