### PR TITLE
fix(macos): remove dead main-thread RecordingSession insert

### DIFF
--- a/app/macos/hyperwhisper/CoreData/PersistenceController.swift
+++ b/app/macos/hyperwhisper/CoreData/PersistenceController.swift
@@ -2048,66 +2048,18 @@ class PersistenceController: ObservableObject {
     }
     
     // MARK: - RecordingSession Operations
-    
-    /// Creates a new recording session
-    /// - Parameters:
-    ///   - deviceId: The audio device ID
-    ///   - deviceName: The audio device name
-    ///   - sampleRate: Audio sample rate
-    ///   - channelCount: Number of audio channels
-    ///   - audioFormat: Audio format description
-    /// - Returns: The created recording session
-    @discardableResult
-    func createRecordingSession(
-        deviceId: String,
-        deviceName: String,
-        sampleRate: Double,
-        channelCount: Int16,
-        audioFormat: String
-    ) -> RecordingSession {
-        let context = container.viewContext
-        
-        let session = RecordingSession(context: context)
-        session.id = UUID()
-        session.startTime = Date()
-        session.deviceId = deviceId
-        session.deviceName = deviceName
-        session.sampleRate = sampleRate
-        session.channelCount = channelCount
-        session.audioFormat = audioFormat
-        session.status = "recording"
-        session.retryCount = 0
-        
-        save()
-        
-        return session
-    }
-    
-    /// Updates a recording session with transcription result
-    /// - Parameters:
-    ///   - session: The recording session to update
-    ///   - transcript: The resulting transcript (if successful)
-    ///   - error: Error message (if failed)
-    ///   - retryCount: Number of retry attempts made
-    func updateRecordingSessionWithResult(
-        _ session: RecordingSession,
-        transcript: Transcript? = nil,
-        error: String? = nil,
-        retryCount: Int16 = 0
-    ) {
-        session.retryCount = retryCount
-        
-        if let transcript = transcript {
-            session.transcript = transcript
-            session.status = "completed"
-        } else if let error = error {
-            session.errorMessage = error
-            session.status = "failed"
-        }
-        
-        save()
-    }
-    
+    //
+    // NOTE: Session create/update/delete live on RecordingSessionManager +
+    // performWriteRequiringSave (serial background writer context), NOT here.
+    // A pre-refactor synchronous pair (`createRecordingSession(deviceId:...)` /
+    // `updateRecordingSessionWithResult`) used to live in this section — it
+    // inserted + saved a RecordingSession directly on `container.viewContext`
+    // (main thread, no `perform`/`performAndWait`), which reproduced Sentry
+    // HYPERWHISPER-SH / HYPERWHISPER-R0 ("DB on Main Thread at Recording
+    // Start"). It had no remaining callers after the async rewrite, so it was
+    // deleted rather than fixed in place — do not reintroduce a synchronous
+    // viewContext insert/save for RecordingSession here.
+
     // MARK: - Vocabulary Operations
     
     /// Adds a new vocabulary item to Core Data


### PR DESCRIPTION
## Sentry issues
- HYPERWHISPER-SH — `performance_db_main_thread`, 1,247 occurrences / 66 users, still firing as of 2026-07-16 on `hyperwhisper@2.39.0`.
- HYPERWHISPER-R0 — same title, 380 events / 15 users, last seen <1h ago.

Both report the same offending span: `db.sql.transaction — INSERTED 1 'RecordingSession'` inside the "Recording Start" transaction (`audio.recording.start`), on `thread.name: main`, ~224ms exclusive time.

## Root cause
Both issues share one root cause: a **pre-refactor, dead** pair of methods in `PersistenceController.swift` — `createRecordingSession(deviceId:...)` / `updateRecordingSessionWithResult(...)` — which inserted and saved a `RecordingSession` directly on `container.viewContext` (main thread, no `perform`/`performAndWait`). This is an exact structural match for the reported span.

These methods have **zero live callers**. The actual live recording-start path (`RecordingTranscriptionFlow+StartRecording.swift` → `RecordingLifecycle.persistSessionForActiveRecording()` → `RecordingSessionManager.scheduleRecordingSessionCreation` → `PersistenceController.performWriteRequiringSave`) already defers `RecordingSession` persistence until *after* the "Recording Start" Sentry span closes, and runs it on a dedicated serial background writer context (`container.newBackgroundContext()` via `context.perform`) — this was fixed in #18 (`606599530`, "fix stop→paste freeze"), shipped in `macos/v2.41.0`.

Every recording-start trigger (global hotkey, push-to-talk, menu bar/window button, RecordingDialog, onboarding, Quick Capture) funnels through this single shared function, so there was never a second, independent code path — SH and R0 are the same bug. The events still appearing in Sentry (SH pinned to `2.39.0`, two releases behind current `2.41.0`; R0 unpinned but Windows has no equivalent "Recording Start" transaction, so it's macOS too) are consistent with users on stale builds that predate the async rewrite, not a live regression on current `main`.

## Fix
Removed the dead synchronous methods so the landmine can't be reintroduced or accidentally wired back up. Left a `NOTE:` comment pointing at the real (already-async) session-creation path and referencing both Sentry IDs, since this file has apparently attracted more than one main-thread-DB fix before (see `HYPERWHISPER-KP`, also fixed at this call site's neighbor).

## Verification
No Xcode toolchain available in this sandbox, so no `xcodebuild` run. Instead:
- Grepped for all callers of the removed methods before/after the edit — zero hits.
- Confirmed brace balance in the edited file.
- Traced the full call graph/threading model of the live path (`context.perform` vs `performAndWait`, `newBackgroundContext()` vs `viewContext`) to confirm it's genuinely off the main thread and outside the Sentry span.
- Checked git history/tags to confirm the async rewrite (commit `6065995`, #18) predates and is included in current `main` / `macos/v2.41.0`.

A real Xcode build should still be run before merging.

---
Requested in Slack. Opened by Claude running in a Percy sandbox.