### PR TITLE
fix(macos): surface mic auto-boost failures behind no-speech results

### DIFF
--- a/app/macos/hyperwhisper/Managers/AudioRecording/Recording/RecordingLifecycle.swift
+++ b/app/macos/hyperwhisper/Managers/AudioRecording/Recording/RecordingLifecycle.swift
@@ -113,6 +113,15 @@ class RecordingLifecycle {
     /// the saved volume to the wrong device (issue #235).
     private var originalMicVolumeDeviceID: AudioDeviceID?
 
+    /// HYPERWHISPER-EX: set when the fire-and-forget mic auto-boost task
+    /// (STEP 4.5 in `startRecording`) fails via `setInputVolumeScalar`. The
+    /// recording proceeds at unboosted (possibly too-quiet) gain in that case,
+    /// which downstream can get misclassified as `TranscriptionError.noSpeechDetected`
+    /// instead of a capture-quality issue. Callers check this right after a
+    /// no-speech result to distinguish "user didn't speak" from "we couldn't
+    /// boost the mic". Reset at the start of every recording.
+    private(set) var lastMicBoostFailed = false
+
     /// Recordings directory URL
     private var recordingsDirectory: URL {
         if let path = settingsManager?.recordingsFolder, !path.isEmpty {
@@ -232,6 +241,7 @@ class RecordingLifecycle {
         // has fresh, unique file URLs based on current timestamp
         self.finalURL = nil
         self.rawURL = nil
+        self.lastMicBoostFailed = false
 
         // STEP 3: Stop any existing recording
         if isRecording {
@@ -392,6 +402,14 @@ class RecordingLifecycle {
                     }
                 } else {
                     AppLogger.audio.warning("🎚️ [ASYNC] FAILED - CoreAudio setInputVolumeScalar returned false (device may not support software volume control)")
+                    SentryService.addBreadcrumb(
+                        message: "Mic auto-boost failed (setInputVolumeScalar)",
+                        category: "audio.recording",
+                        data: ["deviceName": deviceName, "deviceType": deviceType]
+                    )
+                    await MainActor.run { [weak self] in
+                        self?.lastMicBoostFailed = true
+                    }
                 }
 
                 AppLogger.audio.info("🎚️ [ASYNC] Auto-increase mic volume task COMPLETED")

--- a/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+ErrorHandling.swift
+++ b/app/macos/hyperwhisper/Managers/AudioRecording/RecordingFlow/RecordingTranscriptionFlow+ErrorHandling.swift
@@ -308,6 +308,25 @@ extension RecordingTranscriptionFlow {
     /// the view context AFTER awaiting the writer (auto-merge has applied the
     /// failed status by then).
     func handleTranscriptionError(_ error: Error, processingTranscriptID: NSManagedObjectID?, mode: String, duration: TimeInterval, audioURL: URL) {
+        // HYPERWHISPER-EX: `TranscriptionPipeline` deliberately excludes
+        // `.noSpeechDetected` from Sentry capture as "user-recoverable" — which
+        // also hides the case where the mic auto-boost silently failed (fire-and-
+        // forget task, see `RecordingLifecycle.lastMicBoostFailed`) and the
+        // resulting quiet-but-not-silent recording got misclassified as no-speech.
+        // That's a capture-quality defect, not the user simply staying silent, so
+        // report it distinctly here (this call site isn't covered by the
+        // pipeline's blanket exclusion — no duplicate event for the common case).
+        if AppLogger.isErrorLoggingEnabled,
+           let te = error as? TranscriptionError, case .noSpeechDetected = te,
+           recordingLifecycle.lastMicBoostFailed {
+            SentryService.capture(
+                error: te,
+                message: "No speech detected after mic auto-boost failure",
+                extras: ["mode": mode, "durationSeconds": duration],
+                tags: ["category": "audio", "kind": "no_speech_after_boost_failure"]
+            )
+        }
+
         let isNetworkOutage: Bool
         if let transcriptionError = error as? TranscriptionError, case .transientNetwork = transcriptionError {
             isNetworkOutage = true


### PR DESCRIPTION
Addresses **HYPERWHISPER-EX** (`transcribeWithDetails failed`, 15 users, 48 events, `error_class: audio`, `errorKind: no_speech_detected`, `errorCode: 19`).

## Verification

Sentry event details (sample event on old 2.26.1: `CoreAudio setInputVolumeScalar returned false`, `AVAudioRecorder.record() returned false`, M4A conversion fallback) were provided directly in the dispatch thread — no Sentry API access in this environment, so I could not check the version distribution across all 48 events as asked. Verified via code tracing instead, including git history back to the earliest available commit, to judge whether this is a version-upgrade fix.

**Verdict: not mitigated by version.** The relevant code (`RecordingLifecycle`'s mic auto-boost, `TranscriptionPipeline`'s no-speech classification) is unchanged since the earliest available history (~2.40.0) through current 2.41.0.

Note: `AVAudioRecorder.record() == false` is a red herring here — that failure is already handled correctly (thrown, surfaced to the user, captured to Sentry as a distinct `"Failed to start recording"` event) and can't be the source of a `no_speech_detected` result, since it aborts before any audio is captured.

## Root cause

`RecordingLifecycle.startRecording()` boosts mic input volume via a fire-and-forget `Task.detached` CoreAudio call (deliberately non-blocking — the comment above it documents a prior 12s UI freeze on some Bluetooth/USB devices). When `setInputVolumeScalar` fails, the only outcome was a local `os.Logger` warning: no breadcrumb, no correlation with the recording that follows, no signal beyond that one log line. Recording proceeds anyway at unboosted (possibly too quiet) gain.

Downstream, both the local Whisper silence guard and the shared Rust core's empty-transcript mapping (`shared-core-rs/crates/hw-net/src/providers/common.rs` — the same mechanism as the Windows sibling HYPERWHISPER-PA) classify that quiet-but-not-silent audio as `.noSpeechDetected`, indistinguishable from the user simply not speaking.

Separately, `TranscriptionPipeline+ErrorClassification.swift`'s `shouldCaptureTranscriptionErrorInSentry` excludes `.noSpeechDetected` from Sentry capture entirely as "user-recoverable." That's likely why this issue looks quieter/staler than the real occurrence rate — not because it's fixed.

## Fix

- `RecordingLifecycle`: track `lastMicBoostFailed`, reset at the start of every recording, set `true` (plus a Sentry breadcrumb) when `setInputVolumeScalar` fails.
- `RecordingTranscriptionFlow.handleTranscriptionError`: when a `.noSpeechDetected` result follows a boost failure for that same recording, report it distinctly to Sentry (`kind: no_speech_after_boost_failure`) — bypassing the pipeline's blanket no-speech suppression **only** for this correlated, capture-quality case. The common "user genuinely didn't speak" case is untouched and stays suppressed as designed, so this doesn't reopen the noise the exclusion was meant to prevent.

## Not fixed here (flagged as follow-up, scope reasons below)

- This makes the failure *visible and diagnosable* rather than silently misattributed — it doesn't yet change the user-facing message (still the generic "no speech detected" copy) or retry/boost the mic a second time. Doing either well would mean either touching 39 locale files for a new message, or making the fire-and-forget CoreAudio call block/retry inline — which risks reintroducing the 12s UI freeze the fire-and-forget design was explicitly built to avoid. Recommend scoping those as a separate, deliberate follow-up once the correlation data from this fix confirms the theory at scale.
- The misleading-adjacent Whisper-only `"will use cloud fallback"` log line (unrelated class of bug, see the sibling SV/TD PR) is untouched here.

References: HYPERWHISPER-EX