### PR TITLE
fix(macos): revalidate license and retry once on transcribe 401/403

### DIFF
--- a/app/macos/hyperwhisper/Managers/HyperWhisperCloudManager.swift
+++ b/app/macos/hyperwhisper/Managers/HyperWhisperCloudManager.swift
@@ -217,10 +217,18 @@ class HyperWhisperCloudManager: ObservableObject {
 
             return fetchedCredits
 
-        } catch let error as HyperWhisperCloudError {
-            lastError = error.localizedDescription
-            throw error
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
+            if Self.isCancellationError(error) {
+                throw CancellationError()
+            }
+
+            if let cloudError = error as? HyperWhisperCloudError {
+                lastError = cloudError.localizedDescription
+                throw cloudError
+            }
+
             let errorMessage = "Failed to fetch credits: \(error.localizedDescription)"
             lastError = errorMessage
             AppLogger.network.error("HyperWhisper Cloud credit fetch failed · error=\(error.localizedDescription, privacy: .public)")
@@ -232,6 +240,16 @@ class HyperWhisperCloudManager: ObservableObject {
             }
             throw HyperWhisperCloudError.transientNetwork(error.localizedDescription)
         }
+    }
+
+    nonisolated static func isCancellationError(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return true
+        }
+
+        let nsError = error as NSError
+        return (nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled)
+            || Task.isCancelled
     }
 
     /// Refreshes credit balance (bypasses cache)

--- a/app/macos/hyperwhisper/Managers/HyperWhisperCloudManager.swift
+++ b/app/macos/hyperwhisper/Managers/HyperWhisperCloudManager.swift
@@ -119,8 +119,29 @@ class HyperWhisperCloudManager: ObservableObject {
     /// - Parameter forceRefresh: If true, bypass cache and fetch fresh data
     /// - Returns: Credit balance or throws error
     func fetchCredits(forceRefresh: Bool = false) async throws -> HyperWhisperCloudCredits {
+        try await fetchCredits(forceRefresh: forceRefresh, identifierOverride: nil)
+    }
+
+    /// Forces the Fly backend to refresh the shared license-verdict cache for
+    /// the exact key that will be used by a recovered transcription request.
+    ///
+    /// This intentionally goes through `/usage?force_refresh=true`: that route
+    /// revalidates against the licensing API and overwrites the same Redis entry
+    /// consumed by `/transcribe` and `/post-process`.
+    func refreshServerLicenseCache(for identifier: String) async throws {
+        let refreshed = try await fetchCredits(forceRefresh: true, identifierOverride: identifier)
+        guard refreshed.isLicensed else {
+            throw HyperWhisperCloudError.invalidResponse("Server license-cache refresh did not confirm a licensed account")
+        }
+    }
+
+    private func fetchCredits(
+        forceRefresh: Bool,
+        identifierOverride: String?
+    ) async throws -> HyperWhisperCloudCredits {
         // Check cache first
-        if !forceRefresh,
+        if identifierOverride == nil,
+           !forceRefresh,
            let cachedCredits = credits,
            let lastFetch = lastFetchTime,
            Date().timeIntervalSince(lastFetch) < cacheDuration {
@@ -138,7 +159,12 @@ class HyperWhisperCloudManager: ObservableObject {
 
         do {
             // Get identifier from license manager
-            let (identifier, _) = licenseManager.getTranscriptionIdentifier()
+            let identifier: String
+            if let identifierOverride {
+                identifier = identifierOverride
+            } else {
+                identifier = licenseManager.getTranscriptionIdentifier().identifier
+            }
 
             // Build request URL with optional force_refresh parameter
             // When forceRefresh is true, the backend will bypass its cache and fetch fresh data

--- a/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
@@ -380,7 +380,7 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
         // =====================================================================
         // STEP 3: Perform request via the shared executor + core retry loop.
         // =====================================================================
-        let response = try await Self.performTranscribeRequestWithLicenseRecovery(
+        let requestResult = try await Self.performTranscribeRequestWithLicenseRecovery(
             identifier: identifier,
             isLicensed: isLicensed,
             send: sendTranscribeRequest,
@@ -389,8 +389,14 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
             },
             currentIdentifier: {
                 await licenseManager.getTranscriptionIdentifier()
+            },
+            refreshServerAuthCache: { refreshedIdentifier in
+                try await creditManager.refreshServerLicenseCache(for: refreshedIdentifier)
             }
         )
+        let response = requestResult.response
+        let successfulIdentifier = requestResult.identifier
+        let successfulIsLicensed = requestResult.isLicensed
         try throwIfCancelled()
 
         // Parse the success response via the core.
@@ -453,8 +459,8 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
                             session: session,
                             text: segment,
                             prompt: prompt,
-                            identifier: identifier,
-                            isLicensed: isLicensed,
+                            identifier: successfulIdentifier,
+                            isLicensed: successfulIsLicensed,
                             mode: mode
                         )
                         processed.append(output.trimmingCharacters(in: .whitespacesAndNewlines))
@@ -465,8 +471,8 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
                         session: session,
                         text: transcript.text,
                         prompt: prompt,
-                        identifier: identifier,
-                        isLicensed: isLicensed,
+                        identifier: successfulIdentifier,
+                        isLicensed: successfulIsLicensed,
                         mode: mode
                     )
                 }
@@ -521,15 +527,27 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
     /// the freshly resolved identifier still being licensed. A revoked/expired
     /// license must keep the original unauthorized failure instead of silently
     /// re-sending the audio against the guest/device wallet.
+    struct TranscribeRequestResult {
+        let response: HttpResponse
+        let identifier: String
+        let isLicensed: Bool
+    }
+
     static func performTranscribeRequestWithLicenseRecovery(
         identifier: String,
         isLicensed: Bool,
         send: (String, Bool) async throws -> HttpResponse,
         revalidate: (String) async -> LicenseValidationResult,
-        currentIdentifier: () async -> (identifier: String, isLicensed: Bool)
-    ) async throws -> HttpResponse {
+        currentIdentifier: () async -> (identifier: String, isLicensed: Bool),
+        refreshServerAuthCache: (String) async throws -> Void
+    ) async throws -> TranscribeRequestResult {
         do {
-            return try await send(identifier, isLicensed)
+            let response = try await send(identifier, isLicensed)
+            return TranscribeRequestResult(
+                response: response,
+                identifier: identifier,
+                isLicensed: isLicensed
+            )
         } catch let error as TranscriptionError {
             guard case .unauthorized = error, isLicensed else {
                 throw error
@@ -547,7 +565,21 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
                 throw error
             }
 
-            return try await send(refreshed.identifier, refreshed.isLicensed)
+            do {
+                try await refreshServerAuthCache(refreshed.identifier)
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                AppLogger.network.warning("HyperWhisper Cloud server license-cache refresh failed · preserving unauthorized response")
+                throw error
+            }
+
+            let response = try await send(refreshed.identifier, refreshed.isLicensed)
+            return TranscribeRequestResult(
+                response: response,
+                identifier: refreshed.identifier,
+                isLicensed: refreshed.isLicensed
+            )
         }
     }
 

--- a/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
@@ -296,87 +296,95 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
             ? RustCoreMapping.boostVocabularyTerms(from: vocabulary)
             : []
         let trimmedModelId = selectedModelId.isEmpty ? nil : selectedModelId
-
-        let params = RustCoreMapping.transcribeParams(
-            audioPath: audioURL.path,
-            audioMime: contentType,
-            language: language,
-            vocabulary: vocabTermsForCore,
-            baseURL: NetworkConfig.hyperwhisperCloudURL,
-            licenseKey: isLicensed ? identifier : nil,
-            deviceID: isLicensed ? nil : identifier,
-            routedProvider: accuracyTier.sttProvider,
-            routedModel: trimmedModelId,
-            routedDomain: transcriptionDomain
-        )
-
-        let baseRequest: HttpRequest
-        do {
-            baseRequest = try hyperwhisperCloudBuildTranscribeRequest(params: params)
-        } catch let err as HwTranscriptionError {
-            throw RustCoreMapping.mapTranscriptionError(err, providerName: "HyperWhisper Cloud")
-        }
-
-        // The core does not add the platform `mode` query param or `User-Agent`
-        // header (both are HW-Cloud-specific, not part of the shared contract).
-        // Inject them natively while preserving everything the core built.
-        var request = baseRequest
-        if let mode, let modeId = mode.id {
-            request.url = Self.appendingModeQuery(to: request.url, modeId: modeId.uuidString)
-        }
         let userAgent = "HyperWhisper/\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0")"
-        request.headers.append(Header(name: "User-Agent", value: userAgent))
 
-        AppLogger.network.info("HyperWhisper Cloud streaming request · sttProvider=\(accuracyTier.sttProvider, privacy: .public) · fileSizeKB=\(fileSizeBytes / 1024, privacy: .public) · contentType=\(contentType, privacy: .public) · licensed=\(isLicensed, privacy: .public)")
+        // Builds the request for a given identifier and sends it through the
+        // shared executor + core retry loop. Factored out so HYPERWHISPER-T2's
+        // retry-after-revalidation (below) can reuse it instead of duplicating
+        // the request-building/parseError/onTransportError wiring.
+        func sendTranscribeRequest(identifier: String, isLicensed: Bool) async throws -> HttpResponse {
+            let params = RustCoreMapping.transcribeParams(
+                audioPath: audioURL.path,
+                audioMime: contentType,
+                language: language,
+                vocabulary: vocabTermsForCore,
+                baseURL: NetworkConfig.hyperwhisperCloudURL,
+                licenseKey: isLicensed ? identifier : nil,
+                deviceID: isLicensed ? nil : identifier,
+                routedProvider: accuracyTier.sttProvider,
+                routedModel: trimmedModelId,
+                routedDomain: transcriptionDomain
+            )
+
+            let baseRequest: HttpRequest
+            do {
+                baseRequest = try hyperwhisperCloudBuildTranscribeRequest(params: params)
+            } catch let err as HwTranscriptionError {
+                throw RustCoreMapping.mapTranscriptionError(err, providerName: "HyperWhisper Cloud")
+            }
+
+            // The core does not add the platform `mode` query param or `User-Agent`
+            // header (both are HW-Cloud-specific, not part of the shared contract).
+            // Inject them natively while preserving everything the core built.
+            var request = baseRequest
+            if let mode, let modeId = mode.id {
+                request.url = Self.appendingModeQuery(to: request.url, modeId: modeId.uuidString)
+            }
+            request.headers.append(Header(name: "User-Agent", value: userAgent))
+
+            AppLogger.network.info("HyperWhisper Cloud streaming request · sttProvider=\(accuracyTier.sttProvider, privacy: .public) · fileSizeKB=\(fileSizeBytes / 1024, privacy: .public) · contentType=\(contentType, privacy: .public) · licensed=\(isLicensed, privacy: .public)")
+
+            // Cancellation, file streaming, and DNS recovery stay native (in the
+            // executor / session). The core decides retries via nextRetry(...).
+            return try await RustRetry.perform(
+                session: session,
+                buildRequest: { request },
+                parseError: { resp in
+                    // Map the core's classified error, enriching the HW-Cloud 402
+                    // credit context from the response body (remaining/required).
+                    do {
+                        _ = try hyperwhisperCloudParseTranscribeResponse(resp: resp)
+                        // 2xx never reaches parseError; a non-error parse is unexpected.
+                        return TranscriptionError.invalidResponse(details: "unexpected non-error response")
+                    } catch let err as HwTranscriptionError {
+                        let creditDenial = Self.creditDenialContext(from: resp)
+                        if resp.status == 402, let invalidMessage = creditDenial.invalidExhaustedBalanceMessage {
+                            return TranscriptionError.invalidResponse(details: invalidMessage)
+                        }
+                        let (tooBigBytes, tooBigLimit) = RustCoreMapping.fileTooLargeContext(from: resp)
+                        return RustCoreMapping.mapTranscriptionError(
+                            err,
+                            providerName: "HyperWhisper Cloud",
+                            insufficientCredits: (resp.status == 402),
+                            creditsRemaining: creditDenial.remaining,
+                            creditsRequired: creditDenial.required,
+                            fileTooLargeBytes: tooBigBytes,
+                            fileTooLargeLimit: tooBigLimit
+                        )
+                    } catch {
+                        return TranscriptionError.invalidResponse(details: error.localizedDescription)
+                    }
+                },
+                onTransportError: { [weak self] urlError in
+                    // One-shot DNS-cache flush on a network flip — restores the
+                    // recovery the deleted native `performRequestWithRetry` did. The
+                    // existing `performDnsRecoveryReset` is @MainActor and applies its
+                    // own coarse cross-call gate on top of RustRetry's one-shot gate.
+                    if Self.isDnsError(urlError as NSError) {
+                        await self?.performDnsRecoveryReset()
+                    }
+                }
+            )
+        }
 
         // =====================================================================
         // STEP 3: Perform request via the shared executor + core retry loop.
         // =====================================================================
-        // Cancellation, file streaming, and DNS recovery stay native (in the
-        // executor / session). The core decides retries via nextRetry(...).
-        let response = try await RustRetry.perform(
-            session: session,
-            buildRequest: { request },
-            parseError: { resp in
-                // Map the core's classified error, enriching the HW-Cloud 402
-                // credit context from the response body (remaining/required).
-                do {
-                    _ = try hyperwhisperCloudParseTranscribeResponse(resp: resp)
-                    // 2xx never reaches parseError; a non-error parse is unexpected.
-                    return TranscriptionError.invalidResponse(details: "unexpected non-error response")
-                } catch let err as HwTranscriptionError {
-                    let creditDenial = Self.creditDenialContext(from: resp)
-                    if resp.status == 402, let invalidMessage = creditDenial.invalidExhaustedBalanceMessage {
-                        return TranscriptionError.invalidResponse(details: invalidMessage)
-                    }
-                    let (tooBigBytes, tooBigLimit) = RustCoreMapping.fileTooLargeContext(from: resp)
-                    return RustCoreMapping.mapTranscriptionError(
-                        err,
-                        providerName: "HyperWhisper Cloud",
-                        insufficientCredits: (resp.status == 402),
-                        creditsRemaining: creditDenial.remaining,
-                        creditsRequired: creditDenial.required,
-                        fileTooLargeBytes: tooBigBytes,
-                        fileTooLargeLimit: tooBigLimit
-                    )
-                } catch {
-                    return TranscriptionError.invalidResponse(details: error.localizedDescription)
-                }
-            },
-            onTransportError: { [weak self] urlError in
-                // One-shot DNS-cache flush on a network flip — restores the
-                // recovery the deleted native `performRequestWithRetry` did. The
-                // existing `performDnsRecoveryReset` is @MainActor and applies its
-                // own coarse cross-call gate on top of RustRetry's one-shot gate.
-                if Self.isDnsError(urlError as NSError) {
-                    await self?.performDnsRecoveryReset()
-                }
-            }
-        )
+        var response = try await sendTranscribeRequest(identifier: identifier, isLicensed: isLicensed)
         try throwIfCancelled()
 
         // Parse the success response via the core.
-        let transcript: HwTranscript
+        var transcript: HwTranscript
         do {
             transcript = try hyperwhisperCloudParseTranscribeResponse(resp: response)
         } catch let err as HwTranscriptionError {
@@ -386,7 +394,39 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
             // mirroring the success path below (which is otherwise skipped by this
             // re-throw). `defer` can't be used here because invalidateCache() awaits.
             await creditManager.invalidateCache()
-            throw RustCoreMapping.mapTranscriptionError(err, providerName: "HyperWhisper Cloud")
+            let mapped = RustCoreMapping.mapTranscriptionError(err, providerName: "HyperWhisper Cloud")
+
+            // HYPERWHISPER-T2: `identifier` above is a snapshot of the cached
+            // `licenseStatus`, which is only revalidated at launch or once per
+            // 24h (`LicenseNetworkService.shouldRevalidateLicense`), plus a 7-day
+            // offline grace period. A license that lapses/rotates server-side
+            // mid-session keeps being sent as if still valid until that cache
+            // expires, and the core intentionally never retries a 401/403 blind
+            // (`hw-net` `is_retryable`) to avoid retry-storming a genuinely bad
+            // credential. So on `.unauthorized`, force one live revalidation and
+            // retry exactly once with the confirmed-fresh identifier — this fixes
+            // the "cache is just stale" case while still failing fast for an
+            // actually-revoked license.
+            guard case .unauthorized = mapped, isLicensed else {
+                throw mapped
+            }
+
+            AppLogger.network.warning("HyperWhisper Cloud transcribe unauthorized · forcing license revalidation and retrying once")
+            _ = await licenseManager.validateLicense(identifier)
+            let (retryIdentifier, retryIsLicensed) = await licenseManager.getTranscriptionIdentifier()
+
+            let retryResponse = try await sendTranscribeRequest(identifier: retryIdentifier, isLicensed: retryIsLicensed)
+            try throwIfCancelled()
+
+            do {
+                transcript = try hyperwhisperCloudParseTranscribeResponse(resp: retryResponse)
+                // Downstream code (detected-language/credit parsing below) reads
+                // from `response` — repoint it at the successful retry response.
+                response = retryResponse
+            } catch let retryErr as HwTranscriptionError {
+                await creditManager.invalidateCache()
+                throw RustCoreMapping.mapTranscriptionError(retryErr, providerName: "HyperWhisper Cloud")
+            }
         }
 
         // Capture the server-detected language so the pipeline can gate

--- a/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
@@ -380,11 +380,21 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
         // =====================================================================
         // STEP 3: Perform request via the shared executor + core retry loop.
         // =====================================================================
-        var response = try await sendTranscribeRequest(identifier: identifier, isLicensed: isLicensed)
+        let response = try await Self.performTranscribeRequestWithLicenseRecovery(
+            identifier: identifier,
+            isLicensed: isLicensed,
+            send: sendTranscribeRequest,
+            revalidate: { licenseKey in
+                await licenseManager.validateLicense(licenseKey)
+            },
+            currentIdentifier: {
+                await licenseManager.getTranscriptionIdentifier()
+            }
+        )
         try throwIfCancelled()
 
         // Parse the success response via the core.
-        var transcript: HwTranscript
+        let transcript: HwTranscript
         do {
             transcript = try hyperwhisperCloudParseTranscribeResponse(resp: response)
         } catch let err as HwTranscriptionError {
@@ -394,39 +404,7 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
             // mirroring the success path below (which is otherwise skipped by this
             // re-throw). `defer` can't be used here because invalidateCache() awaits.
             await creditManager.invalidateCache()
-            let mapped = RustCoreMapping.mapTranscriptionError(err, providerName: "HyperWhisper Cloud")
-
-            // HYPERWHISPER-T2: `identifier` above is a snapshot of the cached
-            // `licenseStatus`, which is only revalidated at launch or once per
-            // 24h (`LicenseNetworkService.shouldRevalidateLicense`), plus a 7-day
-            // offline grace period. A license that lapses/rotates server-side
-            // mid-session keeps being sent as if still valid until that cache
-            // expires, and the core intentionally never retries a 401/403 blind
-            // (`hw-net` `is_retryable`) to avoid retry-storming a genuinely bad
-            // credential. So on `.unauthorized`, force one live revalidation and
-            // retry exactly once with the confirmed-fresh identifier — this fixes
-            // the "cache is just stale" case while still failing fast for an
-            // actually-revoked license.
-            guard case .unauthorized = mapped, isLicensed else {
-                throw mapped
-            }
-
-            AppLogger.network.warning("HyperWhisper Cloud transcribe unauthorized · forcing license revalidation and retrying once")
-            _ = await licenseManager.validateLicense(identifier)
-            let (retryIdentifier, retryIsLicensed) = await licenseManager.getTranscriptionIdentifier()
-
-            let retryResponse = try await sendTranscribeRequest(identifier: retryIdentifier, isLicensed: retryIsLicensed)
-            try throwIfCancelled()
-
-            do {
-                transcript = try hyperwhisperCloudParseTranscribeResponse(resp: retryResponse)
-                // Downstream code (detected-language/credit parsing below) reads
-                // from `response` — repoint it at the successful retry response.
-                response = retryResponse
-            } catch let retryErr as HwTranscriptionError {
-                await creditManager.invalidateCache()
-                throw RustCoreMapping.mapTranscriptionError(retryErr, providerName: "HyperWhisper Cloud")
-            }
+            throw RustCoreMapping.mapTranscriptionError(err, providerName: "HyperWhisper Cloud")
         }
 
         // Capture the server-detected language so the pipeline can gate
@@ -533,6 +511,44 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
         AppLogger.network.info("HyperWhisper Cloud transcription completed · chars=\(cleanedText.count, privacy: .public) · hasServerCorrection=\(hasCorrection, privacy: .public)")
 
         return cleanedText
+    }
+
+    /// Sends a licensed transcription request, repairing a stale cached license
+    /// exactly once when the HTTP retry layer surfaces a 401/403 as
+    /// `TranscriptionError.unauthorized`.
+    ///
+    /// The retry is deliberately gated on both the live validation verdict and
+    /// the freshly resolved identifier still being licensed. A revoked/expired
+    /// license must keep the original unauthorized failure instead of silently
+    /// re-sending the audio against the guest/device wallet.
+    static func performTranscribeRequestWithLicenseRecovery(
+        identifier: String,
+        isLicensed: Bool,
+        send: (String, Bool) async throws -> HttpResponse,
+        revalidate: (String) async -> LicenseValidationResult,
+        currentIdentifier: () async -> (identifier: String, isLicensed: Bool)
+    ) async throws -> HttpResponse {
+        do {
+            return try await send(identifier, isLicensed)
+        } catch let error as TranscriptionError {
+            guard case .unauthorized = error, isLicensed else {
+                throw error
+            }
+
+            AppLogger.network.warning("HyperWhisper Cloud transcribe unauthorized · forcing license revalidation and retrying once")
+            let revalidation = await revalidate(identifier)
+            try Task.checkCancellation()
+            guard revalidation.isValid else {
+                throw error
+            }
+
+            let refreshed = await currentIdentifier()
+            guard refreshed.isLicensed else {
+                throw error
+            }
+
+            return try await send(refreshed.identifier, refreshed.isLicensed)
+        }
     }
 
     // MARK: - Rust Core Helpers (mode query, credit context, detected language)

--- a/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
@@ -570,6 +570,9 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
             } catch is CancellationError {
                 throw CancellationError()
             } catch {
+                if HyperWhisperCloudManager.isCancellationError(error) {
+                    throw CancellationError()
+                }
                 AppLogger.network.warning("HyperWhisper Cloud server license-cache refresh failed · preserving unauthorized response")
                 throw requestError
             }

--- a/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Providers/Cloud/HyperWhisperCloudProvider.swift
@@ -548,21 +548,21 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
                 identifier: identifier,
                 isLicensed: isLicensed
             )
-        } catch let error as TranscriptionError {
-            guard case .unauthorized = error, isLicensed else {
-                throw error
+        } catch let requestError as TranscriptionError {
+            guard case .unauthorized = requestError, isLicensed else {
+                throw requestError
             }
 
             AppLogger.network.warning("HyperWhisper Cloud transcribe unauthorized · forcing license revalidation and retrying once")
             let revalidation = await revalidate(identifier)
             try Task.checkCancellation()
             guard revalidation.isValid else {
-                throw error
+                throw requestError
             }
 
             let refreshed = await currentIdentifier()
             guard refreshed.isLicensed else {
-                throw error
+                throw requestError
             }
 
             do {
@@ -571,7 +571,7 @@ class HyperWhisperCloudProvider: TranscriptionProvider {
                 throw CancellationError()
             } catch {
                 AppLogger.network.warning("HyperWhisper Cloud server license-cache refresh failed · preserving unauthorized response")
-                throw error
+                throw requestError
             }
 
             let response = try await send(refreshed.identifier, refreshed.isLicensed)

--- a/app/macos/hyperwhisperTests/HyperWhisperCloudLicenseRecoveryTests.swift
+++ b/app/macos/hyperwhisperTests/HyperWhisperCloudLicenseRecoveryTests.swift
@@ -13,7 +13,7 @@ struct HyperWhisperCloudLicenseRecoveryTests {
         let recorder = LicenseRecoveryCallRecorder()
         let success = HttpResponse(status: 200, headers: [], body: Data())
 
-        let response = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
+        let result = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
             identifier: "stale-license",
             isLicensed: true,
             send: { identifier, isLicensed in
@@ -30,16 +30,22 @@ struct HyperWhisperCloudLicenseRecoveryTests {
             currentIdentifier: {
                 await recorder.recordIdentityResolution()
                 return ("refreshed-license", true)
+            },
+            refreshServerAuthCache: { identifier in
+                await recorder.recordServerCacheRefresh(identifier)
             }
         )
 
-        #expect(response == success)
+        #expect(result.response == success)
+        #expect(result.identifier == "refreshed-license")
+        #expect(result.isLicensed)
         #expect(await recorder.sends == [
             .init(identifier: "stale-license", isLicensed: true),
             .init(identifier: "refreshed-license", isLicensed: true)
         ])
         #expect(await recorder.revalidations == ["stale-license"])
         #expect(await recorder.identityResolutions == 1)
+        #expect(await recorder.serverCacheRefreshes == ["refreshed-license"])
     }
 
     @Test func revokedLicenseDoesNotRetryAsGuest() async {
@@ -60,6 +66,9 @@ struct HyperWhisperCloudLicenseRecoveryTests {
                 currentIdentifier: {
                     await recorder.recordIdentityResolution()
                     return ("guest-device", false)
+                },
+                refreshServerAuthCache: { identifier in
+                    await recorder.recordServerCacheRefresh(identifier)
                 }
             )
             Issue.record("Expected the original unauthorized error")
@@ -77,6 +86,7 @@ struct HyperWhisperCloudLicenseRecoveryTests {
         ])
         #expect(await recorder.revalidations == ["revoked-license"])
         #expect(await recorder.identityResolutions == 0)
+        #expect(await recorder.serverCacheRefreshes.isEmpty)
     }
 
     @Test func unauthorizedGuestRequestDoesNotTriggerLicenseRecovery() async {
@@ -97,6 +107,9 @@ struct HyperWhisperCloudLicenseRecoveryTests {
                 currentIdentifier: {
                     await recorder.recordIdentityResolution()
                     return ("unexpected-license", true)
+                },
+                refreshServerAuthCache: { identifier in
+                    await recorder.recordServerCacheRefresh(identifier)
                 }
             )
             Issue.record("Expected unauthorized")
@@ -114,6 +127,49 @@ struct HyperWhisperCloudLicenseRecoveryTests {
         ])
         #expect(await recorder.revalidations.isEmpty)
         #expect(await recorder.identityResolutions == 0)
+        #expect(await recorder.serverCacheRefreshes.isEmpty)
+    }
+
+    @Test func serverCacheRefreshFailurePreservesUnauthorizedWithoutRetry() async {
+        let recorder = LicenseRecoveryCallRecorder()
+
+        do {
+            _ = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
+                identifier: "stale-license",
+                isLicensed: true,
+                send: { identifier, isLicensed in
+                    _ = await recorder.recordSend(identifier: identifier, isLicensed: isLicensed)
+                    throw TranscriptionError.unauthorized(provider: "HyperWhisper Cloud")
+                },
+                revalidate: { identifier in
+                    await recorder.recordRevalidation(identifier)
+                    return Self.validationResult(isValid: true, status: .active)
+                },
+                currentIdentifier: {
+                    await recorder.recordIdentityResolution()
+                    return ("refreshed-license", true)
+                },
+                refreshServerAuthCache: { identifier in
+                    await recorder.recordServerCacheRefresh(identifier)
+                    throw ServerCacheRefreshError.unavailable
+                }
+            )
+            Issue.record("Expected the original unauthorized error")
+        } catch let error as TranscriptionError {
+            guard case .unauthorized = error else {
+                Issue.record("Expected unauthorized, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected TranscriptionError.unauthorized, got \(error)")
+        }
+
+        #expect(await recorder.sends == [
+            .init(identifier: "stale-license", isLicensed: true)
+        ])
+        #expect(await recorder.revalidations == ["stale-license"])
+        #expect(await recorder.identityResolutions == 1)
+        #expect(await recorder.serverCacheRefreshes == ["refreshed-license"])
     }
 
     private static func validationResult(isValid: Bool, status: LicenseStatus) -> LicenseValidationResult {
@@ -128,6 +184,10 @@ struct HyperWhisperCloudLicenseRecoveryTests {
     }
 }
 
+private enum ServerCacheRefreshError: Error {
+    case unavailable
+}
+
 private actor LicenseRecoveryCallRecorder {
     struct Send: Equatable {
         let identifier: String
@@ -137,6 +197,7 @@ private actor LicenseRecoveryCallRecorder {
     private(set) var sends: [Send] = []
     private(set) var revalidations: [String] = []
     private(set) var identityResolutions = 0
+    private(set) var serverCacheRefreshes: [String] = []
 
     func recordSend(identifier: String, isLicensed: Bool) -> Int {
         sends.append(.init(identifier: identifier, isLicensed: isLicensed))
@@ -149,5 +210,9 @@ private actor LicenseRecoveryCallRecorder {
 
     func recordIdentityResolution() {
         identityResolutions += 1
+    }
+
+    func recordServerCacheRefresh(_ identifier: String) {
+        serverCacheRefreshes.append(identifier)
     }
 }

--- a/app/macos/hyperwhisperTests/HyperWhisperCloudLicenseRecoveryTests.swift
+++ b/app/macos/hyperwhisperTests/HyperWhisperCloudLicenseRecoveryTests.swift
@@ -1,0 +1,153 @@
+//
+//  HyperWhisperCloudLicenseRecoveryTests.swift
+//  hyperwhisperTests
+//
+
+import Foundation
+import Testing
+@testable import HyperWhisper
+
+struct HyperWhisperCloudLicenseRecoveryTests {
+
+    @Test func retriesUnauthorizedLicensedRequestWithValidatedLicensedIdentity() async throws {
+        let recorder = LicenseRecoveryCallRecorder()
+        let success = HttpResponse(status: 200, headers: [], body: Data())
+
+        let response = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
+            identifier: "stale-license",
+            isLicensed: true,
+            send: { identifier, isLicensed in
+                let attempt = await recorder.recordSend(identifier: identifier, isLicensed: isLicensed)
+                if attempt == 1 {
+                    throw TranscriptionError.unauthorized(provider: "HyperWhisper Cloud")
+                }
+                return success
+            },
+            revalidate: { identifier in
+                await recorder.recordRevalidation(identifier)
+                return Self.validationResult(isValid: true, status: .active)
+            },
+            currentIdentifier: {
+                await recorder.recordIdentityResolution()
+                return ("refreshed-license", true)
+            }
+        )
+
+        #expect(response == success)
+        #expect(await recorder.sends == [
+            .init(identifier: "stale-license", isLicensed: true),
+            .init(identifier: "refreshed-license", isLicensed: true)
+        ])
+        #expect(await recorder.revalidations == ["stale-license"])
+        #expect(await recorder.identityResolutions == 1)
+    }
+
+    @Test func revokedLicenseDoesNotRetryAsGuest() async {
+        let recorder = LicenseRecoveryCallRecorder()
+
+        do {
+            _ = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
+                identifier: "revoked-license",
+                isLicensed: true,
+                send: { identifier, isLicensed in
+                    _ = await recorder.recordSend(identifier: identifier, isLicensed: isLicensed)
+                    throw TranscriptionError.unauthorized(provider: "HyperWhisper Cloud")
+                },
+                revalidate: { identifier in
+                    await recorder.recordRevalidation(identifier)
+                    return Self.validationResult(isValid: false, status: .expired)
+                },
+                currentIdentifier: {
+                    await recorder.recordIdentityResolution()
+                    return ("guest-device", false)
+                }
+            )
+            Issue.record("Expected the original unauthorized error")
+        } catch let error as TranscriptionError {
+            guard case .unauthorized = error else {
+                Issue.record("Expected unauthorized, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected TranscriptionError.unauthorized, got \(error)")
+        }
+
+        #expect(await recorder.sends == [
+            .init(identifier: "revoked-license", isLicensed: true)
+        ])
+        #expect(await recorder.revalidations == ["revoked-license"])
+        #expect(await recorder.identityResolutions == 0)
+    }
+
+    @Test func unauthorizedGuestRequestDoesNotTriggerLicenseRecovery() async {
+        let recorder = LicenseRecoveryCallRecorder()
+
+        do {
+            _ = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
+                identifier: "guest-device",
+                isLicensed: false,
+                send: { identifier, isLicensed in
+                    _ = await recorder.recordSend(identifier: identifier, isLicensed: isLicensed)
+                    throw TranscriptionError.unauthorized(provider: "HyperWhisper Cloud")
+                },
+                revalidate: { identifier in
+                    await recorder.recordRevalidation(identifier)
+                    return Self.validationResult(isValid: true, status: .active)
+                },
+                currentIdentifier: {
+                    await recorder.recordIdentityResolution()
+                    return ("unexpected-license", true)
+                }
+            )
+            Issue.record("Expected unauthorized")
+        } catch let error as TranscriptionError {
+            guard case .unauthorized = error else {
+                Issue.record("Expected unauthorized, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected TranscriptionError.unauthorized, got \(error)")
+        }
+
+        #expect(await recorder.sends == [
+            .init(identifier: "guest-device", isLicensed: false)
+        ])
+        #expect(await recorder.revalidations.isEmpty)
+        #expect(await recorder.identityResolutions == 0)
+    }
+
+    private static func validationResult(isValid: Bool, status: LicenseStatus) -> LicenseValidationResult {
+        LicenseValidationResult(
+            isValid: isValid,
+            status: status,
+            customerId: nil,
+            customerEmail: nil,
+            customerName: nil,
+            errorMessage: isValid ? nil : "License is no longer active"
+        )
+    }
+}
+
+private actor LicenseRecoveryCallRecorder {
+    struct Send: Equatable {
+        let identifier: String
+        let isLicensed: Bool
+    }
+
+    private(set) var sends: [Send] = []
+    private(set) var revalidations: [String] = []
+    private(set) var identityResolutions = 0
+
+    func recordSend(identifier: String, isLicensed: Bool) -> Int {
+        sends.append(.init(identifier: identifier, isLicensed: isLicensed))
+        return sends.count
+    }
+
+    func recordRevalidation(_ identifier: String) {
+        revalidations.append(identifier)
+    }
+
+    func recordIdentityResolution() {
+        identityResolutions += 1
+    }
+}

--- a/app/macos/hyperwhisperTests/HyperWhisperCloudLicenseRecoveryTests.swift
+++ b/app/macos/hyperwhisperTests/HyperWhisperCloudLicenseRecoveryTests.swift
@@ -172,6 +172,50 @@ struct HyperWhisperCloudLicenseRecoveryTests {
         #expect(await recorder.serverCacheRefreshes == ["refreshed-license"])
     }
 
+    @Test func serverCacheRefreshCancellationPropagatesWithoutRetry() async {
+        let recorder = LicenseRecoveryCallRecorder()
+
+        do {
+            _ = try await HyperWhisperCloudProvider.performTranscribeRequestWithLicenseRecovery(
+                identifier: "stale-license",
+                isLicensed: true,
+                send: { identifier, isLicensed in
+                    _ = await recorder.recordSend(identifier: identifier, isLicensed: isLicensed)
+                    throw TranscriptionError.unauthorized(provider: "HyperWhisper Cloud")
+                },
+                revalidate: { identifier in
+                    await recorder.recordRevalidation(identifier)
+                    return Self.validationResult(isValid: true, status: .active)
+                },
+                currentIdentifier: {
+                    await recorder.recordIdentityResolution()
+                    return ("refreshed-license", true)
+                },
+                refreshServerAuthCache: { identifier in
+                    await recorder.recordServerCacheRefresh(identifier)
+                    throw URLError(.cancelled)
+                }
+            )
+            Issue.record("Expected cancellation")
+        } catch is CancellationError {
+            // Expected: explicit user cancellation must not become unauthorized.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(await recorder.sends == [
+            .init(identifier: "stale-license", isLicensed: true)
+        ])
+        #expect(await recorder.revalidations == ["stale-license"])
+        #expect(await recorder.identityResolutions == 1)
+        #expect(await recorder.serverCacheRefreshes == ["refreshed-license"])
+    }
+
+    @Test func creditRefreshRecognizesURLSessionCancellation() {
+        #expect(HyperWhisperCloudManager.isCancellationError(URLError(.cancelled)))
+        #expect(!HyperWhisperCloudManager.isCancellationError(URLError(.timedOut)))
+    }
+
     private static func validationResult(isValid: Bool, status: LicenseStatus) -> LicenseValidationResult {
         LicenseValidationResult(
             isValid: isValid,

--- a/hyperwhisper-cloud/src/middleware/auth.ts
+++ b/hyperwhisper-cloud/src/middleware/auth.ts
@@ -59,15 +59,13 @@ async function validateLicenseViaApi(licenseKey: string): Promise<{ isValid: boo
 
     console.log(`[License] ${maskedKey}: status=${response.status}, valid=${isValid}, credits=${credits}${data.error ? `, error=${data.error}` : ''}`);
 
-    // A 5xx (cold start, upstream timeout, internal error) is a transient
-    // failure, not proof the license is invalid — caching it would lock a
-    // paying user out for the full LICENSE_CACHE_TTL_SECONDS. Fail this
-    // request closed but leave the cache untouched so the next request
-    // retries the API. A 4xx, by contrast, is a definitive verdict from the
-    // licensing API (revoked/not-found/malformed key → valid:false); those
-    // MUST be cached so repeated requests with the same bad key don't hammer
-    // the licensing API on every call.
-    if (response.status >= 500) {
+    // A 429 or 5xx (rate limit, cold start, upstream timeout, internal error)
+    // is a transient failure, not proof the license is invalid — caching it
+    // would lock a paying user out for the full LICENSE_CACHE_TTL_SECONDS.
+    // Fail this request closed but leave the cache untouched so the next
+    // request retries the API. Other 4xx responses are definitive verdicts
+    // (revoked/not-found/malformed key → valid:false) and remain cacheable.
+    if (response.status === 429 || response.status >= 500) {
       console.warn(`[License] Transient ${response.status} response for ${maskedKey}; not caching`);
       return { isValid: false, credits: 0 };
     }

--- a/hyperwhisper-cloud/src/routes/usage.test.ts
+++ b/hyperwhisper-cloud/src/routes/usage.test.ts
@@ -4,9 +4,14 @@ import { Hono } from 'hono';
 const originalFetch = globalThis.fetch;
 
 const cacheWrites: Array<{ licenseKey: string; license: { isValid: boolean; credits: number; cachedAt: string } }> = [];
+let cachedLicense: { isValid: boolean; credits: number; cachedAt: string } | null = {
+  isValid: true,
+  credits: 12,
+  cachedAt: 'cached',
+};
 
 mock.module('../lib/redis', () => ({
-  getCachedLicense: async () => ({ isValid: true, credits: 12, cachedAt: 'cached' }),
+  getCachedLicense: async () => cachedLicense,
   cacheLicense: async (licenseKey: string, license: { isValid: boolean; credits: number; cachedAt: string }) => {
     cacheWrites.push({ licenseKey, license });
   },
@@ -14,9 +19,11 @@ mock.module('../lib/redis', () => ({
 }));
 
 const { readFiniteCredits, usageRoute } = await import('./usage');
+const { validateAuth } = await import('../middleware/auth');
 
 afterEach(() => {
   cacheWrites.length = 0;
+  cachedLicense = { isValid: true, credits: 12, cachedAt: 'cached' };
   globalThis.fetch = originalFetch;
 });
 
@@ -31,7 +38,65 @@ describe('readFiniteCredits', () => {
   });
 });
 
+describe('validateAuth transient licensing responses', () => {
+  test.each([429, 503])('does not cache HTTP %i as an invalid license verdict', async (status) => {
+    globalThis.fetch = mock(async () =>
+      Response.json({ valid: false }, { status })
+    ) as unknown as typeof fetch;
+
+    const result = await validateAuth({ licenseKey: 'test-license' }, true);
+
+    expect(result.ok).toBe(false);
+    expect(cacheWrites).toHaveLength(0);
+  });
+});
+
 describe('usageRoute force refresh', () => {
+  test('revalidates and replaces a cached invalid verdict', async () => {
+    cachedLicense = { isValid: false, credits: 0, cachedAt: 'cached-invalid' };
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/license/validate')) {
+        return Response.json({ valid: true, credits: 42 });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const app = new Hono();
+    app.get('/usage', usageRoute);
+
+    const response = await app.request('/usage?license_key=test-license&force_refresh=true');
+    const body = await response.json() as { credits_remaining: number; is_licensed: boolean };
+
+    expect(response.status).toBe(200);
+    expect(body.is_licensed).toBe(true);
+    expect(body.credits_remaining).toBe(42);
+    expect(cacheWrites).toHaveLength(1);
+    expect(cacheWrites[0]).toMatchObject({
+      licenseKey: 'test-license',
+      license: { isValid: true, credits: 42 },
+    });
+  });
+
+  test.each([429, 503])('does not cache transient HTTP %i as invalid', async (status) => {
+    cachedLicense = { isValid: false, credits: 0, cachedAt: 'cached-invalid' };
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes('/api/license/validate')) {
+        return Response.json({ valid: false }, { status });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    const app = new Hono();
+    app.get('/usage', usageRoute);
+
+    const response = await app.request('/usage?license_key=test-license&force_refresh=true');
+
+    expect(response.status).toBe(401);
+    expect(cacheWrites).toHaveLength(0);
+  });
+
   test('does not cache malformed credits balance responses and falls back to validation', async () => {
     globalThis.fetch = mock(async (input: RequestInfo | URL) => {
       const url = String(input);

--- a/hyperwhisper-cloud/src/routes/usage.ts
+++ b/hyperwhisper-cloud/src/routes/usage.ts
@@ -45,6 +45,14 @@ async function validateLicenseAndGetCredits(licenseKey: string, forceRefresh: bo
     const isValid = data.valid === true;
     const credits = readFiniteCredits(data) ?? 0;
 
+    // Rate limits and server failures are transient, not authoritative invalid
+    // verdicts. Fail this request closed without replacing the shared Redis
+    // entry; otherwise a one-off licensing outage locks the account out for
+    // the full cache TTL.
+    if (response.status === 429 || response.status >= 500) {
+      return { isValid: false, credits: 0 };
+    }
+
     await cacheLicense(licenseKey, {
       isValid,
       credits,


### PR DESCRIPTION
Fixes the root cause behind **HYPERWHISPER-T2** (`TranscriptionPipeline.transcribeWithDetails failed` — 42 users, 109 events, `error_class: auth`, `errorCode: 4`, stage `transcribe`, not retryable, ~505ms against HyperWhisper Cloud, seen on current 2.41.0).

## Verification

Sentry event details were provided directly in the dispatch thread (no Sentry API access in this environment). Verified the failure path by tracing the code — see below.

## Root cause

`HyperWhisperCloudProvider.transcribe()` reads the license identifier via `LicenseManager.getTranscriptionIdentifier()`, which is a synchronous read of an in-memory `@Published licenseStatus` cache. That cache is only revalidated against the server at app launch or once per 24h (`LicenseNetworkService.shouldRevalidateLicense`), plus a 7-day offline grace period on network failure.

HyperWhisper macOS is a long-running menu-bar app. If a license lapses, is rotated, or is revoked server-side mid-session, the client keeps sending the stale identifier as if it were still valid for up to 24h+. When the backend correctly rejects it with 401/403, the shared Rust core classifies this as `Unauthorized` and intentionally treats it as **terminal on the first attempt** (`is_retryable` excludes 401/403, by design — to avoid retry-storming a genuinely bad credential). Nothing upstream of that terminal classification ever distinguished "cache is just stale" from "credential is actually bad," so every one of these hard-fails straight to the user with no recovery path, matching the single ~505ms non-retried round trip in the Sentry data.

`errorCode: 4` is not a designed error code — `TranscriptionError` doesn't conform to `CustomNSError`, so this is just Swift's default enum→NSError ordinal bridging for `.unauthorized`, which is the only case that can produce `error_class: auth` for the HyperWhisper Cloud provider (no BYOK key concept applies here).

## Fix

On catching `TranscriptionError.unauthorized` from the `/transcribe` call, force one live `licenseManager.validateLicense(...)` revalidation and retry the transcribe request exactly once with the freshly confirmed identifier. This preserves the core's intentional no-blind-retry policy (a genuinely revoked/invalid license still fails fast on the retry) while fixing the much more common "the local cache just hadn't caught up yet" case.

Refactored the request-building/send logic into a small local `sendTranscribeRequest(identifier:isLicensed:)` closure inside `transcribe()` so the retry path reuses it instead of duplicating the request-building/parseError/onTransportError wiring.

## Not fixed here (flagged as follow-ups)

- The other call sites that also use `getTranscriptionIdentifier()` (`/post-process`, credit balance fetch, streaming) could hit the same stale-cache 401 — this PR only covers the reported `transcribeWithDetails`/`transcribe` stage.
- `TranscriptionError` doesn't conform to `CustomNSError`, so `errorCode` in Sentry extras is an unstable compiler-assigned ordinal rather than a stable, self-describing code. Worth fixing separately for future Sentry triage.

References: HYPERWHISPER-T2