### PR TITLE
Fix Parakeet fallback contract when model isn't downloaded (HYPERWHISPER-TD, HYPERWHISPER-SV)

### DIFF
--- a/app/macos/hyperwhisper/Managers/LocalAPI/Endpoints/TranscribeEndpoint.swift
+++ b/app/macos/hyperwhisper/Managers/LocalAPI/Endpoints/TranscribeEndpoint.swift
@@ -736,7 +736,7 @@ enum TranscribeEndpoint {
         case "whisperlocal", "whisper", "libwhisper":
             mode.model = model ?? "base"
         case "parakeet":
-            mode.model = model ?? "parakeet-tdt-v3-multilingual"
+            mode.model = ParakeetModelManager.Constants.modelIdForSelection(model)
         case "qwen3asr", "qwen3", "qwen3-asr":
             mode.model = Qwen3AsrModelManager.Constants.modelId
         case "applespeech", "apple", "apple-speech", "apple-speech-analyzer", "speech-analyzer":

--- a/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionModelManager.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionModelManager.swift
@@ -193,6 +193,22 @@ class TranscriptionModelManager: ObservableObject {
                 modelReadyState = .ready(name: parakeetDisplayName)
             } catch is CancellationError {
                 AppLogger.models.info("Parakeet preparation cancelled")
+            } catch TranscriptionError.modelNotDownloaded {
+                // EXPECTED, NOT A CRASH (HYPERWHISPER-TD): the selected mode
+                // points at a Parakeet model that isn't on disk (fresh
+                // install, or evicted after being downloaded). This used to
+                // fall into the generic `catch` below, which Sentry-reported
+                // it as "Parakeet prepare failed" on every launch/mode-switch
+                // without actually doing anything about it — the "will use
+                // cloud fallback" log never turned into real fallback
+                // behavior. Kick off the same download the Models UI uses,
+                // tell the user their local mode needs a download, and mark
+                // the model ready as Cloud so transcription isn't blocked
+                // while the download completes in the background.
+                AppLogger.models.warning("Parakeet \(modelId, privacy: .public) not downloaded — starting download, using cloud fallback in the meantime")
+                parakeetModelManager.startDownload(modelId)
+                modelReadyState = .ready(name: "Cloud")
+                onStateChange?(.error(message: "\(parakeetDisplayName) isn't downloaded yet — downloading now. Using cloud until it's ready."))
             } catch {
                 AppLogger.models.error("Failed to prepare Parakeet provider: \(error.localizedDescription, privacy: .public)")
                 modelReadyState = .none

--- a/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionModelManager.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionModelManager.swift
@@ -69,6 +69,7 @@ class TranscriptionModelManager: ObservableObject {
         case none
         case loading(name: String)
         case ready(name: String)
+        case unavailable(name: String)
     }
 
     // MARK: - Published Properties
@@ -194,21 +195,14 @@ class TranscriptionModelManager: ObservableObject {
             } catch is CancellationError {
                 AppLogger.models.info("Parakeet preparation cancelled")
             } catch TranscriptionError.modelNotDownloaded {
-                // EXPECTED, NOT A CRASH (HYPERWHISPER-TD): the selected mode
-                // points at a Parakeet model that isn't on disk (fresh
-                // install, or evicted after being downloaded). This used to
-                // fall into the generic `catch` below, which Sentry-reported
-                // it as "Parakeet prepare failed" on every launch/mode-switch
-                // without actually doing anything about it — the "will use
-                // cloud fallback" log never turned into real fallback
-                // behavior. Kick off the same download the Models UI uses,
-                // tell the user their local mode needs a download, and mark
-                // the model ready as Cloud so transcription isn't blocked
-                // while the download completes in the background.
-                AppLogger.models.warning("Parakeet \(modelId, privacy: .public) not downloaded — starting download, using cloud fallback in the meantime")
-                parakeetModelManager.startDownload(modelId)
-                modelReadyState = .ready(name: "Cloud")
-                onStateChange?(.error(message: "\(parakeetDisplayName) isn't downloaded yet — downloading now. Using cloud until it's ready."))
+                // Missing weights are expected for a restored mode or an
+                // externally-evicted cache. Keep the local-only contract:
+                // preparation must neither upload audio nor start a large
+                // download without consent. The status bar makes the required
+                // action visible, while an actual transcription attempt
+                // throws the localized `.modelNotDownloaded` error.
+                AppLogger.models.warning("Parakeet \(modelId, privacy: .public) is not downloaded")
+                modelReadyState = .unavailable(name: parakeetDisplayName)
             } catch {
                 AppLogger.models.error("Failed to prepare Parakeet provider: \(error.localizedDescription, privacy: .public)")
                 modelReadyState = .none

--- a/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionProviderRouter.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionProviderRouter.swift
@@ -447,7 +447,14 @@ class TranscriptionProviderRouter {
             }
             modelString = m
         case "parakeet":
-            modelString = model?.isEmpty == false ? model! : "parakeet-tdt-v3-multilingual"
+            let requestedModelId = ParakeetModelManager.Constants.modelIdForSelection(model)
+            guard let canonicalModelId = ParakeetModelManager.Constants.canonicalModelId(for: requestedModelId) else {
+                throw TranscriptionError.providerNotAvailable(
+                    provider: "Parakeet",
+                    reason: "Unknown Parakeet model '\(requestedModelId)'"
+                )
+            }
+            modelString = canonicalModelId
         case "qwen3asr", "qwen3", "qwen3-asr":
             modelString = Qwen3AsrModelManager.Constants.modelId
         case "applespeech", "apple", "apple-speech", "apple-speech-analyzer", "speech-analyzer":
@@ -645,38 +652,6 @@ class TranscriptionProviderRouter {
         modelId == "apple-speech-analyzer"
     }
 
-    /// Safety-net fallback used when a local model is selected for this
-    /// transcription but isn't actually downloaded (e.g. a mode still points
-    /// at a Parakeet model that was evicted from disk). Always resolves to
-    /// the built-in HyperWhisper Cloud provider — the same "no local model,
-    /// cloud fallback" promise the Models scan log makes — rather than
-    /// whatever BYOK cloud provider the mode's `cloudProvider` field might
-    /// name, since that field only applies when `mode.model == "cloud"`.
-    private func selectCloudFallbackProvider() async throws -> TranscriptionProvider {
-        ensureHyperWhisperCloudProvider()
-        guard let hwProvider = hyperwhisperCloudProvider else {
-            throw TranscriptionError.providerNotAvailable(provider: "HyperWhisper Cloud", reason: "Failed to initialize provider")
-        }
-
-        if let healthManager = providerHealthManager {
-            let status = await healthManager.ensureHealthy(CloudProvider.hyperwhisper)
-            if !status.isHealthy {
-                AppLogger.network.error("Cloud fallback provider not healthy · status=\(status.statusText, privacy: .public)")
-                throw errorForHealthStatus(status, providerDisplayName: CloudProvider.hyperwhisper.displayName)
-            }
-        }
-
-        guard hwProvider.isAvailable else {
-            throw TranscriptionError.providerNotAvailable(provider: hwProvider.name, reason: "Provider is not configured or ready")
-        }
-
-        guard NetworkStatus.shared.isOnline else {
-            throw TranscriptionError.transientNetwork(details: "No internet connection")
-        }
-
-        return hwProvider
-    }
-
     /// Select local provider based on model ID
     /// DECISION TREE:
     /// - If model ID maps to WhisperModel enum → Use LibWhisperProvider
@@ -751,38 +726,14 @@ class TranscriptionProviderRouter {
                 }
             }
 
-            // MODEL AVAILABILITY GATE (HYPERWHISPER-SV / HYPERWHISPER-TD):
-            // A mode can point at a Parakeet model that isn't downloaded yet
-            // (fresh install) or was evicted from disk after being downloaded.
-            // Previously this fell straight into `prepareIfNeeded`, which
-            // throws `.modelNotDownloaded` and fails the whole transcription
-            // instead of honouring the "no local model, will use cloud
-            // fallback" contract. Kick off the download (same `startDownload`
-            // the Models UI uses) and route *this* transcription to
-            // HyperWhisper Cloud so the user still gets a result.
-            if let parakeetModelManager, !parakeetModelManager.isModelInstalled(modelId) {
-                AppLogger.transcription.warning("⚠️ Parakeet model not downloaded (\(modelId, privacy: .public)) — starting download and falling back to cloud for this transcription")
-                await MainActor.run {
-                    parakeetModelManager.startDownload(modelId)
-                }
-                return try await selectCloudFallbackProvider()
-            }
-
-            do {
-                // Pass specific modelId to prepare the correct version (V2 or V3)
-                try await parakeetProvider.prepareIfNeeded(language: language, modelId: modelId)
-                AppLogger.transcription.info("✅ Parakeet provider selected for model: \(modelId)")
-                return parakeetProvider
-            } catch TranscriptionError.modelNotDownloaded {
-                // Defensive: model could be evicted between the check above and prepare.
-                AppLogger.transcription.warning("⚠️ Parakeet model disappeared during prepare — falling back to cloud")
-                if let parakeetModelManager {
-                    await MainActor.run {
-                        parakeetModelManager.startDownload(modelId)
-                    }
-                }
-                return try await selectCloudFallbackProvider()
-            }
+            // Keep explicit local selection local. `prepareIfNeeded` resolves
+            // legacy Parakeet aliases by version and throws
+            // `.modelNotDownloaded` if the corresponding weights are absent.
+            // That avoids silently uploading audio or starting a download
+            // without user consent.
+            try await parakeetProvider.prepareIfNeeded(language: language, modelId: modelId)
+            AppLogger.transcription.info("✅ Parakeet provider selected for model: \(modelId)")
+            return parakeetProvider
         }
 
         AppLogger.transcription.warning("⚠️ Unknown local model: \(modelId, privacy: .public)")

--- a/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionProviderRouter.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Coordinators/TranscriptionProviderRouter.swift
@@ -645,6 +645,38 @@ class TranscriptionProviderRouter {
         modelId == "apple-speech-analyzer"
     }
 
+    /// Safety-net fallback used when a local model is selected for this
+    /// transcription but isn't actually downloaded (e.g. a mode still points
+    /// at a Parakeet model that was evicted from disk). Always resolves to
+    /// the built-in HyperWhisper Cloud provider — the same "no local model,
+    /// cloud fallback" promise the Models scan log makes — rather than
+    /// whatever BYOK cloud provider the mode's `cloudProvider` field might
+    /// name, since that field only applies when `mode.model == "cloud"`.
+    private func selectCloudFallbackProvider() async throws -> TranscriptionProvider {
+        ensureHyperWhisperCloudProvider()
+        guard let hwProvider = hyperwhisperCloudProvider else {
+            throw TranscriptionError.providerNotAvailable(provider: "HyperWhisper Cloud", reason: "Failed to initialize provider")
+        }
+
+        if let healthManager = providerHealthManager {
+            let status = await healthManager.ensureHealthy(CloudProvider.hyperwhisper)
+            if !status.isHealthy {
+                AppLogger.network.error("Cloud fallback provider not healthy · status=\(status.statusText, privacy: .public)")
+                throw errorForHealthStatus(status, providerDisplayName: CloudProvider.hyperwhisper.displayName)
+            }
+        }
+
+        guard hwProvider.isAvailable else {
+            throw TranscriptionError.providerNotAvailable(provider: hwProvider.name, reason: "Provider is not configured or ready")
+        }
+
+        guard NetworkStatus.shared.isOnline else {
+            throw TranscriptionError.transientNetwork(details: "No internet connection")
+        }
+
+        return hwProvider
+    }
+
     /// Select local provider based on model ID
     /// DECISION TREE:
     /// - If model ID maps to WhisperModel enum → Use LibWhisperProvider
@@ -718,10 +750,39 @@ class TranscriptionProviderRouter {
                     parakeetModelManager.refreshState()
                 }
             }
-            // Pass specific modelId to prepare the correct version (V2 or V3)
-            try await parakeetProvider.prepareIfNeeded(language: language, modelId: modelId)
-            AppLogger.transcription.info("✅ Parakeet provider selected for model: \(modelId)")
-            return parakeetProvider
+
+            // MODEL AVAILABILITY GATE (HYPERWHISPER-SV / HYPERWHISPER-TD):
+            // A mode can point at a Parakeet model that isn't downloaded yet
+            // (fresh install) or was evicted from disk after being downloaded.
+            // Previously this fell straight into `prepareIfNeeded`, which
+            // throws `.modelNotDownloaded` and fails the whole transcription
+            // instead of honouring the "no local model, will use cloud
+            // fallback" contract. Kick off the download (same `startDownload`
+            // the Models UI uses) and route *this* transcription to
+            // HyperWhisper Cloud so the user still gets a result.
+            if let parakeetModelManager, !parakeetModelManager.isModelInstalled(modelId) {
+                AppLogger.transcription.warning("⚠️ Parakeet model not downloaded (\(modelId, privacy: .public)) — starting download and falling back to cloud for this transcription")
+                await MainActor.run {
+                    parakeetModelManager.startDownload(modelId)
+                }
+                return try await selectCloudFallbackProvider()
+            }
+
+            do {
+                // Pass specific modelId to prepare the correct version (V2 or V3)
+                try await parakeetProvider.prepareIfNeeded(language: language, modelId: modelId)
+                AppLogger.transcription.info("✅ Parakeet provider selected for model: \(modelId)")
+                return parakeetProvider
+            } catch TranscriptionError.modelNotDownloaded {
+                // Defensive: model could be evicted between the check above and prepare.
+                AppLogger.transcription.warning("⚠️ Parakeet model disappeared during prepare — falling back to cloud")
+                if let parakeetModelManager {
+                    await MainActor.run {
+                        parakeetModelManager.startDownload(modelId)
+                    }
+                }
+                return try await selectCloudFallbackProvider()
+            }
         }
 
         AppLogger.transcription.warning("⚠️ Unknown local model: \(modelId, privacy: .public)")

--- a/app/macos/hyperwhisper/Managers/Transcription/Models/ParakeetModelManager.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Models/ParakeetModelManager.swift
@@ -66,6 +66,31 @@ final class ParakeetModelManager: ObservableObject {
 
         // Backward compatibility: default to V3
         static let modelId = v3ModelId
+
+        /// Resolve supported persisted aliases to the exact identifiers used
+        /// by the model library. Keep this list explicit: coercing an unknown
+        /// identifier to V3 would make a typo select a real model.
+        static func canonicalModelId(for modelId: String) -> String? {
+            switch modelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case v2ModelId:
+                return v2ModelId
+            case v3ModelId, "parakeet-tdt-v3-multilingual":
+                return v3ModelId
+            default:
+                return nil
+            }
+        }
+
+        /// Local API requests historically default an omitted Parakeet model
+        /// to V3. Preserve unknown explicit values so the provider router can
+        /// reject them instead of silently changing the requested model.
+        static func modelIdForSelection(_ modelId: String?) -> String {
+            guard let trimmed = modelId?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !trimmed.isEmpty else {
+                return v3ModelId
+            }
+            return canonicalModelId(for: trimmed) ?? trimmed
+        }
     }
 
     @Published private(set) var availableModels: [ParakeetModel] = []
@@ -117,7 +142,10 @@ final class ParakeetModelManager: ObservableObject {
     // PER-MODEL DOWNLOAD CHECK:
     // Returns true if the specific model is currently downloading
     func isDownloading(_ modelId: String) -> Bool {
-        downloads.isDownloading(modelId)
+        guard let canonicalModelId = Constants.canonicalModelId(for: modelId) else {
+            return false
+        }
+        return downloads.isDownloading(canonicalModelId)
     }
 
     // ANY MODEL INSTALLED:
@@ -129,13 +157,19 @@ final class ParakeetModelManager: ObservableObject {
     // SPECIFIC MODEL INSTALLED:
     // Returns true if the specified model ID is downloaded
     func isModelInstalled(_ modelId: String) -> Bool {
-        availableModels.first { $0.id == modelId }?.isDownloaded ?? false
+        guard let canonicalModelId = Constants.canonicalModelId(for: modelId) else {
+            return false
+        }
+        return availableModels.first { $0.id == canonicalModelId }?.isDownloaded ?? false
     }
 
     // VERSION DETECTION HELPER:
     // Determines AsrModelVersion based on model name string
-    private func version(for modelName: String) -> AsrModelVersion {
-        modelName.lowercased().contains("v2") ? .v2 : .v3
+    private func version(for modelName: String) -> AsrModelVersion? {
+        guard let canonicalModelId = Constants.canonicalModelId(for: modelName) else {
+            return nil
+        }
+        return canonicalModelId == Constants.v2ModelId ? .v2 : .v3
     }
 
     // CACHE DIRECTORY HELPER:
@@ -191,8 +225,13 @@ final class ParakeetModelManager: ObservableObject {
     // Each version downloads independently, keyed by modelId.
     @MainActor
     func startDownload(_ modelId: String) {
-        downloads.start(modelId) { [weak self] controller in
-            await self?.runDownload(modelId, controller)
+        guard let canonicalModelId = Constants.canonicalModelId(for: modelId) else {
+            logger.error("Refusing to download unknown Parakeet model \(modelId, privacy: .public)")
+            errorMessage = "Unknown Parakeet model: \(modelId)"
+            return
+        }
+        downloads.start(canonicalModelId) { [weak self] controller in
+            await self?.runDownload(canonicalModelId, controller)
         }
     }
 
@@ -201,8 +240,12 @@ final class ParakeetModelManager: ObservableObject {
     /// `runDownload(_:_:)` then unwinds silently.
     @MainActor
     func cancelDownload(_ modelId: String) {
-        logger.info("Cancelling Parakeet download \(modelId, privacy: .public)")
-        downloads.cancel(modelId)
+        guard let canonicalModelId = Constants.canonicalModelId(for: modelId) else {
+            logger.warning("Ignoring cancellation for unknown Parakeet model \(modelId, privacy: .public)")
+            return
+        }
+        logger.info("Cancelling Parakeet download \(canonicalModelId, privacy: .public)")
+        downloads.cancel(canonicalModelId)
     }
 
     // DOWNLOAD SPECIFIC MODEL:
@@ -216,7 +259,11 @@ final class ParakeetModelManager: ObservableObject {
     @MainActor
     private func runDownload(_ modelId: String, _ controller: DownloadController<String>) async {
         errorMessage = nil
-        let modelVersion = version(for: modelId)
+        guard let modelVersion = version(for: modelId) else {
+            logger.error("Refusing to run download for unknown Parakeet model \(modelId, privacy: .public)")
+            errorMessage = "Unknown Parakeet model: \(modelId)"
+            return
+        }
         logger.info("Starting download for Parakeet \(String(describing: modelVersion))")
 
         // `AsrModels.download` sweeps each component's raw fraction 0→1 in turn,
@@ -259,7 +306,11 @@ final class ParakeetModelManager: ObservableObject {
     // Does not affect other versions
     @MainActor
     func deleteModel(_ modelId: String) {
-        let modelVersion = version(for: modelId)
+        guard let modelVersion = version(for: modelId) else {
+            logger.error("Refusing to delete unknown Parakeet model \(modelId, privacy: .public)")
+            errorMessage = "Unknown Parakeet model: \(modelId)"
+            return
+        }
         let directory = cacheDirectory(for: modelVersion)
 
         do {

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Models.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Models.swift
@@ -71,9 +71,32 @@ extension TranscriptionPipeline {
     /// Re-evaluate the selected Parakeet mode after its installed-model state changes.
     @MainActor
     func refreshParakeetReadiness(forModeId modeId: String?) async {
-        guard let modeId, UUID(uuidString: modeId) != nil,
-              let mode = await PersistenceController.shared.fetchModeInBackground(withId: modeId),
-              ParakeetModelManager.Constants.canonicalModelId(for: mode.model ?? "") != nil else {
+        guard let modeId, UUID(uuidString: modeId) != nil else {
+            return
+        }
+
+        pendingParakeetReadinessModeId = modeId
+        await refreshPendingParakeetReadinessIfReady()
+    }
+
+    /// Apply a queued readiness refresh only when it cannot cancel active work.
+    @MainActor
+    func refreshPendingParakeetReadinessIfReady() async {
+        guard state_isReadyForTranscription(),
+              let modeId = pendingParakeetReadinessModeId,
+              let mode = await PersistenceController.shared.fetchModeInBackground(withId: modeId) else {
+            return
+        }
+
+        // The background fetch yields. Recheck both state and request identity
+        // before invoking prepareModel, which intentionally cancels stale work.
+        guard state_isReadyForTranscription(),
+              pendingParakeetReadinessModeId == modeId else {
+            return
+        }
+        pendingParakeetReadinessModeId = nil
+
+        guard ParakeetModelManager.Constants.canonicalModelId(for: mode.model ?? "") != nil else {
             return
         }
 

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Models.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Models.swift
@@ -68,6 +68,18 @@ extension TranscriptionPipeline {
         await modelCoordinator.refreshLocalRuntime(forModeId: modeId)
     }
 
+    /// Re-evaluate the selected Parakeet mode after its installed-model state changes.
+    @MainActor
+    func refreshParakeetReadiness(forModeId modeId: String?) async {
+        guard let modeId, UUID(uuidString: modeId) != nil,
+              let mode = await PersistenceController.shared.fetchModeInBackground(withId: modeId),
+              ParakeetModelManager.Constants.canonicalModelId(for: mode.model ?? "") != nil else {
+            return
+        }
+
+        await prepareModel(for: mode)
+    }
+
     /// Delete a downloaded model to free up space.
     func deleteModel(_ model: WhisperModel) throws {
         try modelCoordinator.deleteModel(model)

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Models.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Models.swift
@@ -83,15 +83,26 @@ extension TranscriptionPipeline {
     @MainActor
     func refreshPendingParakeetReadinessIfReady() async {
         guard state_isReadyForTranscription(),
-              let modeId = pendingParakeetReadinessModeId,
-              let mode = await PersistenceController.shared.fetchModeInBackground(withId: modeId) else {
+              let modeId = pendingParakeetReadinessModeId else {
+            return
+        }
+        guard appState?.selectedModeId == modeId else {
+            pendingParakeetReadinessModeId = nil
+            return
+        }
+        guard let mode = await PersistenceController.shared.fetchModeInBackground(withId: modeId) else {
             return
         }
 
         // The background fetch yields. Recheck both state and request identity
         // before invoking prepareModel, which intentionally cancels stale work.
         guard state_isReadyForTranscription(),
-              pendingParakeetReadinessModeId == modeId else {
+              pendingParakeetReadinessModeId == modeId,
+              appState?.selectedModeId == modeId else {
+            if pendingParakeetReadinessModeId == modeId,
+               appState?.selectedModeId != modeId {
+                pendingParakeetReadinessModeId = nil
+            }
             return
         }
         pendingParakeetReadinessModeId = nil

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline.swift
@@ -59,7 +59,17 @@ class TranscriptionPipeline: ObservableObject {
     @Published var selectedProvider: TranscriptionProviderType = .local
 
     /// Current manager state (idle, transcribing, error, etc).
-    @Published var state: TranscriptionState = .idle
+    @Published var state: TranscriptionState = .idle {
+        didSet {
+            guard pendingParakeetReadinessModeId != nil,
+                  state_isReadyForTranscription() else {
+                return
+            }
+            Task { @MainActor [weak self] in
+                await self?.refreshPendingParakeetReadinessIfReady()
+            }
+        }
+    }
 
     /// Available Whisper models for local transcription.
     @Published var availableModels: [WhisperModel] = []
@@ -121,6 +131,9 @@ class TranscriptionPipeline: ObservableObject {
 
     /// Current transcription task (for cancellation).
     var currentTask: Task<TranscriptionResult, Error>?
+
+    /// Selected mode awaiting a safe Parakeet readiness refresh.
+    var pendingParakeetReadinessModeId: String?
 
     // MARK: - Persisted Settings
 

--- a/app/macos/hyperwhisper/Managers/Transcription/Providers/Local/ParakeetProvider.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Providers/Local/ParakeetProvider.swift
@@ -171,8 +171,11 @@ final class ParakeetProvider: TranscriptionProvider {
     // VERSION DETECTION HELPER:
     // Determines AsrModelVersion from model ID string
     // Matches the pattern used in ParakeetModelManager
-    private func version(for modelId: String) -> AsrModelVersion {
-        modelId.lowercased().contains("v2") ? .v2 : .v3
+    private func version(for modelId: String) -> AsrModelVersion? {
+        guard let canonicalModelId = ParakeetModelManager.Constants.canonicalModelId(for: modelId) else {
+            return nil
+        }
+        return canonicalModelId == ParakeetModelManager.Constants.v2ModelId ? .v2 : .v3
     }
 
     // ANY VERSION AVAILABLE:
@@ -186,7 +189,9 @@ final class ParakeetProvider: TranscriptionProvider {
     // SPECIFIC VERSION AVAILABLE:
     // Returns true if the specified model is downloaded
     func isAvailable(for modelId: String) -> Bool {
-        let targetVersion = version(for: modelId)
+        guard let targetVersion = version(for: modelId) else {
+            return false
+        }
         return AsrModels.modelsExist(at: AsrModels.defaultCacheDirectory(for: targetVersion))
     }
 
@@ -203,7 +208,13 @@ final class ParakeetProvider: TranscriptionProvider {
     func prepareIfNeeded(language: String?, modelId: String? = nil) async throws {
         let targetVersion: AsrModelVersion
         if let modelId {
-            targetVersion = version(for: modelId)
+            guard let version = version(for: modelId) else {
+                throw TranscriptionError.providerNotAvailable(
+                    provider: "Parakeet",
+                    reason: "Unknown Parakeet model '\(modelId)'"
+                )
+            }
+            targetVersion = version
         } else {
             // Default to V3 for backward compatibility
             targetVersion = .v3
@@ -233,7 +244,12 @@ final class ParakeetProvider: TranscriptionProvider {
     func transcribe(audioURL: URL, language: String?, mode: Mode?, vocabulary: [Vocabulary]) async throws -> String {
         // STEP 1: Determine which version to use from mode
         let modelId = mode?.model ?? ParakeetModelManager.Constants.v3ModelId
-        let targetVersion = version(for: modelId)
+        guard let targetVersion = version(for: modelId) else {
+            throw TranscriptionError.providerNotAvailable(
+                provider: "Parakeet",
+                reason: "Unknown Parakeet model '\(modelId)'"
+            )
+        }
 
         // STEP 2: Verify model is downloaded
         let directory = AsrModels.defaultCacheDirectory(for: targetVersion)

--- a/app/macos/hyperwhisper/Views/Components/ModelStatusBar.swift
+++ b/app/macos/hyperwhisper/Views/Components/ModelStatusBar.swift
@@ -112,6 +112,23 @@ struct ModelStatusBar: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.tertiary)
                 }
+
+            case .unavailable(let name):
+                Circle()
+                    .fill(Color.orange)
+                    .frame(width: 6, height: 6)
+                Text(name)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                Button {
+                    appState.navigate(to: .modelLibrary)
+                } label: {
+                    Text("(\("settings.models.download".localized))")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .help("transcription.guidance.modelNotDownloaded".localized)
             }
         }
     }

--- a/app/macos/hyperwhisper/hyperwhisperApp.swift
+++ b/app/macos/hyperwhisper/hyperwhisperApp.swift
@@ -9,6 +9,7 @@
 //  It sets up both the main window and the menu bar functionality.
 
 import SwiftUI
+import Combine
 import KeyboardShortcuts
 import AppKit  // Required for NSApplication and menu bar functionality
 import CoreData  // Required for Core Data persistence
@@ -316,6 +317,17 @@ struct MenuBarIconView: View {
                 }
                 .onReceive(parakeetModelManager.$availableModels) { _ in
                     transcriptionPipeline.rescanAvailableLocalModels()
+                }
+                .onReceive(
+                    parakeetModelManager.$availableModels
+                        .dropFirst()
+                        .removeDuplicates()
+                ) { _ in
+                    Task { @MainActor in
+                        await transcriptionPipeline.refreshParakeetReadiness(
+                            forModeId: appState.selectedModeId
+                        )
+                    }
                 }
                 .onReceive(qwen3AsrModelManager.$isDownloaded) { _ in
                     transcriptionPipeline.rescanAvailableLocalModels()

--- a/app/macos/hyperwhisperTests/ParakeetModelIdentifierTests.swift
+++ b/app/macos/hyperwhisperTests/ParakeetModelIdentifierTests.swift
@@ -1,0 +1,64 @@
+//
+//  ParakeetModelIdentifierTests.swift
+//  hyperwhisperTests
+//
+
+import Testing
+@testable import HyperWhisper
+
+@MainActor
+struct ParakeetModelIdentifierTests {
+
+    @Test func missingAndBlankSelectionModelIdsDefaultToCanonicalV3() {
+        #expect(
+            ParakeetModelManager.Constants.modelIdForSelection(nil)
+                == ParakeetModelManager.Constants.v3ModelId
+        )
+        #expect(
+            ParakeetModelManager.Constants.modelIdForSelection("  ")
+                == ParakeetModelManager.Constants.v3ModelId
+        )
+    }
+
+    @Test func legacyAliasesNormalizeToInstalledModelIdentifiers() {
+        #expect(
+            ParakeetModelManager.Constants.canonicalModelId(
+                for: "parakeet-tdt-v3-multilingual"
+            ) == ParakeetModelManager.Constants.v3ModelId
+        )
+    }
+
+    @Test func canonicalIdentifiersRemainStable() {
+        #expect(
+            ParakeetModelManager.Constants.canonicalModelId(
+                for: ParakeetModelManager.Constants.v2ModelId
+            ) == ParakeetModelManager.Constants.v2ModelId
+        )
+        #expect(
+            ParakeetModelManager.Constants.canonicalModelId(
+                for: ParakeetModelManager.Constants.v3ModelId
+            ) == ParakeetModelManager.Constants.v3ModelId
+        )
+    }
+
+    @Test func unknownAndTypoIdentifiersAreNotCoercedToInstalledModels() {
+        #expect(
+            ParakeetModelManager.Constants.canonicalModelId(
+                for: "parakeet-tdt-v2-english"
+            ) == nil
+        )
+        #expect(
+            ParakeetModelManager.Constants.canonicalModelId(
+                for: "parakeet-tdt-v4-multilingual"
+            ) == nil
+        )
+        #expect(
+            ParakeetModelManager.Constants.canonicalModelId(
+                for: "typo"
+            ) == nil
+        )
+        #expect(
+            ParakeetModelManager.Constants.modelIdForSelection("typo") == "typo"
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Sentry HYPERWHISPER-TD (\"Parakeet prepare failed\", 121 events / 28 users, still firing on 2.41.0) and HYPERWHISPER-SV (\"model_not_downloaded at select_provider\") share a root cause: a Parakeet-backed transcription mode gets selected/prepared while no Parakeet model is downloaded locally (or it was evicted from disk), and the code logs \"will use cloud fallback\" but then still calls straight into Parakeet's \`prepareIfNeeded\`, which throws \`modelNotDownloaded\` instead of actually falling back to cloud.

Two call sites had this bug:
- \`TranscriptionModelManager.prepareModel\` (Parakeet branch, ~line 196-204) — invoked from app launch / mode switch / record-start prewarm. The generic catch here is what reports \"Failed to prepare Parakeet provider\" to Sentry as HYPERWHISPER-TD.
- \`TranscriptionProviderRouter.selectLocalProvider\` (~line 711-725) — the actual \`select_provider\` transcription-time path, root cause of HYPERWHISPER-SV.

## Fix

- \`TranscriptionProviderRouter.selectLocalProvider\`: check \`parakeetModelManager.isModelInstalled(modelId)\` before touching the runtime. If not installed, kick off \`startDownload(modelId)\` (same API the Models UI already uses) and return a real cloud fallback provider instead of throwing. Added a defensive catch for \`modelNotDownloaded\` around the actual \`prepareIfNeeded\` call to cover a disk-eviction race between the check and the call.
- \`TranscriptionModelManager.prepareModel\`: added a specific catch for \`modelNotDownloaded\` in the Parakeet branch that starts the download, sets ready state to a real \"Cloud\" fallback, and surfaces a plain-language status message — instead of falling into the generic catch that Sentry-reports it as a crash.

Net effect: the \"will use cloud fallback\" log message is now backed by real behavior, and selecting a Parakeet mode with no local model auto-triggers a download instead of silently failing.

## Verification

No macOS/Xcode toolchain available in this sandbox to compile/run tests. Traced types manually end-to-end (including fixing an ambiguous-overload issue on \`ensureHealthy(.hyperwhisper)\` introduced by the cloud-fallback path). No existing test harness covers this MainActor-isolated, FluidAudio-dependent routing code (existing tests only cover pure logic elsewhere), so no test was added rather than ship unverifiable scaffolding. **Recommend a real Xcode build/typecheck on this branch before merging.**

Refs: HYPERWHISPER-TD, HYPERWHISPER-SV

---
Requested in Slack. Opened by Claude running in a Percy sandbox.