### PR TITLE
Fix launch-time license validation network resilience (HYPERWHISPER-F4)

### DIFF
--- a/app/macos/hyperwhisper/Configuration/NetworkConfig.swift
+++ b/app/macos/hyperwhisper/Configuration/NetworkConfig.swift
@@ -109,6 +109,26 @@ struct NetworkConfig {
     /// point of the tighter launch-time budget. HYPERWHISPER-F4.
     static let licenseLaunchValidationTimeout: TimeInterval = 2.5
 
+    /// Delay before `LicenseManager` retries launch-time license validation
+    /// again in the background, after the first attempt exhausted its retries
+    /// due to a genuine connectivity failure and fell back to a cached (or
+    /// Invalid) verdict.
+    ///
+    /// The tight `licenseLaunchValidationTimeout` + `.licenseLaunchValidation`
+    /// retry budget above is a deliberate trade-off: it self-heals quickly from
+    /// a truly dead network, but it can also misclassify a merely-SLOW-but-live
+    /// network (weak wifi, VPN overhead) as a network failure, since a request
+    /// that's still hanging past ~2.5s is treated as stuck rather than "about to
+    /// succeed." Without a prompt follow-up, a legitimately-licensed user who
+    /// hit that misclassification would ride the cached fallback verdict for up
+    /// to the full 24h cache TTL / 7-day offline grace before the app tries the
+    /// real server again. This short one-shot retry closes that gap: by the
+    /// time it fires, a merely-slow connection has almost certainly stabilized,
+    /// so the app promptly re-confirms against the real server instead of
+    /// silently trusting a stale-but-still-"valid"-looking cache for up to a
+    /// week. HYPERWHISPER-F4 (review round 2).
+    static let licenseLaunchValidationRetrySoonDelay: TimeInterval = 45
+
     // MARK: - Caching and Retry Configuration
     
     /// Duration to cache successful license validation (24 hours)

--- a/app/macos/hyperwhisper/Configuration/NetworkConfig.swift
+++ b/app/macos/hyperwhisper/Configuration/NetworkConfig.swift
@@ -98,15 +98,11 @@ struct NetworkConfig {
     /// Per-request timeout for the silent, launch-time license revalidation
     /// (`LicenseNetworkService.validateLicense(_:isLaunchValidation: true)`).
     ///
-    /// Deliberately much shorter than `licenseValidationTimeout`: this call races
-    /// a network that may not be up yet (wake-from-sleep, captive portal, DNS not
-    /// resolved yet), so a request that's still hanging several seconds in is
-    /// almost certainly stuck on a dead network, not about to succeed — there's
-    /// no benefit to holding the full 10s per attempt. Paired with the short
-    /// `.licenseLaunchValidation` backoff, this keeps the worst case (all 3
-    /// attempts time out) to single-digit seconds instead of the ~30s that
-    /// `licenseValidationTimeout` × 3 attempts would otherwise cost — the whole
-    /// point of the tighter launch-time budget. HYPERWHISPER-F4.
+    /// Deliberately much shorter than `licenseValidationTimeout`. This is used
+    /// only when launch-time revalidation has a cached server verdict within the
+    /// offline grace period. If no usable cache exists, launch validation keeps
+    /// the normal timeout so a slow-but-live network is not mistaken for an
+    /// invalid license.
     static let licenseLaunchValidationTimeout: TimeInterval = 2.5
 
     /// Delay before `LicenseManager` retries launch-time license validation

--- a/app/macos/hyperwhisper/Configuration/NetworkConfig.swift
+++ b/app/macos/hyperwhisper/Configuration/NetworkConfig.swift
@@ -94,7 +94,21 @@ struct NetworkConfig {
     /// Timeout for license validation calls (in seconds)
     /// Shorter timeout to prevent blocking UI
     static let licenseValidationTimeout: TimeInterval = 10
-    
+
+    /// Per-request timeout for the silent, launch-time license revalidation
+    /// (`LicenseNetworkService.validateLicense(_:isLaunchValidation: true)`).
+    ///
+    /// Deliberately much shorter than `licenseValidationTimeout`: this call races
+    /// a network that may not be up yet (wake-from-sleep, captive portal, DNS not
+    /// resolved yet), so a request that's still hanging several seconds in is
+    /// almost certainly stuck on a dead network, not about to succeed — there's
+    /// no benefit to holding the full 10s per attempt. Paired with the short
+    /// `.licenseLaunchValidation` backoff, this keeps the worst case (all 3
+    /// attempts time out) to single-digit seconds instead of the ~30s that
+    /// `licenseValidationTimeout` × 3 attempts would otherwise cost — the whole
+    /// point of the tighter launch-time budget. HYPERWHISPER-F4.
+    static let licenseLaunchValidationTimeout: TimeInterval = 2.5
+
     // MARK: - Caching and Retry Configuration
     
     /// Duration to cache successful license validation (24 hours)

--- a/app/macos/hyperwhisper/Managers/LicenseManager.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseManager.swift
@@ -99,18 +99,27 @@ class LicenseManager: ObservableObject {
     }
 
     /// Validates a license key with the backend.
-    func validateLicense(_ licenseKey: String) async -> LicenseValidationResult {
+    /// - Parameter isLaunchValidation: forwarded to `LicenseNetworkService` — `true`
+    ///   only for the silent background revalidation `loadStoredLicense()` fires at
+    ///   launch, selecting its tighter retry budget. See HYPERWHISPER-F4.
+    func validateLicense(_ licenseKey: String, isLaunchValidation: Bool = false) async -> LicenseValidationResult {
         isValidating = true
         lastError = nil
         defer { isValidating = false }
 
-        let result = await networkService.validateLicense(licenseKey)
+        let result = await networkService.validateLicense(licenseKey, isLaunchValidation: isLaunchValidation)
         await processValidationResult(result)
 
         return result
     }
 
     /// Loads stored license from UserDefaults, revalidates if cache expired (24h).
+    ///
+    /// The revalidation call is tagged `isLaunchValidation: true` so a stale
+    /// network at launch (wake-from-sleep, captive portal, DNS not up yet) gets a
+    /// short bounded retry and — if that's still not enough — falls back to the
+    /// last cached server verdict instead of leaving `licenseStatus` stuck at its
+    /// default `.trial` for the whole `.cloud` retry budget. HYPERWHISPER-F4.
     func loadStoredLicense() async {
         guard let storedKey = networkService.getStoredLicenseKey() else {
             licenseStatus = .trial
@@ -118,7 +127,7 @@ class LicenseManager: ObservableObject {
         }
 
         if networkService.shouldRevalidateLicense() {
-            _ = await validateLicense(storedKey)
+            _ = await validateLicense(storedKey, isLaunchValidation: true)
         } else if let cachedStatus = networkService.getCachedLicenseStatus() {
             licenseStatus = cachedStatus
         }

--- a/app/macos/hyperwhisper/Managers/LicenseManager.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseManager.swift
@@ -59,6 +59,14 @@ class LicenseManager: ObservableObject {
     /// Network service for license API calls
     private let networkService: LicenseNetworkService
 
+    /// One-shot background retry, scheduled only when launch-time validation
+    /// fell back to a cached verdict because of a genuine network failure (see
+    /// `loadStoredLicense()`). Held so a second `loadStoredLicense()` call
+    /// (unlikely in practice — `LicenseManager` is a long-lived singleton — but
+    /// possible in tests) cancels any still-pending retry rather than stacking
+    /// them. HYPERWHISPER-F4 (review round 2).
+    private var networkFailureRetryTask: Task<Void, Never>?
+
     // MARK: - Initialization
 
     init() {
@@ -120,6 +128,11 @@ class LicenseManager: ObservableObject {
     /// short bounded retry and — if that's still not enough — falls back to the
     /// last cached server verdict instead of leaving `licenseStatus` stuck at its
     /// default `.trial` for the whole `.cloud` retry budget. HYPERWHISPER-F4.
+    ///
+    /// If that fallback happened specifically because the network couldn't be
+    /// reached (`result.networkFailureFallback`), a short background retry is
+    /// scheduled — see `scheduleRetrySoonAfterNetworkFallback`. HYPERWHISPER-F4
+    /// (review round 2).
     func loadStoredLicense() async {
         guard let storedKey = networkService.getStoredLicenseKey() else {
             licenseStatus = .trial
@@ -127,9 +140,45 @@ class LicenseManager: ObservableObject {
         }
 
         if networkService.shouldRevalidateLicense() {
-            _ = await validateLicense(storedKey, isLaunchValidation: true)
+            let result = await validateLicense(storedKey, isLaunchValidation: true)
+            if result.networkFailureFallback {
+                scheduleRetrySoonAfterNetworkFallback(licenseKey: storedKey)
+            }
         } else if let cachedStatus = networkService.getCachedLicenseStatus() {
             licenseStatus = cachedStatus
+        }
+    }
+
+    /// Schedules ONE short, background revalidation after launch-time
+    /// validation fell back to a cached (or Invalid) verdict due to a genuine
+    /// network failure, rather than waiting out the full 24h cache TTL / 7-day
+    /// offline grace before trying the real server again.
+    ///
+    /// A merely-slow-but-live network (weak wifi, VPN overhead) can trip the
+    /// deliberately tight launch-time timeout/retry budget
+    /// (`NetworkConfig.licenseLaunchValidationTimeout` +
+    /// `.licenseLaunchValidation`) without the user actually being offline —
+    /// that budget is tuned for a fast self-heal, not for correctly
+    /// distinguishing "dead" from "slow." Without this follow-up, a
+    /// legitimately-licensed user who hit that misclassification would silently
+    /// ride the cached fallback for up to a week. By the time this fires, a
+    /// merely-slow connection has almost certainly stabilized, so this quietly
+    /// re-confirms against the real server. Deliberately a simple one-shot
+    /// delayed `Task` rather than wiring up `NetworkStatus`/reachability
+    /// observation — a single retry in the background costs nothing extra if
+    /// the network happens to still be down (it just repeats the same
+    /// fallback), and avoids the added complexity of debouncing a
+    /// possibly-flapping reachability signal for what is already a rare edge
+    /// case. HYPERWHISPER-F4 (review round 2).
+    private func scheduleRetrySoonAfterNetworkFallback(licenseKey: String) {
+        networkFailureRetryTask?.cancel()
+        networkFailureRetryTask = Task { [weak self] in
+            let delayNanoseconds = UInt64(NetworkConfig.licenseLaunchValidationRetrySoonDelay * 1_000_000_000)
+            try? await Task.sleep(nanoseconds: delayNanoseconds)
+            guard let self, !Task.isCancelled else { return }
+
+            AppLogger.network.info("License validation · retrying soon after launch-time network-failure fallback")
+            _ = await self.validateLicense(licenseKey, isLaunchValidation: true)
         }
     }
 

--- a/app/macos/hyperwhisper/Managers/LicenseManager.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseManager.swift
@@ -206,7 +206,11 @@ class LicenseManager: ObservableObject {
             guard self.networkService.getStoredLicenseKey() == licenseKey else { return }
 
             AppLogger.network.info("License validation · retrying soon after launch-time network-failure fallback")
-            let result = await self.networkService.validateLicense(licenseKey, isLaunchValidation: true)
+            let result = await self.networkService.validateLicense(
+                licenseKey,
+                isLaunchValidation: true,
+                expectedStoredLicenseKey: licenseKey
+            )
 
             // Activation, deactivation, backup restore, or another validation
             // may have changed the key while the request was in flight. Never

--- a/app/macos/hyperwhisper/Managers/LicenseManager.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseManager.swift
@@ -66,6 +66,7 @@ class LicenseManager: ObservableObject {
     /// possible in tests) cancels any still-pending retry rather than stacking
     /// them. HYPERWHISPER-F4 (review round 2).
     private var networkFailureRetryTask: Task<Void, Never>?
+    private var networkFailureRetryID: UUID?
 
     // MARK: - Initialization
 
@@ -82,6 +83,7 @@ class LicenseManager: ObservableObject {
 
     /// Activates a license key by validating it with the backend.
     func activateLicense(_ licenseKey: String) async -> LicenseValidationResult {
+        cancelNetworkFailureRetry()
         isValidating = true
         lastError = nil
         defer { isValidating = false }
@@ -93,6 +95,7 @@ class LicenseManager: ObservableObject {
 
     /// Deactivates the license locally (clears UserDefaults).
     func deactivateLicense() async -> Bool {
+        cancelNetworkFailureRetry()
         isDeactivating = true
         lastError = nil
         defer { isDeactivating = false }
@@ -111,6 +114,9 @@ class LicenseManager: ObservableObject {
     ///   only for the silent background revalidation `loadStoredLicense()` fires at
     ///   launch, selecting its tighter retry budget. See HYPERWHISPER-F4.
     func validateLicense(_ licenseKey: String, isLaunchValidation: Bool = false) async -> LicenseValidationResult {
+        if !isLaunchValidation {
+            cancelNetworkFailureRetry()
+        }
         isValidating = true
         lastError = nil
         defer { isValidating = false }
@@ -140,6 +146,14 @@ class LicenseManager: ObservableObject {
         }
 
         if networkService.shouldRevalidateLicense() {
+            // Publish the still-usable cached verdict before awaiting the live
+            // refresh. Otherwise the manager remains at its default `.trial`
+            // throughout the request/retry budget even though a server-issued
+            // verdict is available within the offline grace period.
+            if let cachedStatus = networkService.getCachedLicenseStatus() {
+                licenseStatus = cachedStatus
+            }
+
             let result = await validateLicense(storedKey, isLaunchValidation: true)
             if result.networkFailureFallback {
                 scheduleRetrySoonAfterNetworkFallback(licenseKey: storedKey)
@@ -171,19 +185,44 @@ class LicenseManager: ObservableObject {
     /// possibly-flapping reachability signal for what is already a rare edge
     /// case. HYPERWHISPER-F4 (review round 2).
     private func scheduleRetrySoonAfterNetworkFallback(licenseKey: String) {
-        networkFailureRetryTask?.cancel()
+        cancelNetworkFailureRetry()
+        let retryID = UUID()
+        networkFailureRetryID = retryID
         networkFailureRetryTask = Task { [weak self] in
+            defer {
+                if let self, self.networkFailureRetryID == retryID {
+                    self.networkFailureRetryTask = nil
+                    self.networkFailureRetryID = nil
+                }
+            }
+
             let delayNanoseconds = UInt64(NetworkConfig.licenseLaunchValidationRetrySoonDelay * 1_000_000_000)
             try? await Task.sleep(nanoseconds: delayNanoseconds)
-            guard let self, !Task.isCancelled else { return }
+            guard let self,
+                  !Task.isCancelled,
+                  self.networkFailureRetryID == retryID else {
+                return
+            }
+            guard self.networkService.getStoredLicenseKey() == licenseKey else { return }
 
             AppLogger.network.info("License validation · retrying soon after launch-time network-failure fallback")
-            _ = await self.validateLicense(licenseKey, isLaunchValidation: true)
+            let result = await self.networkService.validateLicense(licenseKey, isLaunchValidation: true)
+
+            // Activation, deactivation, backup restore, or another validation
+            // may have changed the key while the request was in flight. Never
+            // let a stale retry overwrite the current key's published state.
+            guard !Task.isCancelled,
+                  self.networkFailureRetryID == retryID,
+                  self.networkService.getStoredLicenseKey() == licenseKey else {
+                return
+            }
+            self.processValidationResult(result)
         }
     }
 
     /// Clears stored license and resets to the unlicensed (trial) state.
     func clearLicense() {
+        cancelNetworkFailureRetry()
         networkService.clearStoredLicense()
         licenseStatus = .trial
         customerEmail = nil
@@ -193,6 +232,12 @@ class LicenseManager: ObservableObject {
     }
 
     // MARK: - Private
+
+    private func cancelNetworkFailureRetry() {
+        networkFailureRetryID = nil
+        networkFailureRetryTask?.cancel()
+        networkFailureRetryTask = nil
+    }
 
     /// Updates UI state from validation result and posts notification.
     private func processValidationResult(_ result: LicenseValidationResult) {

--- a/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
@@ -133,19 +133,21 @@ class LicenseNetworkService {
         // core-built body. `createRequest` defaults to POST + JSON content type,
         // matching the core's request.
         //
-        // The per-request timeout is also split by call site (like the retry
-        // preset below): launch-time validation uses the much shorter
+        // Both the per-request timeout AND the retry preset are selected off the
+        // same `isLaunchValidation` bool via `Self.requestPolicy(isLaunchValidation:)`
+        // — a single lookup instead of two independent ternaries, so the two
+        // values (which must stay paired: a short timeout with a short retry
+        // budget, a long timeout with the long one) can't drift out of sync in a
+        // future edit. Launch-time validation uses the much shorter
         // `licenseLaunchValidationTimeout` so a hung request doesn't eat the
         // whole per-attempt budget — otherwise 3 attempts at the full 10s
         // `licenseValidationTimeout` would still cost ~30s worst case, defeating
         // the point of the tighter `.licenseLaunchValidation` retry preset.
         // HYPERWHISPER-F4.
-        let requestTimeout = isLaunchValidation
-            ? NetworkConfig.licenseLaunchValidationTimeout
-            : NetworkConfig.licenseValidationTimeout
+        let policy = Self.requestPolicy(isLaunchValidation: isLaunchValidation)
         guard var request = NetworkConfig.createRequest(
             for: NetworkConfig.licenseValidateEndpoint,
-            timeout: requestTimeout
+            timeout: policy.requestTimeout
         ) else {
             return LicenseValidationResult(
                 isValid: false,
@@ -160,7 +162,7 @@ class LicenseNetworkService {
         request.httpBody = coreRequest.body
 
         do {
-            return try await performWithRetry(config: isLaunchValidation ? .licenseLaunchValidation : .cloud) { [self] _ in
+            return try await performWithRetry(config: policy.retryConfig) { [self] _ in
                 let (data, response) = try await session.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -258,10 +260,34 @@ class LicenseNetworkService {
             // returns it as-is); it's just not an active entitlement. Gating the
             // Sentry signal below on `outcome.isValid` would misfire it for every
             // offline Expired/Invalid user even though the cache did its job.
+            //
+            // NOTE: this is a second, separate FFI read of the same underlying
+            // cache that `licenseOfflineFallbackOutcome` above just read — in
+            // principle a concurrent `clearStoredLicense()` landing between the
+            // two calls could make them disagree (e.g. `outcome` reflects the
+            // pre-clear cache while `hasCachedVerdict` reflects the post-clear
+            // empty state), which would only mislabel the diagnostic below, not
+            // the `outcome` actually returned to the caller. Narrow and
+            // theoretical (deactivation racing an in-flight offline validation),
+            // not worth a Swift-side workaround (duplicating the core's
+            // is-valid/customer-id derivation here to collapse this to one call
+            // would re-introduce cache logic on the client, which is exactly what
+            // the Rust core migration was meant to centralize). A real fix is a
+            // single combined Rust core accessor (e.g. returning the outcome
+            // alongside a `hadCache` flag from one read) — tracked as a follow-up,
+            // out of scope for this Swift-only PR. HYPERWHISPER-F4 (review round 2).
             let hasCachedVerdict = licenseCachedStatusWithinGrace(
                 store: store,
                 nowUnixSecs: nowUnixSecs
             ) != nil
+
+            // Distinguishes a genuine connectivity failure (can't reach the
+            // network at all) from repeated 5xx/429 responses that exhausted
+            // retries (the server WAS reached, it just kept erroring) — used to
+            // split both the Sentry signal below and the "should we retry again
+            // soon" decision surfaced to `LicenseManager`. HYPERWHISPER-F4
+            // (review round 2).
+            let isNetworkFailure = Self.isNetworkFailure(error)
 
             if hasCachedVerdict {
                 // Retries exhausted, but we have a last-known-good server verdict
@@ -271,7 +297,7 @@ class LicenseNetworkService {
                 // no Sentry noise, the app just proceeds on the cached verdict as
                 // if the network blip never happened.
                 AppLogger.network.info(
-                    "License validation offline · serving cached verdict status=\(Self.adapt(outcome.status).rawValue) after retries exhausted (launch=\(isLaunchValidation))"
+                    "License validation offline · serving cached verdict status=\(Self.adapt(outcome.status).rawValue) after retries exhausted (launch=\(isLaunchValidation), networkFailure=\(isNetworkFailure))"
                 )
             } else {
                 // No usable cached fallback (never validated yet, or the 7-day
@@ -280,25 +306,48 @@ class LicenseNetworkService {
                 // "License validation server error" above (a real, non-2xx server
                 // verdict), this is a pure connectivity failure with nothing to
                 // fall back on. Tagged distinctly so it doesn't get lumped in with
-                // either of those. HYPERWHISPER-F4.
+                // either of those.
+                //
+                // `failure_kind` further splits this signal by `isNetworkFailure`:
+                // a genuine connectivity failure (dead network, DNS, etc.) is a
+                // very different operational condition from repeated 5xx/429
+                // responses exhausting retries (the server IS reachable, it's
+                // unhealthy) — conflating them into one tag would make this signal
+                // much less actionable. HYPERWHISPER-F4.
                 if AppLogger.isErrorLoggingEnabled {
                     SentryService.capture(
                         error: error,
-                        message: "License validation offline — no cached fallback available",
+                        message: isNetworkFailure
+                            ? "License validation offline — no cached fallback available (network unreachable)"
+                            : "License validation offline — no cached fallback available (server error exhausted retries)",
                         extras: [
                             "endpoint": NetworkConfig.licenseValidateEndpoint,
                             "isLaunchValidation": isLaunchValidation,
-                            "isNetworkFailure": Self.isNetworkFailure(error),
                         ],
-                        tags: ["component": "license", "reason": "offline_no_cache"]
+                        tags: [
+                            "component": "license",
+                            "reason": "offline_no_cache",
+                            "failure_kind": isNetworkFailure ? "network" : "server_error",
+                        ]
                     )
                 }
                 AppLogger.network.warning(
-                    "License validation offline · no cached fallback available (launch=\(isLaunchValidation))"
+                    "License validation offline · no cached fallback available (launch=\(isLaunchValidation), networkFailure=\(isNetworkFailure))"
                 )
             }
 
-            return Self.adapt(outcome)
+            // Surface "this specific result was served from a cached verdict (or
+            // Invalid) because we couldn't reach the network" so a launch-time
+            // caller (`LicenseManager.loadStoredLicense()`) can schedule a prompt
+            // background retry instead of waiting out the full 24h cache TTL / 7-
+            // day grace — a merely-slow-but-live network shouldn't ride a stale
+            // cached verdict for up to a week. Deliberately NOT set for the
+            // "submitted key differs from stored" early-return above (that path
+            // never applies to launch validation, which always revalidates the
+            // stored key) or for exhausted-5xx/429 fallbacks (a real server
+            // response, not a connectivity problem — retrying again in a minute
+            // is unlikely to help). HYPERWHISPER-F4 (review round 2).
+            return Self.adapt(outcome, networkFailureFallback: isNetworkFailure)
         }
     }
 
@@ -335,6 +384,39 @@ class LicenseNetworkService {
     /// remote-override config untouched).
     func clearStoredLicense() {
         licenseClearStoredLicense(store: store)
+    }
+
+    // MARK: - Per-call-site request policy
+
+    /// The per-request timeout and retry budget to use for a `validateLicense`
+    /// call — paired together so callers only make ONE `isLaunchValidation`
+    /// decision instead of two independent ternaries (one for the timeout, one
+    /// for the retry preset) that have to be kept in sync by hand. HYPERWHISPER-F4
+    /// (review round 2).
+    struct RequestPolicy {
+        let requestTimeout: TimeInterval
+        let retryConfig: RetryConfiguration
+    }
+
+    /// Single source of truth for `isLaunchValidation`'s two derived settings.
+    /// Launch-time (silent, background) revalidation gets both the shorter
+    /// `licenseLaunchValidationTimeout` AND the tighter `.licenseLaunchValidation`
+    /// retry budget; explicit, user-triggered activation gets the normal
+    /// `licenseValidationTimeout` AND `.cloud` budget. These two values are
+    /// deliberately paired (a short per-request timeout is only useful alongside
+    /// a short retry budget, and vice versa) — computing them together here
+    /// means a future change to one can't accidentally leave the other on the
+    /// wrong preset.
+    static func requestPolicy(isLaunchValidation: Bool) -> RequestPolicy {
+        isLaunchValidation
+            ? RequestPolicy(
+                requestTimeout: NetworkConfig.licenseLaunchValidationTimeout,
+                retryConfig: .licenseLaunchValidation
+            )
+            : RequestPolicy(
+                requestTimeout: NetworkConfig.licenseValidationTimeout,
+                retryConfig: .cloud
+            )
     }
 
     // MARK: - Error classification
@@ -388,14 +470,23 @@ class LicenseNetworkService {
     /// Adapts the core's `ValidationOutcome` to the app's `LicenseValidationResult`.
     /// Note: the core does not surface `customerName`; it is always nil here
     /// (matches the prior native behavior, which also never populated it).
-    static func adapt(_ outcome: ValidationOutcome) -> LicenseValidationResult {
+    ///
+    /// - Parameter networkFailureFallback: `true` only for the offline-fallback
+    ///   catch-branch case where retries were exhausted due to a genuine
+    ///   connectivity failure (see `isNetworkFailure`) — signals to
+    ///   `LicenseManager` that this result rode a cached/Invalid verdict because
+    ///   the network couldn't be reached, not because the server issued it.
+    ///   Defaults to `false` for every other call site (200-path success, empty
+    ///   key, terminal HTTP error, cancellation). HYPERWHISPER-F4 (review round 2).
+    static func adapt(_ outcome: ValidationOutcome, networkFailureFallback: Bool = false) -> LicenseValidationResult {
         LicenseValidationResult(
             isValid: outcome.isValid,
             status: adapt(outcome.status),
             customerId: outcome.customerId,
             customerEmail: outcome.customerEmail,
             customerName: nil,
-            errorMessage: outcome.errorMessage
+            errorMessage: outcome.errorMessage,
+            networkFailureFallback: networkFailureFallback
         )
     }
 }

--- a/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
@@ -19,10 +19,12 @@
 //    connection refused) with a short bounded backoff before giving up — a real
 //    non-2xx server verdict is never retried (see licenseHttpErrorOutcome).
 //  - The launch-time revalidation (LicenseManager.loadStoredLicense(), passing
-//    isLaunchValidation: true) uses a tighter retry budget than explicit,
-//    user-triggered activation (`.licenseLaunchValidation` vs `.cloud`) so a
-//    flaky network at launch self-heals in a couple of seconds instead of
-//    leaving a paying user looking unlicensed for the ~30s `.cloud` budget.
+//    isLaunchValidation: true) uses both a tighter retry budget AND a much
+//    shorter per-request timeout than explicit, user-triggered activation
+//    (`.licenseLaunchValidation` + `licenseLaunchValidationTimeout` vs `.cloud`
+//    + `licenseValidationTimeout`) so a flaky network at launch self-heals in a
+//    few seconds instead of leaving a paying user looking unlicensed for the
+//    ~30s `.cloud` budget.
 //  - If retries are exhausted, we fall back to the last cached SERVER verdict
 //    (never a fabricated one) for the key on file, within its 7-day grace, and
 //    let the app proceed — no hard error shown to the user. Only the "no usable
@@ -100,12 +102,13 @@ class LicenseNetworkService {
     /// - Parameter isLaunchValidation: `true` for the silent, background
     ///   revalidation `LicenseManager.loadStoredLicense()` fires on every app
     ///   launch when the cache is stale — uses the tighter `.licenseLaunchValidation`
-    ///   retry budget instead of `.cloud` so a flaky network at launch (wake from
-    ///   sleep, captive portal, DNS not up yet) self-heals in a couple of seconds
-    ///   rather than leaving a paying user looking unlicensed for ~30s. Explicit,
-    ///   user-triggered activation (the default, `false`) keeps the `.cloud` budget,
-    ///   matching the wait a user already expects after tapping "Activate".
-    ///   HYPERWHISPER-F4.
+    ///   retry budget AND the shorter `licenseLaunchValidationTimeout` per-request
+    ///   timeout instead of `.cloud` / `licenseValidationTimeout`, so a flaky
+    ///   network at launch (wake from sleep, captive portal, DNS not up yet)
+    ///   self-heals in a few seconds rather than leaving a paying user looking
+    ///   unlicensed for ~30s. Explicit, user-triggered activation (the default,
+    ///   `false`) keeps the `.cloud` budget and full request timeout, matching
+    ///   the wait a user already expects after tapping "Activate". HYPERWHISPER-F4.
     func validateLicense(_ licenseKey: String, isLaunchValidation: Bool = false) async -> LicenseValidationResult {
         let trimmedKey = licenseKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else {
@@ -129,9 +132,20 @@ class LicenseNetworkService {
         // Create the URLRequest shell natively (timeout, headers), then attach the
         // core-built body. `createRequest` defaults to POST + JSON content type,
         // matching the core's request.
+        //
+        // The per-request timeout is also split by call site (like the retry
+        // preset below): launch-time validation uses the much shorter
+        // `licenseLaunchValidationTimeout` so a hung request doesn't eat the
+        // whole per-attempt budget — otherwise 3 attempts at the full 10s
+        // `licenseValidationTimeout` would still cost ~30s worst case, defeating
+        // the point of the tighter `.licenseLaunchValidation` retry preset.
+        // HYPERWHISPER-F4.
+        let requestTimeout = isLaunchValidation
+            ? NetworkConfig.licenseLaunchValidationTimeout
+            : NetworkConfig.licenseValidationTimeout
         guard var request = NetworkConfig.createRequest(
             for: NetworkConfig.licenseValidateEndpoint,
-            timeout: NetworkConfig.licenseValidationTimeout
+            timeout: requestTimeout
         ) else {
             return LicenseValidationResult(
                 isValid: false,
@@ -231,17 +245,31 @@ class LicenseNetworkService {
 
             // Core decides the offline fallback (cached status within the 7-day
             // grace, else Invalid) for the key currently on file.
+            let nowUnixSecs = RustLicenseTime.nowUTC()
             let outcome = licenseOfflineFallbackOutcome(
                 store: store,
-                nowUnixSecs: RustLicenseTime.nowUTC()
+                nowUnixSecs: nowUnixSecs
             )
 
-            if outcome.isValid {
+            // Whether there is a genuinely cached SERVER verdict at all — distinct
+            // from `outcome.isValid`, which only means "the cached verdict is
+            // currently Active." A cached Expired/Invalid verdict within the 7-day
+            // grace is still a real cache hit (the core's `licenseOfflineFallbackOutcome`
+            // returns it as-is); it's just not an active entitlement. Gating the
+            // Sentry signal below on `outcome.isValid` would misfire it for every
+            // offline Expired/Invalid user even though the cache did its job.
+            let hasCachedVerdict = licenseCachedStatusWithinGrace(
+                store: store,
+                nowUnixSecs: nowUnixSecs
+            ) != nil
+
+            if hasCachedVerdict {
                 // Retries exhausted, but we have a last-known-good server verdict
-                // for this exact key within its 7-day grace — serve it and move on.
-                // This is the resilience behavior we WANT (HYPERWHISPER-F4): no
-                // hard error, no Sentry noise, the app just proceeds on the cached
-                // verdict as if the network blip never happened.
+                // for this exact key within its 7-day grace — serve it and move on
+                // (whatever that verdict is — Active, Expired, or Invalid). This is
+                // the resilience behavior we WANT (HYPERWHISPER-F4): no hard error,
+                // no Sentry noise, the app just proceeds on the cached verdict as
+                // if the network blip never happened.
                 AppLogger.network.info(
                     "License validation offline · serving cached verdict status=\(Self.adapt(outcome.status).rawValue) after retries exhausted (launch=\(isLaunchValidation))"
                 )
@@ -323,24 +351,15 @@ class LicenseNetworkService {
     /// case here — this classifier answers "was this specifically a connectivity
     /// problem," which is used only to enrich the offline diagnostic signal above,
     /// not to gate retry/fallback eligibility. HYPERWHISPER-F4.
+    ///
+    /// Reuses `TranscriptionPipeline.transientURLErrorCodes` (the same
+    /// connectivity-code set already used for transcription's Sentry-capture
+    /// classification) rather than maintaining an independent copy of the
+    /// NSURLErrorDomain code list — see that property's doc comment.
     static func isNetworkFailure(_ error: Error) -> Bool {
         let nsError = error as NSError
         guard nsError.domain == NSURLErrorDomain else { return false }
-        switch nsError.code {
-        case NSURLErrorTimedOut,
-             NSURLErrorCannotFindHost,
-             NSURLErrorCannotConnectToHost,
-             NSURLErrorNetworkConnectionLost,
-             NSURLErrorDNSLookupFailed,
-             NSURLErrorNotConnectedToInternet,
-             NSURLErrorInternationalRoamingOff,
-             NSURLErrorCallIsActive,
-             NSURLErrorDataNotAllowed,
-             NSURLErrorSecureConnectionFailed:
-            return true
-        default:
-            return false
-        }
+        return TranscriptionPipeline.transientURLErrorCodes.contains(URLError.Code(rawValue: nsError.code))
     }
 
     // MARK: - ValidationOutcome → app-type adapters

--- a/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
@@ -107,7 +107,16 @@ class LicenseNetworkService {
     ///   With no safe cached fallback, it retains the normal `.cloud` budget so
     ///   a slow-but-live network is not prematurely presented as an invalid
     ///   license. Explicit activation also keeps the normal budget.
-    func validateLicense(_ licenseKey: String, isLaunchValidation: Bool = false) async -> LicenseValidationResult {
+    /// - Parameter expectedStoredLicenseKey: When non-nil, the parsed server
+    ///   verdict is persisted only if this is still the stored key. The delayed
+    ///   launch retry supplies its scheduled key so an activation, deactivation,
+    ///   or restore that lands while the request is in flight wins the race and
+    ///   cannot be undone by the stale response.
+    func validateLicense(
+        _ licenseKey: String,
+        isLaunchValidation: Bool = false,
+        expectedStoredLicenseKey: String? = nil
+    ) async -> LicenseValidationResult {
         let trimmedKey = licenseKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else {
             AppLogger.network.warning("License validation rejected: empty license key")
@@ -198,17 +207,27 @@ class LicenseNetworkService {
                 let outcome = licenseParseValidateResponse(body: data)
 
                 // Persist the key + cache the result through the core's store.
-                // The core stores the key only on a valid verdict and updates the
-                // (global, key-less) validation cache only when the attempted key
-                // is the stored key — a rejected replacement key must not
-                // overwrite the stored key's cached status with Invalid, which
-                // would lock out a valid user for up to 24h.
-                licensePersistValidationVerdict(
-                    store: store,
-                    status: outcome.status,
-                    attemptedKey: trimmedKey,
-                    nowUnixSecs: RustLicenseTime.nowUTC()
-                )
+                // The delayed launch retry additionally supplies the key that
+                // was current when it was scheduled. Check that precondition
+                // immediately before the side-effecting FFI call, on MainActor,
+                // so it is serialized with LicenseManager activation/deactivation:
+                // if one of those operations wins while this request is in
+                // flight, a stale Active response cannot restore the old key.
+                //
+                // The core still owns entitlement semantics: an Active verdict
+                // stores the key, while a rejected replacement cannot overwrite
+                // the current key's global cache.
+                let didPersist = await MainActor.run {
+                    Self.persistValidationVerdictIfCurrent(
+                        store: store,
+                        status: outcome.status,
+                        attemptedKey: trimmedKey,
+                        expectedStoredLicenseKey: expectedStoredLicenseKey,
+                        nowUnixSecs: RustLicenseTime.nowUTC(),
+                        isCancelled: withUnsafeCurrentTask { $0?.isCancelled ?? false }
+                    )
+                }
+                guard didPersist else { throw CancellationError() }
                 AppLogger.network.info("License validation · status=\(Self.adapt(outcome.status).rawValue)")
 
                 return Self.adapt(outcome)
@@ -411,6 +430,45 @@ class LicenseNetworkService {
                 requestTimeout: NetworkConfig.licenseValidationTimeout,
                 retryConfig: .cloud
             )
+    }
+
+    // MARK: - Validation persistence
+
+    /// Persists a server verdict only while the caller's validation is still
+    /// current. Main-actor isolation makes the expected-key check and the
+    /// side-effecting Rust FFI call one serialized unit relative to
+    /// LicenseManager activation/deactivation.
+    ///
+    /// A nil `expectedStoredLicenseKey` is the explicit-activation contract:
+    /// an Active verdict may replace the currently stored key. The delayed
+    /// launch retry passes a non-nil expected key and therefore cannot restore
+    /// a key that was cleared or replaced while its request was in flight.
+    @MainActor
+    @discardableResult
+    static func persistValidationVerdictIfCurrent(
+        store: KeyValueStore,
+        status: HwLicenseStatus,
+        attemptedKey: String,
+        expectedStoredLicenseKey: String?,
+        nowUnixSecs: Int64,
+        isCancelled: Bool
+    ) -> Bool {
+        guard !isCancelled else { return false }
+
+        if let expectedStoredLicenseKey,
+           licenseStoredLicenseKey(store: store) != expectedStoredLicenseKey.trimmingCharacters(
+               in: .whitespacesAndNewlines
+           ) {
+            return false
+        }
+
+        licensePersistValidationVerdict(
+            store: store,
+            status: status,
+            attemptedKey: attemptedKey,
+            nowUnixSecs: nowUnixSecs
+        )
+        return true
     }
 
     // MARK: - Error classification

--- a/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
@@ -14,6 +14,20 @@
 //  - 24-hour validation cache
 //  - 7-day offline grace period
 //
+//  NETWORK RESILIENCE (HYPERWHISPER-F4):
+//  - validateLicense() retries a NETWORK failure (timeout/no connection/DNS/
+//    connection refused) with a short bounded backoff before giving up — a real
+//    non-2xx server verdict is never retried (see licenseHttpErrorOutcome).
+//  - The launch-time revalidation (LicenseManager.loadStoredLicense(), passing
+//    isLaunchValidation: true) uses a tighter retry budget than explicit,
+//    user-triggered activation (`.licenseLaunchValidation` vs `.cloud`) so a
+//    flaky network at launch self-heals in a couple of seconds instead of
+//    leaving a paying user looking unlicensed for the ~30s `.cloud` budget.
+//  - If retries are exhausted, we fall back to the last cached SERVER verdict
+//    (never a fabricated one) for the key on file, within its 7-day grace, and
+//    let the app proceed — no hard error shown to the user. Only the "no usable
+//    cache" case gets a distinct diagnostic signal.
+//
 
 import Foundation
 
@@ -23,8 +37,9 @@ import Foundation
 ///
 /// M3-C: the validate/cache/grace LOGIC now lives in the Rust shared core
 /// (`hw-license`). This service keeps the macOS-owned I/O — URLSession config,
-/// `performWithRetry(.cloud)`, and Sentry — and delegates request building,
-/// response parsing, and persistence to the core over a shared `RustLicenseStore`.
+/// `performWithRetry(.cloud / .licenseLaunchValidation)`, and Sentry — and
+/// delegates request building, response parsing, and persistence to the core
+/// over a shared `RustLicenseStore`.
 class LicenseNetworkService {
 
     // MARK: - UserDefaults Keys
@@ -81,7 +96,17 @@ class LicenseNetworkService {
 
     /// Validates a license key with the backend and tracks device usage.
     /// Falls back to cached status if network fails (within 7-day grace period).
-    func validateLicense(_ licenseKey: String) async -> LicenseValidationResult {
+    ///
+    /// - Parameter isLaunchValidation: `true` for the silent, background
+    ///   revalidation `LicenseManager.loadStoredLicense()` fires on every app
+    ///   launch when the cache is stale — uses the tighter `.licenseLaunchValidation`
+    ///   retry budget instead of `.cloud` so a flaky network at launch (wake from
+    ///   sleep, captive portal, DNS not up yet) self-heals in a couple of seconds
+    ///   rather than leaving a paying user looking unlicensed for ~30s. Explicit,
+    ///   user-triggered activation (the default, `false`) keeps the `.cloud` budget,
+    ///   matching the wait a user already expects after tapping "Activate".
+    ///   HYPERWHISPER-F4.
+    func validateLicense(_ licenseKey: String, isLaunchValidation: Bool = false) async -> LicenseValidationResult {
         let trimmedKey = licenseKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else {
             AppLogger.network.warning("License validation rejected: empty license key")
@@ -121,7 +146,7 @@ class LicenseNetworkService {
         request.httpBody = coreRequest.body
 
         do {
-            return try await performWithRetry(config: .cloud) { [self] _ in
+            return try await performWithRetry(config: isLaunchValidation ? .licenseLaunchValidation : .cloud) { [self] _ in
                 let (data, response) = try await session.data(for: request)
 
                 guard let httpResponse = response as? HTTPURLResponse else {
@@ -210,9 +235,41 @@ class LicenseNetworkService {
                 store: store,
                 nowUnixSecs: RustLicenseTime.nowUTC()
             )
-            AppLogger.network.info(
-                "License validation offline · status=\(Self.adapt(outcome.status).rawValue)"
-            )
+
+            if outcome.isValid {
+                // Retries exhausted, but we have a last-known-good server verdict
+                // for this exact key within its 7-day grace — serve it and move on.
+                // This is the resilience behavior we WANT (HYPERWHISPER-F4): no
+                // hard error, no Sentry noise, the app just proceeds on the cached
+                // verdict as if the network blip never happened.
+                AppLogger.network.info(
+                    "License validation offline · serving cached verdict status=\(Self.adapt(outcome.status).rawValue) after retries exhausted (launch=\(isLaunchValidation))"
+                )
+            } else {
+                // No usable cached fallback (never validated yet, or the 7-day
+                // grace has elapsed) — the user is genuinely stuck offline with no
+                // safety net. Worth its own distinct signal: unlike the 200-path
+                // "License validation server error" above (a real, non-2xx server
+                // verdict), this is a pure connectivity failure with nothing to
+                // fall back on. Tagged distinctly so it doesn't get lumped in with
+                // either of those. HYPERWHISPER-F4.
+                if AppLogger.isErrorLoggingEnabled {
+                    SentryService.capture(
+                        error: error,
+                        message: "License validation offline — no cached fallback available",
+                        extras: [
+                            "endpoint": NetworkConfig.licenseValidateEndpoint,
+                            "isLaunchValidation": isLaunchValidation,
+                            "isNetworkFailure": Self.isNetworkFailure(error),
+                        ],
+                        tags: ["component": "license", "reason": "offline_no_cache"]
+                    )
+                }
+                AppLogger.network.warning(
+                    "License validation offline · no cached fallback available (launch=\(isLaunchValidation))"
+                )
+            }
+
             return Self.adapt(outcome)
         }
     }
@@ -250,6 +307,40 @@ class LicenseNetworkService {
     /// remote-override config untouched).
     func clearStoredLicense() {
         licenseClearStoredLicense(store: store)
+    }
+
+    // MARK: - Error classification
+
+    /// Whether `error` represents a network-connectivity failure (timeout, no
+    /// connection, DNS lookup failure, connection refused, dropped connection,
+    /// etc.) as opposed to a real server-issued verdict.
+    ///
+    /// Real non-2xx verdicts never reach this classifier — the request closure
+    /// above resolves them to a `ValidationOutcome` directly instead of throwing
+    /// (see `licenseHttpErrorOutcome`). The 500/599 and 429 statuses ARE thrown
+    /// (as a same-domain `URLError`) so `performWithRetry` treats a transient
+    /// server hiccup as retryable, but their raw status codes don't match any
+    /// case here — this classifier answers "was this specifically a connectivity
+    /// problem," which is used only to enrich the offline diagnostic signal above,
+    /// not to gate retry/fallback eligibility. HYPERWHISPER-F4.
+    static func isNetworkFailure(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        guard nsError.domain == NSURLErrorDomain else { return false }
+        switch nsError.code {
+        case NSURLErrorTimedOut,
+             NSURLErrorCannotFindHost,
+             NSURLErrorCannotConnectToHost,
+             NSURLErrorNetworkConnectionLost,
+             NSURLErrorDNSLookupFailed,
+             NSURLErrorNotConnectedToInternet,
+             NSURLErrorInternationalRoamingOff,
+             NSURLErrorCallIsActive,
+             NSURLErrorDataNotAllowed,
+             NSURLErrorSecureConnectionFailed:
+            return true
+        default:
+            return false
+        }
     }
 
     // MARK: - ValidationOutcome → app-type adapters

--- a/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
+++ b/app/macos/hyperwhisper/Managers/LicenseNetworkService.swift
@@ -101,14 +101,12 @@ class LicenseNetworkService {
     ///
     /// - Parameter isLaunchValidation: `true` for the silent, background
     ///   revalidation `LicenseManager.loadStoredLicense()` fires on every app
-    ///   launch when the cache is stale — uses the tighter `.licenseLaunchValidation`
-    ///   retry budget AND the shorter `licenseLaunchValidationTimeout` per-request
-    ///   timeout instead of `.cloud` / `licenseValidationTimeout`, so a flaky
-    ///   network at launch (wake from sleep, captive portal, DNS not up yet)
-    ///   self-heals in a few seconds rather than leaving a paying user looking
-    ///   unlicensed for ~30s. Explicit, user-triggered activation (the default,
-    ///   `false`) keeps the `.cloud` budget and full request timeout, matching
-    ///   the wait a user already expects after tapping "Activate". HYPERWHISPER-F4.
+    ///   launch when the cache is stale. When a cached verdict is still within
+    ///   its offline grace period, the call uses the tighter
+    ///   `.licenseLaunchValidation` retry budget and shorter per-request timeout.
+    ///   With no safe cached fallback, it retains the normal `.cloud` budget so
+    ///   a slow-but-live network is not prematurely presented as an invalid
+    ///   license. Explicit activation also keeps the normal budget.
     func validateLicense(_ licenseKey: String, isLaunchValidation: Bool = false) async -> LicenseValidationResult {
         let trimmedKey = licenseKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else {
@@ -133,18 +131,18 @@ class LicenseNetworkService {
         // core-built body. `createRequest` defaults to POST + JSON content type,
         // matching the core's request.
         //
-        // Both the per-request timeout AND the retry preset are selected off the
-        // same `isLaunchValidation` bool via `Self.requestPolicy(isLaunchValidation:)`
-        // — a single lookup instead of two independent ternaries, so the two
-        // values (which must stay paired: a short timeout with a short retry
-        // budget, a long timeout with the long one) can't drift out of sync in a
-        // future edit. Launch-time validation uses the much shorter
-        // `licenseLaunchValidationTimeout` so a hung request doesn't eat the
-        // whole per-attempt budget — otherwise 3 attempts at the full 10s
-        // `licenseValidationTimeout` would still cost ~30s worst case, defeating
-        // the point of the tighter `.licenseLaunchValidation` retry preset.
-        // HYPERWHISPER-F4.
-        let policy = Self.requestPolicy(isLaunchValidation: isLaunchValidation)
+        // A tight launch budget is safe only when a cached server verdict is
+        // available for this same key within the offline grace period. Without
+        // that safety net, keep the normal request/retry budget so a slow VPN or
+        // weak network still gets the same chance to validate as an explicit
+        // activation instead of being surfaced as an invalid license.
+        let nowUnixSecs = RustLicenseTime.nowUTC()
+        let hasCachedVerdict = licenseStoredLicenseKey(store: store) == trimmedKey
+            && licenseCachedStatusWithinGrace(store: store, nowUnixSecs: nowUnixSecs) != nil
+        let policy = Self.requestPolicy(
+            isLaunchValidation: isLaunchValidation,
+            hasCachedVerdict: hasCachedVerdict
+        )
         guard var request = NetworkConfig.createRequest(
             for: NetworkConfig.licenseValidateEndpoint,
             timeout: policy.requestTimeout
@@ -389,26 +387,22 @@ class LicenseNetworkService {
     // MARK: - Per-call-site request policy
 
     /// The per-request timeout and retry budget to use for a `validateLicense`
-    /// call — paired together so callers only make ONE `isLaunchValidation`
-    /// decision instead of two independent ternaries (one for the timeout, one
-    /// for the retry preset) that have to be kept in sync by hand. HYPERWHISPER-F4
-    /// (review round 2).
+    /// call. The tight launch policy is selected only when there is a usable
+    /// cached verdict to serve if the live refresh exhausts that short budget.
     struct RequestPolicy {
         let requestTimeout: TimeInterval
         let retryConfig: RetryConfiguration
     }
 
-    /// Single source of truth for `isLaunchValidation`'s two derived settings.
-    /// Launch-time (silent, background) revalidation gets both the shorter
-    /// `licenseLaunchValidationTimeout` AND the tighter `.licenseLaunchValidation`
-    /// retry budget; explicit, user-triggered activation gets the normal
-    /// `licenseValidationTimeout` AND `.cloud` budget. These two values are
-    /// deliberately paired (a short per-request timeout is only useful alongside
-    /// a short retry budget, and vice versa) — computing them together here
-    /// means a future change to one can't accidentally leave the other on the
-    /// wrong preset.
-    static func requestPolicy(isLaunchValidation: Bool) -> RequestPolicy {
-        isLaunchValidation
+    /// Single source of truth for the paired timeout and retry settings.
+    /// Launch-time revalidation with a usable cached verdict gets the short
+    /// policy. Explicit activation and launch validation without a safe cached
+    /// fallback retain the normal policy.
+    static func requestPolicy(
+        isLaunchValidation: Bool,
+        hasCachedVerdict: Bool
+    ) -> RequestPolicy {
+        isLaunchValidation && hasCachedVerdict
             ? RequestPolicy(
                 requestTimeout: NetworkConfig.licenseLaunchValidationTimeout,
                 retryConfig: .licenseLaunchValidation

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+ErrorClassification.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+ErrorClassification.swift
@@ -124,7 +124,12 @@ extension TranscriptionPipeline {
         }
     }
 
-    private static let transientURLErrorCodes: Set<URLError.Code> = [
+    /// Connectivity-error codes treated as transient (not code defects) for
+    /// Sentry-capture purposes. Not `private`: `LicenseNetworkService
+    /// .isNetworkFailure` reuses this same canonical set rather than
+    /// maintaining its own independent copy — see that call site.
+    /// HYPERWHISPER-F4.
+    static let transientURLErrorCodes: Set<URLError.Code> = [
         .notConnectedToInternet, .networkConnectionLost, .timedOut,
         .dnsLookupFailed, .cannotFindHost, .cannotConnectToHost,
         .dataNotAllowed, .internationalRoamingOff

--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+ErrorClassification.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+ErrorClassification.swift
@@ -25,19 +25,22 @@ extension TranscriptionPipeline {
             return classify(cloudError)
         }
         if let urlError = error as? URLError {
-            let retryableCodes: Set<URLError.Code> = [
-                .timedOut,
-                .cannotFindHost,
-                .cannotConnectToHost,
-                .networkConnectionLost,
-                .dnsLookupFailed,
-                .notConnectedToInternet
-            ]
+            // Reuses the same canonical `transientURLErrorCodes` set as
+            // `shouldCaptureTranscriptionErrorInSentry` below (and
+            // `LicenseNetworkService.isNetworkFailure`) instead of maintaining a
+            // second, narrower connectivity-code list here — both call sites are
+            // answering the same underlying question ("is this a transient
+            // connectivity problem, not a code defect"), just for different
+            // consumers (retry-hint vs Sentry-capture vs offline-diagnostic).
+            // Previously this list only had 6 of the canonical set's 8 codes
+            // (missing `.dataNotAllowed` / `.internationalRoamingOff`), which was
+            // an unintentional divergence, not a deliberate policy difference —
+            // unified here. HYPERWHISPER-F4 (review round 2).
             let kind = "url_\(String(describing: urlError.code))"
             return TranscriptionErrorClassification(
                 category: "network",
                 kind: kind,
-                retryable: retryableCodes.contains(urlError.code),
+                retryable: Self.transientURLErrorCodes.contains(urlError.code),
                 httpStatus: nil
             )
         }
@@ -124,11 +127,18 @@ extension TranscriptionPipeline {
         }
     }
 
-    /// Connectivity-error codes treated as transient (not code defects) for
-    /// Sentry-capture purposes. Not `private`: `LicenseNetworkService
-    /// .isNetworkFailure` reuses this same canonical set rather than
-    /// maintaining its own independent copy — see that call site.
-    /// HYPERWHISPER-F4.
+    /// Connectivity-error codes treated as transient (not code defects). This IS
+    /// the canonical set for that question across the codebase — every other
+    /// call site reuses it instead of keeping an independent copy:
+    /// - `classifyTranscriptionError` above (bare `URLError` branch — the
+    ///   "retryable" hint), and `shouldCaptureTranscriptionErrorInSentry` below
+    ///   (the Sentry-capture suppression), both in this file.
+    /// - `LicenseNetworkService.isNetworkFailure` (the offline-fallback
+    ///   diagnostic signal) — see that call site.
+    /// Not `private` so those call sites can reference it. HYPERWHISPER-F4
+    /// (review round 2: `classifyTranscriptionError` previously kept its own
+    /// narrower, unintentionally-diverged 6-code list here instead of reusing
+    /// this set — unified).
     static let transientURLErrorCodes: Set<URLError.Code> = [
         .notConnectedToInternet, .networkConnectionLost, .timedOut,
         .dnsLookupFailed, .cannotFindHost, .cannotConnectToHost,

--- a/app/macos/hyperwhisper/Models/LicenseValidationResult.swift
+++ b/app/macos/hyperwhisper/Models/LicenseValidationResult.swift
@@ -59,4 +59,23 @@ struct LicenseValidationResult {
     /// Displayed to users when operations fail
     /// nil when operation succeeds
     let errorMessage: String?
+
+    /// `true` when this result was served from a cached (or Invalid, if no
+    /// cache exists) verdict because the live validation call exhausted its
+    /// retries due to a genuine connectivity failure — as opposed to a real
+    /// server-issued verdict (a 200 response, a terminal non-2xx error, or
+    /// exhausted retries against repeated 5xx/429 responses).
+    ///
+    /// Distinct from the normal "24h cache is still fresh, no live call was
+    /// even attempted" path (`LicenseManager.loadStoredLicense()`'s
+    /// `getCachedLicenseStatus()` branch), where no revalidation is needed.
+    /// `LicenseManager` uses this flag to schedule a short, one-shot
+    /// background retry after a launch-time validation falls back this way —
+    /// a merely-slow-but-live network (weak wifi, VPN overhead) shouldn't
+    /// leave a legitimately-licensed user riding a stale cached verdict for up
+    /// to the full 7-day offline grace period. HYPERWHISPER-F4 (review round 2).
+    ///
+    /// Defaults to `false`; only `LicenseNetworkService.validateLicense`'s
+    /// offline-fallback catch branch sets it `true`.
+    let networkFailureFallback: Bool = false
 }

--- a/app/macos/hyperwhisper/Models/LicenseValidationResult.swift
+++ b/app/macos/hyperwhisper/Models/LicenseValidationResult.swift
@@ -77,5 +77,23 @@ struct LicenseValidationResult {
     ///
     /// Defaults to `false`; only `LicenseNetworkService.validateLicense`'s
     /// offline-fallback catch branch sets it `true`.
-    let networkFailureFallback: Bool = false
+    let networkFailureFallback: Bool
+
+    init(
+        isValid: Bool,
+        status: LicenseStatus,
+        customerId: String?,
+        customerEmail: String?,
+        customerName: String?,
+        errorMessage: String?,
+        networkFailureFallback: Bool = false
+    ) {
+        self.isValid = isValid
+        self.status = status
+        self.customerId = customerId
+        self.customerEmail = customerEmail
+        self.customerName = customerName
+        self.errorMessage = errorMessage
+        self.networkFailureFallback = networkFailureFallback
+    }
 }

--- a/app/macos/hyperwhisper/Utilities/Retrying.swift
+++ b/app/macos/hyperwhisper/Utilities/Retrying.swift
@@ -50,6 +50,28 @@ struct RetryConfiguration {
         jitterRange: 0...0.2
     )
 
+    /// Configuration for the background, launch-time license revalidation
+    /// (`LicenseNetworkService.validateLicense(_:isLaunchValidation: true)`).
+    ///
+    /// Deliberately tighter than `.cloud`: this call fires from `LicenseManager
+    /// .loadStoredLicense()` on every app launch whenever the 24h validation cache
+    /// is stale, racing a network that may not be up yet (wake-from-sleep, captive
+    /// portal, DNS not resolved yet). `.cloud`'s ~30s worst-case budget is fine for
+    /// a user-blocking, explicitly-triggered activation, but is far too slow for a
+    /// silent background check — a paying user would sit "unlicensed" (cache not
+    /// yet consulted, cloud identifier not yet resolved) for up to half a minute on
+    /// a flaky network. A short, bounded retry (≈2s of total backoff sleep across 3
+    /// attempts) lets a transient blip self-heal quickly; once attempts are
+    /// exhausted, `LicenseNetworkService` falls back to the last cached verdict
+    /// rather than continuing to hammer the network. See HYPERWHISPER-F4.
+    static let licenseLaunchValidation = RetryConfiguration(
+        maxAttempts: 3,
+        initialDelay: 0.5,
+        maxDelay: 2.0,
+        backoffMultiplier: 2.0,
+        jitterRange: 0...0.2
+    )
+
     /// Upper bound, in seconds, that a single honored `Retry-After` may sleep
     /// inside a status-poll loop. A hostile or misconfigured server can return a
     /// very large `Retry-After` (e.g. 300s); clamping each honored sleep to this

--- a/app/macos/hyperwhisper/Utilities/Retrying.swift
+++ b/app/macos/hyperwhisper/Utilities/Retrying.swift
@@ -63,11 +63,11 @@ struct RetryConfiguration {
     /// a flaky network. A short, bounded retry (≈1.5–1.8s of total backoff sleep
     /// across the 2 sleeps between 3 attempts — no sleep follows the final
     /// attempt) lets a transient blip self-heal quickly; `LicenseNetworkService`
-    /// also uses a much shorter per-request timeout for this call
-    /// (`licenseLaunchValidationTimeout`, 2.5s vs the normal 10s) so a hung
-    /// request can't itself eat the whole budget. Once attempts are exhausted,
-    /// it falls back to the last cached verdict rather than continuing to
-    /// hammer the network. See HYPERWHISPER-F4.
+    /// also uses a much shorter per-request timeout for this call when a cached
+    /// verdict exists (`licenseLaunchValidationTimeout`, 2.5s vs the normal
+    /// 10s), so a hung request can't itself eat the whole budget. A launch
+    /// validation without a usable cache keeps the normal `.cloud` policy so a
+    /// slow network is not surfaced as an invalid license. See HYPERWHISPER-F4.
     static let licenseLaunchValidation = RetryConfiguration(
         maxAttempts: 3,
         initialDelay: 0.5,
@@ -126,4 +126,3 @@ func performWithRetry<T>(
     // All retries exhausted
     throw lastError
 }
-

--- a/app/macos/hyperwhisper/Utilities/Retrying.swift
+++ b/app/macos/hyperwhisper/Utilities/Retrying.swift
@@ -60,10 +60,14 @@ struct RetryConfiguration {
     /// a user-blocking, explicitly-triggered activation, but is far too slow for a
     /// silent background check — a paying user would sit "unlicensed" (cache not
     /// yet consulted, cloud identifier not yet resolved) for up to half a minute on
-    /// a flaky network. A short, bounded retry (≈2s of total backoff sleep across 3
-    /// attempts) lets a transient blip self-heal quickly; once attempts are
-    /// exhausted, `LicenseNetworkService` falls back to the last cached verdict
-    /// rather than continuing to hammer the network. See HYPERWHISPER-F4.
+    /// a flaky network. A short, bounded retry (≈1.5–1.8s of total backoff sleep
+    /// across the 2 sleeps between 3 attempts — no sleep follows the final
+    /// attempt) lets a transient blip self-heal quickly; `LicenseNetworkService`
+    /// also uses a much shorter per-request timeout for this call
+    /// (`licenseLaunchValidationTimeout`, 2.5s vs the normal 10s) so a hung
+    /// request can't itself eat the whole budget. Once attempts are exhausted,
+    /// it falls back to the last cached verdict rather than continuing to
+    /// hammer the network. See HYPERWHISPER-F4.
     static let licenseLaunchValidation = RetryConfiguration(
         maxAttempts: 3,
         initialDelay: 0.5,

--- a/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
+++ b/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
@@ -1,0 +1,87 @@
+//
+//  LicenseNetworkResilienceTests.swift
+//  hyperwhisperTests
+//
+//  HYPERWHISPER-F4: launch-time license validation must self-heal from a
+//  transient network blip (short bounded retry) and, once retries are
+//  exhausted, fall back to the last cached SERVER verdict rather than
+//  surfacing a hard error to a paying user. These tests cover the pure,
+//  synchronously-testable pieces of that fix:
+//    - RetryConfiguration.licenseLaunchValidation stays short and bounded
+//      (tighter than the general-purpose `.cloud` budget).
+//    - LicenseNetworkService.isNetworkFailure classifies connectivity errors
+//      (timeout/no connection/DNS/connection refused) distinctly from other
+//      errors, so the offline diagnostic signal can tell them apart.
+//
+//  The end-to-end retry → cache-fallback flow itself lives in
+//  `LicenseNetworkService.validateLicense` and is exercised indirectly via the
+//  Rust `hw-license::cache` golden tests (offline_fallback_uses_cache_within_grace
+//  / offline_fallback_invalid_after_grace), since that's where the cache
+//  semantics are the single source of truth for all platforms.
+//
+
+import Testing
+import Foundation
+@testable import HyperWhisper
+
+struct LicenseNetworkResilienceTests {
+
+    // MARK: - RetryConfiguration.licenseLaunchValidation
+
+    @Test func launchValidationRetryIsShortAndBounded() {
+        let config = RetryConfiguration.licenseLaunchValidation
+        #expect(config.maxAttempts == 3)
+
+        // Total backoff sleep across all retryable attempts must stay a few
+        // seconds at most — this is what lets a transient blip at launch
+        // self-heal without leaving a paying user looking unlicensed for long.
+        let totalBackoff = (1..<config.maxAttempts).reduce(0.0) { sum, attempt in
+            sum + config.delay(for: attempt)
+        }
+        #expect(totalBackoff < 5.0)
+
+        // Every single delay (even accounting for jitter) stays well under the
+        // `.cloud` budget's own per-attempt ceiling.
+        for attempt in 1..<config.maxAttempts {
+            #expect(config.delay(for: attempt) <= config.maxDelay)
+        }
+    }
+
+    @Test func launchValidationRetryIsTighterThanCloudDefault() {
+        // The launch-time budget is deliberately tighter than `.cloud` (used for
+        // explicit, user-triggered activation) — a silent background check
+        // should not make a paying user wait anywhere near as long as an
+        // explicit "Activate" button press already implies.
+        let launch = RetryConfiguration.licenseLaunchValidation
+        let cloud = RetryConfiguration.cloud
+
+        #expect(launch.initialDelay < cloud.initialDelay)
+        #expect(launch.maxDelay < cloud.maxDelay)
+        #expect(launch.delay(for: 1) < cloud.delay(for: 1))
+    }
+
+    // MARK: - LicenseNetworkService.isNetworkFailure
+
+    @Test func classifiesConnectivityErrorsAsNetworkFailures() {
+        #expect(LicenseNetworkService.isNetworkFailure(URLError(.timedOut)))
+        #expect(LicenseNetworkService.isNetworkFailure(URLError(.notConnectedToInternet)))
+        #expect(LicenseNetworkService.isNetworkFailure(URLError(.cannotFindHost)))
+        #expect(LicenseNetworkService.isNetworkFailure(URLError(.cannotConnectToHost)))
+        #expect(LicenseNetworkService.isNetworkFailure(URLError(.dnsLookupFailed)))
+        #expect(LicenseNetworkService.isNetworkFailure(URLError(.networkConnectionLost)))
+    }
+
+    @Test func doesNotClassifyServerVerdictsAsNetworkFailures() {
+        // A deliberately-thrown "retry this transient server error" URLError
+        // (constructed from a raw 500/429 status code, see validateLicense) must
+        // NOT be misclassified as a connectivity failure — it's a server-side
+        // condition, not "the network isn't up yet".
+        #expect(!LicenseNetworkService.isNetworkFailure(URLError(URLError.Code(rawValue: 500))))
+        #expect(!LicenseNetworkService.isNetworkFailure(URLError(URLError.Code(rawValue: 429))))
+    }
+
+    @Test func doesNotClassifyUnrelatedErrorsAsNetworkFailures() {
+        let unrelated = NSError(domain: "SomeOtherDomain", code: 1, userInfo: nil)
+        #expect(!LicenseNetworkService.isNetworkFailure(unrelated))
+    }
+}

--- a/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
+++ b/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
@@ -74,10 +74,12 @@ struct LicenseNetworkResilienceTests {
         }
         #expect(totalBackoff < 5.0)
 
-        // Every single delay (even accounting for jitter) stays well under the
-        // `.cloud` budget's own per-attempt ceiling.
+        // Pin the launch preset's absolute per-delay ceiling. Comparing a
+        // generated delay to config.maxDelay is vacuous because delay(for:)
+        // clamps to maxDelay by construction.
+        #expect(config.maxDelay <= 2.0)
         for attempt in 1..<config.maxAttempts {
-            #expect(config.delay(for: attempt) <= config.maxDelay)
+            #expect(config.delay(for: attempt) <= 2.0)
         }
     }
 
@@ -203,7 +205,10 @@ struct LicenseNetworkResilienceTests {
         // and retry preset used to be selected via two independent ternaries on
         // the same `isLaunchValidation` bool ~18 lines apart. Now both come from
         // one lookup — assert they stay paired correctly for the launch case.
-        let policy = LicenseNetworkService.requestPolicy(isLaunchValidation: true)
+        let policy = LicenseNetworkService.requestPolicy(
+            isLaunchValidation: true,
+            hasCachedVerdict: true
+        )
         #expect(policy.requestTimeout == NetworkConfig.licenseLaunchValidationTimeout)
         #expect(policy.retryConfig.maxAttempts == RetryConfiguration.licenseLaunchValidation.maxAttempts)
         #expect(policy.retryConfig.initialDelay == RetryConfiguration.licenseLaunchValidation.initialDelay)
@@ -211,7 +216,21 @@ struct LicenseNetworkResilienceTests {
     }
 
     @Test func requestPolicyPairsNormalSettingsForExplicitActivation() {
-        let policy = LicenseNetworkService.requestPolicy(isLaunchValidation: false)
+        let policy = LicenseNetworkService.requestPolicy(
+            isLaunchValidation: false,
+            hasCachedVerdict: true
+        )
+        #expect(policy.requestTimeout == NetworkConfig.licenseValidationTimeout)
+        #expect(policy.retryConfig.maxAttempts == RetryConfiguration.cloud.maxAttempts)
+        #expect(policy.retryConfig.initialDelay == RetryConfiguration.cloud.initialDelay)
+        #expect(policy.retryConfig.maxDelay == RetryConfiguration.cloud.maxDelay)
+    }
+
+    @Test func launchValidationWithoutCachedFallbackKeepsNormalSettings() {
+        let policy = LicenseNetworkService.requestPolicy(
+            isLaunchValidation: true,
+            hasCachedVerdict: false
+        )
         #expect(policy.requestTimeout == NetworkConfig.licenseValidationTimeout)
         #expect(policy.retryConfig.maxAttempts == RetryConfiguration.cloud.maxAttempts)
         #expect(policy.retryConfig.initialDelay == RetryConfiguration.cloud.initialDelay)

--- a/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
+++ b/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
@@ -9,9 +9,19 @@
 //  synchronously-testable pieces of that fix:
 //    - RetryConfiguration.licenseLaunchValidation stays short and bounded
 //      (tighter than the general-purpose `.cloud` budget).
+//    - NetworkConfig.licenseLaunchValidationTimeout (the per-request timeout
+//      for the same call) is also much shorter than the normal
+//      `licenseValidationTimeout`, so the retry preset's short backoff isn't
+//      undermined by each individual attempt still hanging for the full 10s.
 //    - LicenseNetworkService.isNetworkFailure classifies connectivity errors
 //      (timeout/no connection/DNS/connection refused) distinctly from other
 //      errors, so the offline diagnostic signal can tell them apart.
+//    - A cached Expired/Invalid verdict within the 7-day grace is a real cache
+//      hit (`licenseCachedStatusWithinGrace` returns non-nil) even though it's
+//      not an "active" verdict (`licenseOfflineFallbackOutcome(...).isValid`
+//      is false) — this is the exact distinction `validateLicense`'s offline
+//      branch must make to avoid firing the `offline_no_cache` Sentry signal
+//      for a genuinely-cached, merely-non-active verdict.
 //
 //  The end-to-end retry → cache-fallback flow itself lives in
 //  `LicenseNetworkService.validateLicense` and is exercised indirectly via the
@@ -23,6 +33,19 @@
 import Testing
 import Foundation
 @testable import HyperWhisper
+
+/// Minimal in-memory `KeyValueStore` (the `hw-license` core's callback
+/// interface) for exercising the cache/grace/offline-fallback core functions
+/// directly, without touching `RustLicenseStore`'s real UserDefaults +
+/// one-shot Core Data usage seed (irrelevant here and unnecessary coupling
+/// for a pure cache-semantics test).
+private final class FakeKeyValueStore: KeyValueStore {
+    private var storage: [String: String] = [:]
+
+    func get(key: String) -> String? { storage[key] }
+    func set(key: String, value: String) { storage[key] = value }
+    func delete(key: String) { storage.removeValue(forKey: key) }
+}
 
 struct LicenseNetworkResilienceTests {
 
@@ -83,5 +106,98 @@ struct LicenseNetworkResilienceTests {
     @Test func doesNotClassifyUnrelatedErrorsAsNetworkFailures() {
         let unrelated = NSError(domain: "SomeOtherDomain", code: 1, userInfo: nil)
         #expect(!LicenseNetworkService.isNetworkFailure(unrelated))
+    }
+
+    // MARK: - NetworkConfig.licenseLaunchValidationTimeout
+
+    @Test func launchValidationPerRequestTimeoutIsMuchShorterThanDefault() {
+        // The retry preset's short backoff is pointless if each individual
+        // attempt still hangs for the full 10s `licenseValidationTimeout` — the
+        // per-request timeout for launch-time validation must also be tightened
+        // (see `LicenseNetworkService.validateLicense`'s `requestTimeout`
+        // selection) so the worst case (all attempts time out) stays a
+        // single-digit-second budget instead of ~30s.
+        #expect(NetworkConfig.licenseLaunchValidationTimeout < NetworkConfig.licenseValidationTimeout)
+        #expect(NetworkConfig.licenseLaunchValidationTimeout <= 3.0)
+
+        // Sanity bound on the actual worst case this enables: 3 attempts at the
+        // shorter per-request timeout plus the launch retry preset's total
+        // backoff sleep should land in the single digits, nowhere near the old
+        // ~30s (3 × 10s) worst case.
+        let launch = RetryConfiguration.licenseLaunchValidation
+        let totalBackoff = (1..<launch.maxAttempts).reduce(0.0) { $0 + launch.delay(for: $1) }
+        let worstCase = Double(launch.maxAttempts) * NetworkConfig.licenseLaunchValidationTimeout + totalBackoff
+        #expect(worstCase < 10.0)
+    }
+
+    // MARK: - Offline fallback: cached-but-non-active verdicts are still a cache hit
+
+    @Test func cachedExpiredVerdictWithinGraceIsARealCacheHit() {
+        // Regression test for the mislabeled `offline_no_cache` signal: a cached
+        // Expired verdict within the 7-day grace is a genuine cache hit — just
+        // not an ACTIVE one. `outcome.isValid` alone (`status == .active`) must
+        // NOT be used to decide whether to fire the "no cached fallback"
+        // diagnostic; `licenseCachedStatusWithinGrace` is the correct signal for
+        // "is there a cached verdict at all."
+        let store = FakeKeyValueStore()
+        let now = RustLicenseTime.nowUTC()
+
+        licensePersistValidationVerdict(store: store, status: .active, attemptedKey: "KEY-1", nowUnixSecs: now)
+        // Re-validating the same key later comes back Expired, still within grace.
+        licensePersistValidationVerdict(store: store, status: .expired, attemptedKey: "KEY-1", nowUnixSecs: now)
+
+        let outcome = licenseOfflineFallbackOutcome(store: store, nowUnixSecs: now)
+        #expect(outcome.status == .expired)
+        #expect(!outcome.isValid) // Expired ≠ Active, so isValid is false here...
+
+        // ...but there IS a real cached verdict to fall back on — the
+        // offline_no_cache alarm must NOT fire in this case.
+        let hasCachedVerdict = licenseCachedStatusWithinGrace(store: store, nowUnixSecs: now) != nil
+        #expect(hasCachedVerdict)
+    }
+
+    @Test func cachedInvalidVerdictWithinGraceIsARealCacheHit() {
+        let store = FakeKeyValueStore()
+        let now = RustLicenseTime.nowUTC()
+
+        licensePersistValidationVerdict(store: store, status: .active, attemptedKey: "KEY-1", nowUnixSecs: now)
+        licensePersistValidationVerdict(store: store, status: .invalid, attemptedKey: "KEY-1", nowUnixSecs: now)
+
+        let outcome = licenseOfflineFallbackOutcome(store: store, nowUnixSecs: now)
+        #expect(outcome.status == .invalid)
+        #expect(!outcome.isValid)
+
+        let hasCachedVerdict = licenseCachedStatusWithinGrace(store: store, nowUnixSecs: now) != nil
+        #expect(hasCachedVerdict)
+    }
+
+    @Test func noCachedVerdictAtAllIsCorrectlyDetectedAsNoCache() {
+        // The complementary case: nothing was ever validated, so there is truly
+        // no cached verdict — THIS is the case that should fire the
+        // offline_no_cache signal.
+        let store = FakeKeyValueStore()
+        let now = RustLicenseTime.nowUTC()
+
+        let outcome = licenseOfflineFallbackOutcome(store: store, nowUnixSecs: now)
+        #expect(!outcome.isValid)
+
+        let hasCachedVerdict = licenseCachedStatusWithinGrace(store: store, nowUnixSecs: now) != nil
+        #expect(!hasCachedVerdict)
+    }
+
+    @Test func cachedVerdictPastGraceIsCorrectlyDetectedAsNoCache() {
+        // A cached verdict that has fallen out of the 7-day grace window is, for
+        // this purpose, equivalent to "no cache" — it's no longer a usable
+        // safety net.
+        let store = FakeKeyValueStore()
+        let t0 = RustLicenseTime.nowUTC()
+        licensePersistValidationVerdict(store: store, status: .active, attemptedKey: "KEY-1", nowUnixSecs: t0)
+
+        let farFuture = t0 + 604_800 + 10 // just past the 7-day grace period
+        let outcome = licenseOfflineFallbackOutcome(store: store, nowUnixSecs: farFuture)
+        #expect(!outcome.isValid)
+
+        let hasCachedVerdict = licenseCachedStatusWithinGrace(store: store, nowUnixSecs: farFuture) != nil
+        #expect(!hasCachedVerdict)
     }
 }

--- a/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
+++ b/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
@@ -29,6 +29,17 @@
 //  / offline_fallback_invalid_after_grace), since that's where the cache
 //  semantics are the single source of truth for all platforms.
 //
+//  REVIEW ROUND 2 additions:
+//    - `LicenseNetworkService.requestPolicy(isLaunchValidation:)` pairs the
+//      per-request timeout and retry preset from a single lookup so they can't
+//      drift out of sync (previously two independent ternaries).
+//    - `NetworkConfig.licenseLaunchValidationRetrySoonDelay` backs a short,
+//      one-shot background retry `LicenseManager` schedules after a launch-time
+//      validation falls back to cache specifically due to a network failure —
+//      so a merely-slow-but-live network doesn't ride a stale cached verdict
+//      for up to a week. `LicenseValidationResult.networkFailureFallback` is
+//      the signal that triggers it.
+//
 
 import Testing
 import Foundation
@@ -183,6 +194,78 @@ struct LicenseNetworkResilienceTests {
 
         let hasCachedVerdict = licenseCachedStatusWithinGrace(store: store, nowUnixSecs: now) != nil
         #expect(!hasCachedVerdict)
+    }
+
+    // MARK: - RequestPolicy: single lookup pairing timeout + retry preset
+
+    @Test func requestPolicyPairsTighterSettingsForLaunchValidation() {
+        // Regression test for the review-round-2 fix: the per-request timeout
+        // and retry preset used to be selected via two independent ternaries on
+        // the same `isLaunchValidation` bool ~18 lines apart. Now both come from
+        // one lookup — assert they stay paired correctly for the launch case.
+        let policy = LicenseNetworkService.requestPolicy(isLaunchValidation: true)
+        #expect(policy.requestTimeout == NetworkConfig.licenseLaunchValidationTimeout)
+        #expect(policy.retryConfig.maxAttempts == RetryConfiguration.licenseLaunchValidation.maxAttempts)
+        #expect(policy.retryConfig.initialDelay == RetryConfiguration.licenseLaunchValidation.initialDelay)
+        #expect(policy.retryConfig.maxDelay == RetryConfiguration.licenseLaunchValidation.maxDelay)
+    }
+
+    @Test func requestPolicyPairsNormalSettingsForExplicitActivation() {
+        let policy = LicenseNetworkService.requestPolicy(isLaunchValidation: false)
+        #expect(policy.requestTimeout == NetworkConfig.licenseValidationTimeout)
+        #expect(policy.retryConfig.maxAttempts == RetryConfiguration.cloud.maxAttempts)
+        #expect(policy.retryConfig.initialDelay == RetryConfiguration.cloud.initialDelay)
+        #expect(policy.retryConfig.maxDelay == RetryConfiguration.cloud.maxDelay)
+    }
+
+    // MARK: - networkFailureFallback signal (drives the launch-time retry-soon)
+
+    @Test func licenseValidationResultDefaultsNetworkFailureFallbackToFalse() {
+        let result = LicenseValidationResult(
+            isValid: true,
+            status: .active,
+            customerId: nil,
+            customerEmail: nil,
+            customerName: nil,
+            errorMessage: nil
+        )
+        #expect(!result.networkFailureFallback)
+    }
+
+    @Test func adaptPropagatesNetworkFailureFallbackFlagWhenSet() {
+        // `adapt(_:networkFailureFallback:)` is what `validateLicense`'s offline
+        // catch-branch uses to tag a result as "served from cache because we
+        // couldn't reach the network" — the signal `LicenseManager` checks to
+        // decide whether to schedule the short background retry-soon.
+        let outcome = ValidationOutcome(
+            isValid: true,
+            status: .active,
+            customerId: "cust_1",
+            customerEmail: "person@example.com",
+            expiresAt: nil,
+            errorMessage: "Using cached license (offline)"
+        )
+
+        let fellBackDueToNetwork = LicenseNetworkService.adapt(outcome, networkFailureFallback: true)
+        #expect(fellBackDueToNetwork.networkFailureFallback)
+        #expect(fellBackDueToNetwork.isValid) // adapt() doesn't touch the underlying verdict
+
+        // Default (omitted) stays false — every non-offline-fallback call site
+        // (200 success, terminal HTTP error, `getCachedLicenseStatus`) must not
+        // be misclassified as a network-failure fallback.
+        let normal = LicenseNetworkService.adapt(outcome)
+        #expect(!normal.networkFailureFallback)
+    }
+
+    // MARK: - Retry-soon delay: prompt, and nowhere close to the cache cycle it shortcuts
+
+    @Test func retrySoonDelayIsPromptAndFarShorterThanTheCacheCycle() {
+        // "Soon" means within roughly the next minute, not anywhere near the
+        // 24h validation cache or the 7-day offline grace it exists to shortcut.
+        #expect(NetworkConfig.licenseLaunchValidationRetrySoonDelay > 0)
+        #expect(NetworkConfig.licenseLaunchValidationRetrySoonDelay <= 120)
+        #expect(NetworkConfig.licenseLaunchValidationRetrySoonDelay < NetworkConfig.validationCacheDuration)
+        #expect(NetworkConfig.licenseLaunchValidationRetrySoonDelay < NetworkConfig.offlineGracePeriod)
     }
 
     @Test func cachedVerdictPastGraceIsCorrectlyDetectedAsNoCache() {

--- a/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
+++ b/app/macos/hyperwhisperTests/LicenseNetworkResilienceTests.swift
@@ -276,6 +276,102 @@ struct LicenseNetworkResilienceTests {
         #expect(!normal.networkFailureFallback)
     }
 
+    // MARK: - Retry persistence: stale in-flight responses cannot restore old keys
+
+    @MainActor
+    @Test func staleRetryVerdictDoesNotRestoreAReplacedLicense() {
+        let store = FakeKeyValueStore()
+        let t0 = RustLicenseTime.nowUTC()
+
+        licensePersistValidationVerdict(
+            store: store,
+            status: .active,
+            attemptedKey: "KEY-OLD",
+            nowUnixSecs: t0
+        )
+        licensePersistValidationVerdict(
+            store: store,
+            status: .active,
+            attemptedKey: "KEY-NEW",
+            nowUnixSecs: t0 + 1
+        )
+        licensePersistValidationVerdict(
+            store: store,
+            status: .expired,
+            attemptedKey: "KEY-NEW",
+            nowUnixSecs: t0 + 2
+        )
+
+        // The delayed retry for KEY-OLD receives a late Active response after
+        // KEY-NEW became current. Its expected-key contract must reject the
+        // persistence before Rust can restore KEY-OLD or overwrite KEY-NEW's
+        // cached verdict.
+        let didPersist = LicenseNetworkService.persistValidationVerdictIfCurrent(
+            store: store,
+            status: .active,
+            attemptedKey: "KEY-OLD",
+            expectedStoredLicenseKey: "KEY-OLD",
+            nowUnixSecs: t0 + 3,
+            isCancelled: false
+        )
+
+        #expect(!didPersist)
+        #expect(licenseStoredLicenseKey(store: store) == "KEY-NEW")
+        #expect(licenseCachedStatusWithinGrace(store: store, nowUnixSecs: t0 + 3) == .expired)
+    }
+
+    @MainActor
+    @Test func cancelledRetryVerdictDoesNotPersistWhenKeyStillMatches() {
+        let store = FakeKeyValueStore()
+        let t0 = RustLicenseTime.nowUTC()
+
+        licensePersistValidationVerdict(
+            store: store,
+            status: .active,
+            attemptedKey: "KEY-1",
+            nowUnixSecs: t0
+        )
+
+        let didPersist = LicenseNetworkService.persistValidationVerdictIfCurrent(
+            store: store,
+            status: .expired,
+            attemptedKey: "KEY-1",
+            expectedStoredLicenseKey: "KEY-1",
+            nowUnixSecs: t0 + 1,
+            isCancelled: true
+        )
+
+        #expect(!didPersist)
+        #expect(licenseStoredLicenseKey(store: store) == "KEY-1")
+        #expect(licenseCachedStatusWithinGrace(store: store, nowUnixSecs: t0 + 1) == .active)
+    }
+
+    @MainActor
+    @Test func explicitActivationCanStillPersistAReplacementKey() {
+        let store = FakeKeyValueStore()
+        let t0 = RustLicenseTime.nowUTC()
+
+        licensePersistValidationVerdict(
+            store: store,
+            status: .active,
+            attemptedKey: "KEY-OLD",
+            nowUnixSecs: t0
+        )
+
+        let didPersist = LicenseNetworkService.persistValidationVerdictIfCurrent(
+            store: store,
+            status: .active,
+            attemptedKey: "KEY-NEW",
+            expectedStoredLicenseKey: nil,
+            nowUnixSecs: t0 + 1,
+            isCancelled: false
+        )
+
+        #expect(didPersist)
+        #expect(licenseStoredLicenseKey(store: store) == "KEY-NEW")
+        #expect(licenseCachedStatusWithinGrace(store: store, nowUnixSecs: t0 + 1) == .active)
+    }
+
     // MARK: - Retry-soon delay: prompt, and nowhere close to the cache cycle it shortcuts
 
     @Test func retrySoonDelayIsPromptAndFarShorterThanTheCacheCycle() {

--- a/app/macos/hyperwhisperTests/TranscriptionErrorClassificationTests.swift
+++ b/app/macos/hyperwhisperTests/TranscriptionErrorClassificationTests.swift
@@ -7,6 +7,7 @@
 //  side breaks compilation here — that's the point. Do not add a `default:`.
 //
 
+import Foundation
 import Testing
 @testable import HyperWhisper
 

--- a/app/macos/hyperwhisperTests/TranscriptionErrorClassificationTests.swift
+++ b/app/macos/hyperwhisperTests/TranscriptionErrorClassificationTests.swift
@@ -30,6 +30,23 @@ struct TranscriptionErrorClassificationTests {
         }
     }
 
+    @Test func transientURLErrorCodesIsTheSingleCanonicalSetForConnectivityCodes() {
+        // Regression test for the review-round-2 fix: `classifyTranscriptionError`'s
+        // bare-`URLError` branch used to keep its own narrower, independent
+        // 6-code list instead of reusing `transientURLErrorCodes` (missing
+        // `.dataNotAllowed` / `.internationalRoamingOff`), even though the doc
+        // comment already called this the shared canonical set. Both
+        // `classifyTranscriptionError` and `shouldCaptureTranscriptionErrorInSentry`
+        // now derive from this same property — pin its exact membership so a
+        // future edit can't silently narrow it again without this test catching it.
+        let expected: Set<URLError.Code> = [
+            .notConnectedToInternet, .networkConnectionLost, .timedOut,
+            .dnsLookupFailed, .cannotFindHost, .cannotConnectToHost,
+            .dataNotAllowed, .internationalRoamingOff
+        ]
+        #expect(TranscriptionPipeline.transientURLErrorCodes == expected)
+    }
+
     @Test func transcriptionFailureFingerprintIncludesClassificationAndStage() {
         let classification = TranscriptionPipeline.TranscriptionErrorClassification(
             category: "auth",


### PR DESCRIPTION
## Problem

Sentry HYPERWHISPER-F4: License validation network error — 419 occurrences since January, 26 users, component `license`, endpoint `/api/license/validate`. Sample event: app launch at 05:08:35, error at 05:08:38 (~3s post-launch) — consistent with launch-time license validation racing a network that isn't up yet (wake-from-sleep, captive portal, DNS not resolved yet).

## Investigation

- A cached "last known good" license verdict + 7-day offline grace already existed (`hw-license` cache, unmodified by PR #35), and `LicenseNetworkService` already retried and fell back to cache silently on exhaustion — so launch never hard-failed to the user.
- The gap: launch-time revalidation reused the same `.cloud` retry preset as explicit user-triggered "Activate" (3 attempts, worst case ~30s). Since this runs silently in the background at every launch, a flaky-network user could sit on stale `.trial` status for up to 30s before cache fallback kicked in — matching the Sentry timing.
- PR #35 fixed a different, unrelated bug (validation cache not keyed to the license key, causing a rejected replacement key to clobber a valid cached status). Confirmed via its diff — it doesn't touch network-failure resilience.

## Fix

- New `RetryConfiguration.licenseLaunchValidation` — a short, bounded retry preset (3 attempts, ~2s total backoff) used only for launch-time validation, distinct from the `.cloud` preset used by explicit user-triggered activation (unchanged).
- `LicenseNetworkService.validateLicense(_:isLaunchValidation:)` classifies failures via `isNetworkFailure(_:)` (connectivity-only URLErrors) vs. real server verdicts, and now emits a distinct, non-noisy Sentry signal (`component: license, reason: offline_no_cache`) only when retries are exhausted *and* there's no cached verdict to fall back on. Successful cache-fallback recovery stays silent by design — no user-facing error, no Sentry noise.
- `LicenseManager.loadStoredLicense()` now flags its call as launch validation so it gets the tighter budget.
- New unit tests for the retry preset bounds and the network-failure classifier.

## Hard constraint honored

Entitlement enforcement is untouched and stays fully server-side — no client-side bypass, no fake/test keys, no weakening of the actual license check. This only changes how the client tolerates *not yet being able to reach the server* at launch, by trusting a verdict the server already gave it earlier (the existing cache) instead of surfacing an error.

## Out of scope (flagging, not fixing here)

Same Sentry event's logs show an unrelated Core Data migration failure (`NSCocoaErrorDomain 134100`, store model version incompatible) — supports the ongoing V3/V4 Core Data migration investigation. Not touched in this PR.

Refs HYPERWHISPER-F4.

---
Requested in Slack. Opened by Claude running in a Percy sandbox.