### PR TITLE
fix(windows): resolve capture device by ordinal position, not fragile name matching

### DIFF
--- a/app/windows/HyperWhisper/Services/AudioRecorderService.cs
+++ b/app/windows/HyperWhisper/Services/AudioRecorderService.cs
@@ -241,15 +241,34 @@ public class AudioRecorderService : IDisposable
 
     /// <summary>
     /// Resolves the Core Audio (MMDevice) capture endpoint that corresponds to a
-    /// NAudio WaveIn index, so volume boost/restore acts on the device actually
-    /// being recorded rather than the system default comms mic.
+    /// NAudio WaveIn index, so volume boost/restore (and mic volume reads) act on
+    /// the device actually being recorded rather than a different mic entirely.
     ///
-    /// NAudio's <c>WaveIn.GetCapabilities(n).ProductName</c> is truncated to 31
-    /// characters (the MME WAVEINCAPS limit), so we match it as a prefix of the
-    /// full Core Audio <c>FriendlyName</c> instead of by equality. A
-    /// <paramref name="deviceNumber"/> of -1 is NAudio's "default device"
-    /// sentinel; when out of range, unmatched, or ambiguous we fall back to the
-    /// default comms endpoint so the feature degrades gracefully instead of throwing.
+    /// PRIMARY STRATEGY - ordinal position:
+    /// Legacy WinMM (<c>waveInGetNumDevs</c>/<c>waveInGetDevCaps</c>, which NAudio's
+    /// <c>WaveIn</c> wraps) enumerates active capture devices in the same relative
+    /// order as the modern Core Audio active-endpoint list on Windows Vista+, since
+    /// both ultimately come from the same device topology. So the Nth WaveIn device
+    /// is normally the Nth entry of <c>EnumerateAudioEndPoints(Capture, Active)</c>.
+    /// This avoids the previous name-matching bug: NAudio's
+    /// <c>WaveIn.GetCapabilities(n).ProductName</c> is truncated to 31 characters
+    /// (the MME WAVEINCAPS limit) and isn't guaranteed to share a common prefix
+    /// with the Core Audio <c>FriendlyName</c> at all (driver-dependent formatting,
+    /// e.g. "Microphone (Realtek(R) Audio)" vs "Realtek(R) Audio") - when it didn't
+    /// match, this method silently fell back to the *default communications
+    /// device*, which may be a completely different physical mic than the one the
+    /// user selected and is actually recording. That meant volume boost could be
+    /// applied to the wrong device while the real (quiet/muted) capture device was
+    /// left untouched, producing near-silent recordings that surface as no-speech.
+    ///
+    /// FALLBACK - truncated-name prefix match:
+    /// Used only if the ordinal position is out of range for the Core Audio list
+    /// (e.g. list sizes momentarily diverge across the two APIs). Kept as a
+    /// best-effort secondary signal rather than removed outright.
+    ///
+    /// A <paramref name="deviceNumber"/> of -1 is NAudio's "default device"
+    /// sentinel; when both strategies fail we fall back to the default comms
+    /// endpoint so the feature degrades gracefully instead of throwing.
     /// </summary>
     private static MMDevice ResolveCaptureDevice(MMDeviceEnumerator enumerator, int deviceNumber)
     {
@@ -267,53 +286,93 @@ public class AudioRecorderService : IDisposable
             return enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
         }
 
-        MMDevice? matchedDevice = null;
-
+        List<MMDevice> activeEndpoints;
         try
         {
-            foreach (var device in enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active))
-            {
-                var keepDevice = false;
-                try
-                {
-                    if (string.IsNullOrEmpty(targetName) ||
-                        !device.FriendlyName.StartsWith(targetName, StringComparison.OrdinalIgnoreCase))
-                        continue;
-
-                    if (matchedDevice != null)
-                    {
-                        LoggingService.Debug($"AudioRecorderService: Multiple capture endpoints match truncated device name '{targetName}', using default endpoint");
-                        DisposeCaptureDevice(matchedDevice, "previous matched capture endpoint");
-                        matchedDevice = null;
-                        return enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
-                    }
-
-                    matchedDevice = device;
-                    keepDevice = true;
-                }
-                catch (Exception ex)
-                {
-                    LoggingService.Debug($"AudioRecorderService: Skipping capture endpoint while resolving device #{deviceNumber} - {ex.Message}");
-                }
-                finally
-                {
-                    if (!keepDevice)
-                        DisposeCaptureDevice(device, "capture endpoint");
-                }
-            }
+            activeEndpoints = enumerator.EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active).ToList();
         }
         catch (Exception ex)
         {
-            DisposeCaptureDevice(matchedDevice, "matched capture endpoint");
             LoggingService.Debug($"AudioRecorderService: Failed to enumerate capture endpoints for device #{deviceNumber}, using default endpoint - {ex.Message}");
             return enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
         }
 
-        if (matchedDevice != null)
-            return matchedDevice;
+        var disposed = new bool[activeEndpoints.Count];
+        void DisposeUnused(MMDevice? keep)
+        {
+            for (var i = 0; i < activeEndpoints.Count; i++)
+            {
+                if (disposed[i] || ReferenceEquals(activeEndpoints[i], keep))
+                    continue;
+                DisposeCaptureDevice(activeEndpoints[i], "capture endpoint");
+                disposed[i] = true;
+            }
+        }
 
-        // No reliable name match (e.g. two mics share a truncated name); fall back
+        try
+        {
+            if (deviceNumber < activeEndpoints.Count)
+            {
+                var ordinalMatch = activeEndpoints[deviceNumber];
+
+                if (!string.IsNullOrEmpty(targetName) &&
+                    !ordinalMatch.FriendlyName.StartsWith(targetName, StringComparison.OrdinalIgnoreCase))
+                {
+                    // Names don't line up - still trust the ordinal position (it's the
+                    // more reliable signal) but log it so name-format drift is visible.
+                    LoggingService.Debug(
+                        $"AudioRecorderService: Ordinal-resolved capture endpoint '{ordinalMatch.FriendlyName}' " +
+                        $"doesn't prefix-match WaveIn device #{deviceNumber} name '{targetName}'; using it anyway");
+                }
+
+                DisposeUnused(ordinalMatch);
+                return ordinalMatch;
+            }
+
+            LoggingService.Debug(
+                $"AudioRecorderService: WaveIn device #{deviceNumber} has no matching ordinal Core Audio " +
+                $"endpoint ({activeEndpoints.Count} active); falling back to truncated-name matching");
+
+            MMDevice? nameMatch = null;
+            var ambiguous = false;
+            foreach (var device in activeEndpoints)
+            {
+                if (string.IsNullOrEmpty(targetName) ||
+                    !device.FriendlyName.StartsWith(targetName, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                if (nameMatch != null)
+                {
+                    LoggingService.Debug($"AudioRecorderService: Multiple capture endpoints match truncated device name '{targetName}', using default endpoint");
+                    ambiguous = true;
+                    nameMatch = null;
+                    break;
+                }
+
+                nameMatch = device;
+            }
+
+            if (ambiguous)
+            {
+                DisposeUnused(null);
+                return enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
+            }
+
+            if (nameMatch != null)
+            {
+                DisposeUnused(nameMatch);
+                return nameMatch;
+            }
+        }
+        catch (Exception ex)
+        {
+            LoggingService.Debug($"AudioRecorderService: Failed to resolve capture endpoint for device #{deviceNumber}, using default endpoint - {ex.Message}");
+        }
+
+        // No reliable match (e.g. two mics share a truncated name) or an
+        // exception during resolution; release everything and fall back
         // to the default comms endpoint rather than guessing.
+        DisposeUnused(null);
         return enumerator.GetDefaultAudioEndpoint(DataFlow.Capture, Role.Communications);
     }
 

--- a/app/windows/HyperWhisper/Services/HyperWhisperCloudService.cs
+++ b/app/windows/HyperWhisper/Services/HyperWhisperCloudService.cs
@@ -491,11 +491,21 @@ public class HyperWhisperCloudService : ITranscriptionProvider, ITranscriptionDi
         catch (HwTranscriptionException ex)
         {
             // 200-but-no-speech surfaces here as a NoSpeech error.
-            LastDiagnostics = new TranscriptionProviderDiagnostics(
+            var diagnostics = new TranscriptionProviderDiagnostics(
                 Name, requestId, sttProvider,
                 BackendNoSpeechDetected: ex is HwTranscriptionException.NoSpeech,
                 (int)response.@status, totalSw.ElapsedMilliseconds, false);
-            throw RustCoreMapping.MapTranscriptionError(ex, "HyperWhisper Cloud");
+            LastDiagnostics = diagnostics;
+            // Attach the diagnostics we just captured (real HTTP status + latency)
+            // to the thrown exception itself, not just the LastDiagnostics property -
+            // callers that catch this exception directly (e.g. TranscriptionOrchestrator
+            // step 1, which never reaches its own diagnostics read at the bottom of
+            // TranscribeCloudAsync because this throw unwinds past it) would otherwise
+            // see ProviderDiagnostics as null and every Sentry no-speech event would
+            // report backend_http_status=0 / backend_response_latency_ms=0 regardless
+            // of what actually happened on the wire.
+            throw RustCoreMapping.MapTranscriptionError(
+                ex, "HyperWhisper Cloud", (int)response.@status, providerDiagnostics: diagnostics);
         }
 
         LastDiagnostics = new TranscriptionProviderDiagnostics(

--- a/app/windows/HyperWhisper/Services/Transcription/RustCoreMapping.cs
+++ b/app/windows/HyperWhisper/Services/Transcription/RustCoreMapping.cs
@@ -63,7 +63,8 @@ internal static class RustCoreMapping
         int creditsRemaining = 0,
         int creditsRequired = 0,
         long fileTooLargeBytes = 0,
-        long fileTooLargeLimit = 0)
+        long fileTooLargeLimit = 0,
+        TranscriptionProviderDiagnostics? providerDiagnostics = null)
     {
         switch (error)
         {
@@ -72,7 +73,10 @@ internal static class RustCoreMapping
                     TranscriptionErrorCode.Unauthorized,
                     $"Invalid {providerName} API key",
                     providerName,
-                    httpStatusCode);
+                    httpStatusCode,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.QuotaExceeded:
                 // HW Cloud / routed: a 402 is "out of credits". Surface the richer
@@ -84,13 +88,19 @@ internal static class RustCoreMapping
                         TranscriptionErrorCode.QuotaExceeded,
                         $"Insufficient credits (remaining: {creditsRemaining}, required: {creditsRequired})",
                         providerName,
-                        httpStatusCode ?? 402);
+                        httpStatusCode ?? 402,
+                        retryAfterSeconds: null,
+                        innerException: null,
+                        providerDiagnostics: providerDiagnostics);
                 }
                 return new TranscriptionException(
                     TranscriptionErrorCode.QuotaExceeded,
                     $"{providerName} quota exceeded",
                     providerName,
-                    httpStatusCode);
+                    httpStatusCode,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.FileTooLarge:
                 return new TranscriptionException(
@@ -99,7 +109,10 @@ internal static class RustCoreMapping
                         ? $"Audio file ({fileTooLargeBytes / 1_048_576.0:F1} MB) exceeds {providerName}'s {fileTooLargeLimit / 1_048_576} MB limit"
                         : $"Audio file too large for {providerName}",
                     providerName,
-                    httpStatusCode ?? 413);
+                    httpStatusCode ?? 413,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.RateLimited rateLimited:
                 return new TranscriptionException(
@@ -112,21 +125,29 @@ internal static class RustCoreMapping
                     // would wrap to a negative. Clamp to int.MaxValue.
                     rateLimited.@retryAfterSecs.HasValue
                         ? (int)Math.Min(rateLimited.@retryAfterSecs.Value, int.MaxValue)
-                        : null);
+                        : null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.ProviderUnavailable providerUnavailable:
                 return new TranscriptionException(
                     TranscriptionErrorCode.ProviderUnavailable,
                     $"{providerName} unavailable",
                     providerName,
-                    providerUnavailable.@status);
+                    providerUnavailable.@status,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.NoSpeech:
                 return new TranscriptionException(
                     TranscriptionErrorCode.NoSpeechDetected,
                     "No speech detected in audio",
                     providerName,
-                    httpStatusCode);
+                    httpStatusCode,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.BadRequest badRequest:
                 // 400-class. Surface the upstream message; an empty message
@@ -135,7 +156,10 @@ internal static class RustCoreMapping
                     TranscriptionErrorCode.InvalidRequest,
                     string.IsNullOrEmpty(badRequest.@message) ? "Invalid request" : badRequest.@message,
                     providerName,
-                    badRequest.@status);
+                    badRequest.@status,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             case HwTranscriptionException.Parse parse:
                 return new TranscriptionException(
@@ -144,14 +168,20 @@ internal static class RustCoreMapping
                         ? $"Invalid response from {providerName}"
                         : parse.@message,
                     providerName,
-                    httpStatusCode);
+                    httpStatusCode,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
 
             default:
                 return new TranscriptionException(
                     TranscriptionErrorCode.Unknown,
                     error.Message,
                     providerName,
-                    httpStatusCode);
+                    httpStatusCode,
+                    retryAfterSeconds: null,
+                    innerException: null,
+                    providerDiagnostics: providerDiagnostics);
         }
     }
 

--- a/app/windows/HyperWhisper/Services/TranscriptionDiagnosticsService.cs
+++ b/app/windows/HyperWhisper/Services/TranscriptionDiagnosticsService.cs
@@ -28,7 +28,8 @@ public static class TranscriptionDiagnosticsService
         string? inputDeviceName = null,
         string? transcriptionProviderDisplayName = null,
         TranscriptionProviderDiagnostics? providerDiagnostics = null,
-        TranscriptionException? exception = null)
+        TranscriptionException? exception = null,
+        int? captureDeviceCount = null)
     {
         var audioDiagnostics = AnalyzeAudioFile(audioPath, fallbackDurationSeconds);
 
@@ -56,7 +57,15 @@ public static class TranscriptionDiagnosticsService
             ["cloud_accuracy_tier"] = mode?.CloudAccuracyTier ?? "none",
             ["local_engine"] = mode?.LocalEngine ?? "none",
             ["backend_no_speech_detected"] = (providerDiagnostics?.BackendNoSpeechDetected ?? false).ToString().ToLowerInvariant(),
-            ["audio_analysis_succeeded"] = audioDiagnostics.AnalysisSucceeded.ToString().ToLowerInvariant()
+            ["audio_analysis_succeeded"] = audioDiagnostics.AnalysisSucceeded.ToString().ToLowerInvariant(),
+            // Promoted from extras so Sentry can facet/segment on them (extras
+            // aren't aggregable - see HYPERWHISPER-PA). RMS is bucketed to 5dBFS
+            // steps rather than passed raw: a continuous float as a tag has
+            // near-100% cardinality (every event gets its own "bucket" of one),
+            // which defeats faceting entirely - the whole point of promoting it.
+            ["audio_rms_dbfs_bucket"] = BucketDbfs(audioDiagnostics.RmsDbfs),
+            ["selected_input_device_name"] = inputDeviceName ?? "n/a",
+            ["capture_device_count"] = captureDeviceCount?.ToString() ?? "unknown"
         };
 
         var extras = new Dictionary<string, object>
@@ -199,6 +208,22 @@ public static class TranscriptionDiagnosticsService
         }
 
         return Math.Round(20 * Math.Log10(linear), 2);
+    }
+
+    /// <summary>
+    /// Buckets a dBFS value to the nearest 5dB step (e.g. -38.2 -> "-40dbfs") for
+    /// use as a low-cardinality Sentry tag. A raw float would give every event its
+    /// own effectively-unique value, making it useless for faceting/segmenting.
+    /// </summary>
+    private static string BucketDbfs(double dbfs)
+    {
+        if (dbfs <= MinimumDbfs)
+        {
+            return "silent";
+        }
+
+        var bucket = (int)(Math.Floor(dbfs / 5.0) * 5.0);
+        return $"{bucket}dbfs";
     }
 
     private static bool ShouldCaptureNoSpeechDiagnostic(

--- a/app/windows/HyperWhisper/ViewModels/MainViewModel.cs
+++ b/app/windows/HyperWhisper/ViewModels/MainViewModel.cs
@@ -2234,7 +2234,8 @@ public partial class MainViewModel : ViewModelBase
                             inputDeviceName: SelectedAudioDevice?.Name,
                             transcriptionProviderDisplayName: txEx.ProviderName,
                             providerDiagnostics: txEx.ProviderDiagnostics,
-                            exception: txEx);
+                            exception: txEx,
+                            captureDeviceCount: AudioDevices.Count);
                     }
 
                     ShowErrorToastRequested?.Invoke(this, new ErrorToastEventArgs(


### PR DESCRIPTION
Fixes a confirmed subclass of **HYPERWHISPER-PA** (Windows transcription no-speech diagnostic — 60 users, 368 events), restores dropped diagnostic telemetry for the rest, and promotes key fields to Sentry tags for future segmentation.

## Verified against live Sentry data (by Ray — 90d query, all 368 events / 60 users)

I don't have Sentry API/login access in this sandbox, so all code-level investigation below was verification-by-tracing until Ray ran the aggregate query this needed. Two clean populations:

- **`backend_no_speech_detected=true`: 230 events, 48 users** — backend and provider agree there's no speech. The audio itself is the problem (genuinely silent/too quiet). This population is **not** addressed by this PR — it needs a gain/mic-level UX fix (e.g. a chronic-low-RMS warning, input-gain normalization before upload), tracked as follow-up.
- **`backend_no_speech_detected=false`: 138 events, 25 users (~38% of events)** — backend saw speech-ish audio but the provider still returned no-speech. This is the mismatch class this PR targets, and matches the sample event Ray pulled: 1.7s clip, non-silent ratio 0.226, peak -25.5dBFS, RMS -40.6dBFS, 16kHz mono WAV, device `"Microphone (High Definition Aud…"`.

**Verdict (Ray):** scope this PR as the fix for the ~38%/25-user mismatch population; the majority "agreeing no-speech" population needs a separate gain/UX pass and is out of scope here.

## What's in this PR (3 commits)

**1. Ordinal-position device resolution** (`AudioRecorderService.ResolveCaptureDevice`) — the plausible root cause of the mismatch population. Mic-volume boost is supposed to raise a low mic volume to 90% on "the device actually being recorded," resolved by matching NAudio's truncated (31-char) WaveIn `ProductName` as a string *prefix* of the Core Audio `FriendlyName`. Driver-reported names aren't guaranteed to share a prefix at all (e.g. `"Microphone (Realtek(R) Audio)"` vs `"Realtek(R) Audio")`, so on any mismatch/ambiguity it silently fell back to the **default communications endpoint** — a different physical device than the one actually selected and recording. Net effect: boost lands on the wrong device, the real (low-volume) capture device stays untouched, producing recordings with genuine but too-quiet speech — exactly the "provider disagrees" shape.

Fix: switched the primary correlation strategy to **ordinal position** — legacy WinMM (which NAudio's `WaveIn` wraps) enumerates active capture devices in the same relative order as the modern Core Audio active-endpoint list, so the Nth WaveIn device is normally the Nth entry of `EnumerateAudioEndPoints(Capture, Active)`. Doesn't depend on name formatting. Old name-matching kept as a secondary fallback if the two lists ever diverge in size.

**2. Provider diagnostics wiring** (`RustCoreMapping.MapTranscriptionError`, `HyperWhisperCloudService`) — Ray's sample event showed `backend_http_status: 0` and `backend_response_latency_ms: 0`, initially read as a possible transport failure being misreported as no-speech. Traced it: it's dropped telemetry, not a transport failure. `HyperWhisperCloudService` already built a `TranscriptionProviderDiagnostics` with the real HTTP status + latency right before throwing on the "200-but-no-speech" path, but only assigned it to a `LastDiagnostics` property, never to the exception itself — and the shared error mapper every provider's error path goes through never had a parameter to accept one. Fixed by threading `providerDiagnostics` through the full mapper and wiring the throw site to pass it. Going forward, these fields carry real data instead of struct defaults.

**3. Tag promotion** — Ray's query hit a wall: `audio_rms_dbfs` and `selected_input_device_name` are event *extra data*, not tags, so Sentry couldn't facet/aggregate on them for further segmentation. Promoted `audio_rms_dbfs` (bucketed to 5dBFS steps as `audio_rms_dbfs_bucket` — a raw float as a tag is ~100% cardinality and defeats faceting; exact value stays in extras) and `selected_input_device_name` to tags, plus a new `capture_device_count` tag (total audio devices enumerated at capture time) to help spot machines with many/ambiguous devices.

## Residual (explicitly out of scope here)

The 230-event/48-user "backend agrees, audio is genuinely bad" population is real and this PR does not reduce it. Candidate fixes discussed: input-gain normalization before upload, a low-RMS warning in the UI, or a local-Whisper retry/fallback when the provider says no-speech but local analysis disagrees (that last one only helps the mismatch population, not this one). Needs its own scoping pass.

## Other gaps found during investigation (not fixed here, flagging for follow-up)

- Streaming-mode no-speech failures (`MainViewModel.cs:1524-1528`) never call `CaptureNoSpeechDiagnostic` at all — that path's failures are currently invisible in Sentry.
- `OpenAIStreamingStrategy.AudioSampleRate` requests 24kHz capture while every other streaming provider uses 16kHz — a device/driver that can't cleanly deliver 24kHz via the legacy MME path has no app-level verification the rate was honored.
- The file-import flow to the local Parakeet/Qwen3 daemon has no visible resample-to-16kHz/mono step (unlike the whisper.net path's `PrepareAudioStream`), so an imported file at the wrong sample rate could plausibly produce empty/garbage results.

## Testing

No unit test project covers these services with live Core Audio/WaveIn/HTTP behavior (only `HyperWhisper.SmokeTests` exists, and this logic needs live hardware/network). I don't have a Windows environment with audio hardware in this sandbox to exercise it live, so this is verified by code review/tracing plus Ray's live Sentry query — not a runtime repro on my end. Flagging that explicitly rather than claiming more than I've checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
