### PR TITLE
Scale slow-transcription thresholds to audio duration (HYPERWHISPER-P3/P4)

### DIFF
--- a/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+StopRecording.swift
+++ b/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+StopRecording.swift
@@ -391,7 +391,7 @@ extension RecordingTranscriptionFlow {
             // Audio actually sent to the provider: VAD-trimmed length when VAD ran,
             // else the raw recording. Reused below for the UI-side slow threshold so
             // both P3 (pipeline) and P4 (this flow) scale off the same duration.
-            let effectiveAudioDurationSeconds = trimResult?.trimmedDuration ?? recordingDuration
+            let effectiveAudioDurationSeconds = (vadResult.wasProcessed ? trimResult?.trimmedDuration : nil) ?? recordingDuration
             let transcribeStart = Date()
             let transcriptionResult = try await transcriptionMgr.transcribeWithDetails(
                 audioURL: finalAudioURL,

--- a/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+StopRecording.swift
+++ b/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+StopRecording.swift
@@ -53,9 +53,14 @@ extension RecordingTranscriptionFlow {
         var createRowMs = -1
         var transcribeMs = -1
         var coreDataUpdateMs = -1
+        // HYPERWHISPER-P4: same fix as HYPERWHISPER-P3 (TranscriptionPipeline+Transcription.swift) —
+        // these base thresholds cover fixed overhead; `slowTranscribingUIPerAudioSecondMs` adds a
+        // per-audio-second allowance so long-but-proportionally-fast dictations stop tripping the
+        // same bar as short ones.
         let slowTranscribingUIThresholdMs = 8_000
         let slowTranscribingUIWithPostProcessingThresholdMs = 15_000
         let slowTranscribingUIWithLocalLLMThresholdMs = 45_000
+        let slowTranscribingUIPerAudioSecondMs = 150.0
         var transcribingUIStart: Date?
 
         let sessionModeName = activeSessionModeName
@@ -383,12 +388,17 @@ extension RecordingTranscriptionFlow {
             // Use finalAudioURL which may be VAD-trimmed if VAD was enabled.
             // `transcribe` folds provider selection + transcription + post-processing;
             // its wall time is surfaced as the transcribe stage.
+            // Audio actually sent to the provider: VAD-trimmed length when VAD ran,
+            // else the raw recording. Reused below for the UI-side slow threshold so
+            // both P3 (pipeline) and P4 (this flow) scale off the same duration.
+            let effectiveAudioDurationSeconds = trimResult?.trimmedDuration ?? recordingDuration
             let transcribeStart = Date()
             let transcriptionResult = try await transcriptionMgr.transcribeWithDetails(
                 audioURL: finalAudioURL,
                 mode: transcriptionMode,
                 recordingSession: nil, // Will be set by RecordingLifecycle
-                applicationContext: capturedApplicationContext
+                applicationContext: capturedApplicationContext,
+                audioDurationSeconds: effectiveAudioDurationSeconds
             )
             transcribeMs = Int(Date().timeIntervalSince(transcribeStart) * 1000)
 
@@ -553,14 +563,16 @@ extension RecordingTranscriptionFlow {
                 "Recording transcription flow succeeded · attemptId=\(attemptId) · trigger=\(trigger) · mode=\(actualMode) · provider=\(transcriptionResult.provider) · flowMs=\(flowElapsedMs) · transcribingUiMs=\(transcribingUIElapsedMs) · vadProcessed=\(vadResult.wasProcessed) · silenceRemovedSeconds=\(trimmedSeconds) · \(stageTimings)"
 
             let isLocalLLM = transcriptionResult.postProcessingProvider == PostProcessingProvider.localLLM.rawValue
-            let effectiveUIThreshold: Int
+            let uiDurationAllowanceMs = Int(effectiveAudioDurationSeconds * slowTranscribingUIPerAudioSecondMs)
+            let baseUIThreshold: Int
             if isLocalLLM {
-                effectiveUIThreshold = slowTranscribingUIWithLocalLLMThresholdMs
+                baseUIThreshold = slowTranscribingUIWithLocalLLMThresholdMs
             } else if transcriptionResult.wasPostProcessed {
-                effectiveUIThreshold = slowTranscribingUIWithPostProcessingThresholdMs
+                baseUIThreshold = slowTranscribingUIWithPostProcessingThresholdMs
             } else {
-                effectiveUIThreshold = slowTranscribingUIThresholdMs
+                baseUIThreshold = slowTranscribingUIThresholdMs
             }
+            let effectiveUIThreshold = baseUIThreshold + uiDurationAllowanceMs
             if transcribingUIElapsedMs >= effectiveUIThreshold {
                 // Slow path: attach per-stage timings as scope extras (they survive
                 // beforeSend, unlike breadcrumbs) so any subsequent event carries them.
@@ -571,7 +583,10 @@ extension RecordingTranscriptionFlow {
                     "stage_create_row_ms": createRowMs,
                     "stage_transcribe_ms": transcribeMs,
                     "stage_core_data_update_ms": coreDataUpdateMs,
-                    "stage_flow_ms": flowElapsedMs
+                    "stage_flow_ms": flowElapsedMs,
+                    "stage_audio_duration_seconds": effectiveAudioDurationSeconds,
+                    "stage_duration_allowance_ms": uiDurationAllowanceMs,
+                    "stage_effective_ui_threshold_ms": effectiveUIThreshold
                 ])
                 AppLogger.audio.warning("\(uiLogMessage, privacy: .public)")
             } else {

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Transcription.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Transcription.swift
@@ -5,6 +5,8 @@
 //  Core transcription flow, state handling, and instrumentation.
 //
 
+import AVFoundation
+import CoreMedia
 import Foundation
 
 extension TranscriptionPipeline {
@@ -33,7 +35,8 @@ extension TranscriptionPipeline {
         audioURL: URL,
         mode: Mode?,
         recordingSession: RecordingSession? = nil,
-        applicationContext: ApplicationContext? = nil
+        applicationContext: ApplicationContext? = nil,
+        audioDurationSeconds: TimeInterval? = nil
     ) async throws -> TranscriptionResult {
         // If a transcription is already running, cancel it so the latest request wins.
         // This guards against rapid hotkey presses and intentional re-records.
@@ -64,14 +67,35 @@ extension TranscriptionPipeline {
         var capturedPostProcessingProvider: String = "unknown"
         var capturedShouldRunPostProcessing: Bool = false
         var capturedIsHyperwhisperTranscription: Bool = false
+        // Base thresholds cover fixed overhead (network round-trip, model warmup,
+        // queueing). HYPERWHISPER-P3: these used to be flat cutoffs, so a routine
+        // multi-minute dictation (which legitimately takes longer to transcribe
+        // than a 10s clip) tripped the same 8s bar as a 10s clip and flooded
+        // Sentry with "slow" events that were really just long recordings.
+        // `slowTranscriptionPerAudioSecondMs` adds an allowance proportional to
+        // the audio actually sent to the provider, so the bar scales with input
+        // size instead of penalizing longer (but proportionally fast) calls.
         let slowTranscriptionThresholdMs = 8_000
         let slowTranscriptionWithPostProcessingThresholdMs = 15_000
         let slowTranscriptionWithLocalLLMThresholdMs = 45_000
+        let slowTranscriptionPerAudioSecondMs = 150.0
 
         let transcriptionStart = Date()
         var stage = "start"
         var stageStart = transcriptionStart
         var stageTimeline: [String] = []
+
+        // Resolve audio duration concurrently with the transcription itself so it
+        // doesn't add latency to the hot path. Prefers the caller-supplied duration
+        // (e.g. the VAD-trimmed length the audio pipeline already computed) and
+        // falls back to reading the file directly for callers that don't have it.
+        let audioDurationTask = Task<Double, Never> {
+            if let audioDurationSeconds, audioDurationSeconds > 0 { return audioDurationSeconds }
+            let asset = AVURLAsset(url: audioURL)
+            guard let durationCM = try? await asset.load(.duration) else { return 0 }
+            let seconds = CMTimeGetSeconds(durationCM)
+            return seconds.isFinite && seconds > 0 ? seconds : 0
+        }
 
         // Track stage timings for diagnostics and Sentry breadcrumbs.
         func markStage(_ newStage: String) {
@@ -331,14 +355,17 @@ extension TranscriptionPipeline {
 
             let wasPostProcessed = result.wasPostProcessed
             let isLocalLLM = result.postProcessingProvider == PostProcessingProvider.localLLM.rawValue
-            let effectiveThreshold: Int
+            let audioDurationSecondsResolved = await audioDurationTask.value
+            let durationAllowanceMs = Int(audioDurationSecondsResolved * slowTranscriptionPerAudioSecondMs)
+            let baseThreshold: Int
             if isLocalLLM {
-                effectiveThreshold = slowTranscriptionWithLocalLLMThresholdMs
+                baseThreshold = slowTranscriptionWithLocalLLMThresholdMs
             } else if wasPostProcessed {
-                effectiveThreshold = slowTranscriptionWithPostProcessingThresholdMs
+                baseThreshold = slowTranscriptionWithPostProcessingThresholdMs
             } else {
-                effectiveThreshold = slowTranscriptionThresholdMs
+                baseThreshold = slowTranscriptionThresholdMs
             }
+            let effectiveThreshold = baseThreshold + durationAllowanceMs
             if totalElapsedMs >= effectiveThreshold {
                 AppLogger.transcription.warning("\(logMessage, privacy: .public)")
                 if AppLogger.isErrorLoggingEnabled {
@@ -360,6 +387,9 @@ extension TranscriptionPipeline {
                             "isHyperwhisperTranscription": capturedIsHyperwhisperTranscription,
                             "totalElapsedMs": totalElapsedMs,
                             "effectiveThresholdMs": effectiveThreshold,
+                            "baseThresholdMs": baseThreshold,
+                            "audioDurationSeconds": audioDurationSecondsResolved,
+                            "durationAllowanceMs": durationAllowanceMs,
                             "finalStage": stage,
                             "stageTimeline": stageTimelineSnapshot,
                             "recordingSessionID": recordingSession?.id?.uuidString ?? "nil"


### PR DESCRIPTION
## Summary

Fixes noise-level Sentry perf warnings [HYPERWHISPER-P3](https://ray-amjad.sentry.io/issues/HYPERWHISPER-P3) ("Slow transcription completed") and [HYPERWHISPER-P4](https://ray-amjad.sentry.io/issues/HYPERWHISPER-P4) ("Slow transcribing UI completed").

**Verification first:** pulled a sample event — `transcribe=8366ms` of `totalMs=8456` (99% of time in the cloud transcribe call), but `silenceRemovedSeconds=161` shows this was a 3+ minute dictation (VAD trimmed 2.7 min of silence), not a short clip. P3 and P4 fire from the same underlying event (identical trace_id, same user, ~1s apart) — they're the same measurement surfaced at two points in the flow (pipeline transcribe stage vs. UI-completion layer), not two separate bugs.

Root cause: both thresholds (`TranscriptionPipeline+Transcription.swift` for P3, `RecordingTranscriptionFlow+StopRecording.swift` for P4) are flat cutoffs — 8s / 15s (post-processed) / 45s (local LLM) — regardless of audio length. ~8s to transcribe several minutes of audio via a cloud API is fine; the alarm was on absolute time, not throughput.

## Fix

- Add a per-audio-second allowance (`150ms/s`) on top of each base threshold, so the bar scales with the audio actually sent to the provider (VAD-trimmed length when VAD ran, else raw recording) instead of penalizing long-but-proportionally-fast calls.
- Thread the resolved duration from the recording flow into `transcribeWithDetails(audioDurationSeconds:)` so P3 and P4 use the same value; other callers (retry, file-import) fall back to reading the file's duration directly, so they get the same fix for free.
- Surface `audioDurationSeconds` / `durationAllowanceMs` / effective threshold in the Sentry extras attached to any slow-path event, so a real regression (not just a long recording) is easier to triage going forward.

No upload-compression change included — the cloud path already streams raw binary (no multipart overhead per the existing comment in `HyperWhisperCloudProvider`), and 8s for ~2 minutes of trimmed audio is a reasonable ratio, so that wasn't the bottleneck.

## Test plan

- [ ] Could not run `xcodebuild` in this sandbox (Linux, no Xcode toolchain) — needs a macOS build/typecheck pass before merge.
- [ ] Manually dictate a short (~5s) and a long (~3min) recording and confirm neither trips the warning log line under normal cloud latency.
- [ ] Confirm a genuinely slow cloud response (e.g. throttled network) still trips the threshold for both short and long recordings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)