### PR TITLE
Add lightweight macOS PR build+test CI gate

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -1,0 +1,101 @@
+# Lightweight PR gate for the macOS app: build + unit test, no signing.
+#
+# This is deliberately NOT a trimmed-down macos-release.yml — it skips
+# archiving, code signing, notarization, DMG creation, and publishing
+# entirely. Its only job is to prove `main` and open PRs still compile and
+# pass unit tests on a real macOS/Xcode toolchain.
+name: macOS CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "app/macos/**"
+      - "shared-core-rs/**"
+      - ".github/workflows/macos-ci.yml"
+  push:
+    branches: [main]
+    paths:
+      - "app/macos/**"
+      - "shared-core-rs/**"
+      - ".github/workflows/macos-ci.yml"
+
+concurrency:
+  group: macos-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test (macOS, unsigned)
+    runs-on: macos-26
+    steps:
+      # ----------------------------------------------------------------
+      # 1. Checkout
+      # ----------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ----------------------------------------------------------------
+      # 2. Select Xcode version
+      # ----------------------------------------------------------------
+      # Mirrors macos-release.yml's selection exactly: pin to Xcode 26.3
+      # because 26.4 has strict concurrency errors in FluidAudio. Debug and
+      # release builds must compile against the same toolchain.
+      - name: Select Xcode 26.3
+        run: |
+          XCODE_PATH=$(ls -d /Applications/Xcode_26.3*.app 2>/dev/null | sort -V | tail -1)
+          if [ -z "$XCODE_PATH" ]; then
+            XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | grep -v -i beta | sort -V | tail -1)
+          fi
+          if [ -z "$XCODE_PATH" ]; then
+            XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+          fi
+          echo "Using Xcode at: $XCODE_PATH"
+          sudo xcode-select -s "$XCODE_PATH"
+          xcodebuild -version
+
+      # ----------------------------------------------------------------
+      # 3. Build (debug, unsigned)
+      # ----------------------------------------------------------------
+      # The Rust core is consumed as a committed prebuilt static lib
+      # (app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a) — the
+      # Xcode project links it directly and has no build phase that
+      # rebuilds it from shared-core-rs/. Rust itself is tested separately
+      # by shared-core-tests.yml, so this job just trusts the committed
+      # lib and builds/tests the Swift app on top of it.
+      #
+      # Signing is fully disabled (CODE_SIGNING_ALLOWED=NO / _REQUIRED=NO /
+      # empty CODE_SIGN_IDENTITY) since this is a compile+test gate, not a
+      # release — no keychain, cert, or provisioning profile is available
+      # (or needed) here.
+      - name: Build for testing
+        run: |
+          xcodebuild build-for-testing \
+            -project app/macos/hyperwhisper.xcodeproj \
+            -scheme hyperwhisper \
+            -configuration Debug \
+            -destination "platform=macOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_ENTITLEMENTS=""
+
+      # ----------------------------------------------------------------
+      # 4. Run unit tests
+      # ----------------------------------------------------------------
+      # Scoped to hyperwhisperTests only. hyperwhisperUITests launches the
+      # full app UI and needs Accessibility/Input-Monitoring permissions
+      # that can't be granted non-interactively on a hosted runner, so it's
+      # excluded to keep this gate fast and non-flaky.
+      - name: Run unit tests
+        run: |
+          xcodebuild test-without-building \
+            -project app/macos/hyperwhisper.xcodeproj \
+            -scheme hyperwhisper \
+            -configuration Debug \
+            -destination "platform=macOS" \
+            -only-testing:hyperwhisperTests \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_ENTITLEMENTS=""

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -9,7 +9,7 @@ name: macOS CI
 on:
   pull_request:
     branches: [main]
-    paths:
+    paths: &ci-paths
       - "app/macos/**"
       - "shared-core-rs/**"
       # These three repo-root dirs are bundled as Resources into the
@@ -22,13 +22,11 @@ on:
       - ".github/workflows/macos-ci.yml"
   push:
     branches: [main]
-    paths:
-      - "app/macos/**"
-      - "shared-core-rs/**"
-      - "shared-app-classification/**"
-      - "shared-models/**"
-      - "shared-prompts/**"
-      - ".github/workflows/macos-ci.yml"
+    # Same path filter as pull_request above, via YAML anchor (&ci-paths /
+    # *ci-paths) — plain YAML alias resolution, not a GitHub Actions
+    # feature, so this is safe: the parser expands it before Actions ever
+    # sees the workflow.
+    paths: *ci-paths
 
 concurrency:
   # PR runs: a newer push to the same PR branch supersedes the older run,
@@ -48,15 +46,6 @@ jobs:
   build-and-test:
     name: Build & Test (macOS, unsigned)
     runs-on: macos-26
-    env:
-      # Signing is fully disabled for every xcodebuild invocation below
-      # since this is a compile+test gate, not a release — no keychain,
-      # cert, or provisioning profile is available (or needed) here.
-      # Shared as a job-level env block so there's one place to change it.
-      CODE_SIGNING_ALLOWED: "NO"
-      CODE_SIGNING_REQUIRED: "NO"
-      CODE_SIGN_IDENTITY: ""
-      CODE_SIGN_ENTITLEMENTS: ""
     steps:
       # ----------------------------------------------------------------
       # 1. Checkout
@@ -79,9 +68,15 @@ jobs:
           XCODE_PATH=$(ls -d /Applications/Xcode_26.3*.app 2>/dev/null | sort -V | tail -1)
           if [ -z "$XCODE_PATH" ]; then
             XCODE_PATH=$(ls -d /Applications/Xcode_26*.app 2>/dev/null | grep -v -i beta | sort -V | tail -1)
+            if [ -n "$XCODE_PATH" ]; then
+              echo "::warning::Pinned Xcode 26.3 not found on this runner — falling back to $XCODE_PATH. This may silently change build behavior (e.g. Xcode 26.4 has known FluidAudio strict-concurrency breakage)." | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           if [ -z "$XCODE_PATH" ]; then
             XCODE_PATH=$(ls -d /Applications/Xcode*.app 2>/dev/null | sort -V | tail -1)
+            if [ -n "$XCODE_PATH" ]; then
+              echo "::warning::Pinned Xcode 26.3 (and 26.x) not found on this runner — falling back to whatever Xcode is newest: $XCODE_PATH. This may silently change build behavior." | tee -a "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           echo "Using Xcode at: $XCODE_PATH"
           sudo xcode-select -s "$XCODE_PATH"
@@ -106,13 +101,25 @@ jobs:
       # There's no build-time flag to drop hyperwhisperUITests from this
       # step; the "Run unit tests" step below is what excludes it, and only
       # from execution, not from this build.
+      # Signing is fully disabled for this invocation since this is a
+      # compile+test gate, not a release — no keychain, cert, or
+      # provisioning profile is available (or needed) here. These MUST be
+      # passed as xcodebuild command-line build-setting overrides, not as
+      # job-level `env:` vars — this project has explicit Manual signing
+      # configured, and env vars don't override that, only CLI build
+      # settings do (verified: env-only caused "requires a development
+      # team" failures). Don't "clean up" this duplication into env: again.
       - name: Build for testing
         run: |
           xcodebuild build-for-testing \
             -project app/macos/hyperwhisper.xcodeproj \
             -scheme hyperwhisper \
             -configuration Debug \
-            -destination "platform=macOS"
+            -destination "platform=macOS" \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_ENTITLEMENTS=""
 
       # ----------------------------------------------------------------
       # 4. Run unit tests
@@ -123,6 +130,8 @@ jobs:
       # runner, so it's excluded from *running* here to keep this gate fast
       # and non-flaky — note it was still compiled in the step above (see
       # the comment there).
+      # Same signing-disable overrides as the build step above, and same
+      # reason they must stay CLI args, not job-level env: vars.
       - name: Run unit tests
         run: |
           xcodebuild test-without-building \
@@ -130,4 +139,8 @@ jobs:
             -scheme hyperwhisper \
             -configuration Debug \
             -destination "platform=macOS" \
-            -only-testing:hyperwhisperTests
+            -only-testing:hyperwhisperTests \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGN_ENTITLEMENTS=""

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -12,22 +12,51 @@ on:
     paths:
       - "app/macos/**"
       - "shared-core-rs/**"
+      # These three repo-root dirs are bundled as Resources into the
+      # HyperWhisper.app target (see project.pbxproj) and are read at
+      # runtime by Swift tests (catalog/classifier tests etc.), so a
+      # catalog-only change must still trigger this gate.
+      - "shared-app-classification/**"
+      - "shared-models/**"
+      - "shared-prompts/**"
       - ".github/workflows/macos-ci.yml"
   push:
     branches: [main]
     paths:
       - "app/macos/**"
       - "shared-core-rs/**"
+      - "shared-app-classification/**"
+      - "shared-models/**"
+      - "shared-prompts/**"
       - ".github/workflows/macos-ci.yml"
 
 concurrency:
-  group: macos-ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PR runs: a newer push to the same PR branch supersedes the older run,
+  # so cancelling the in-progress one is correct and desired.
+  #
+  # push-to-main runs: github.ref is the same literal string
+  # (refs/heads/main) for every push, so keying on it alone would mean a
+  # second commit landing on main while the first's CI is still running
+  # cancels that first run outright — losing its pass/fail record. Keying
+  # push events on github.sha instead gives every push its own group, and
+  # cancel-in-progress is scoped to pull_request only so push runs never
+  # cancel each other.
+  group: macos-ci-${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-and-test:
     name: Build & Test (macOS, unsigned)
     runs-on: macos-26
+    env:
+      # Signing is fully disabled for every xcodebuild invocation below
+      # since this is a compile+test gate, not a release — no keychain,
+      # cert, or provisioning profile is available (or needed) here.
+      # Shared as a job-level env block so there's one place to change it.
+      CODE_SIGNING_ALLOWED: "NO"
+      CODE_SIGNING_REQUIRED: "NO"
+      CODE_SIGN_IDENTITY: ""
+      CODE_SIGN_ENTITLEMENTS: ""
     steps:
       # ----------------------------------------------------------------
       # 1. Checkout
@@ -41,6 +70,10 @@ jobs:
       # Mirrors macos-release.yml's selection exactly: pin to Xcode 26.3
       # because 26.4 has strict concurrency errors in FluidAudio. Debug and
       # release builds must compile against the same toolchain.
+      #
+      # This block is duplicated verbatim from macos-release.yml. That's a
+      # known, accepted duplication for two callers — not worth a composite
+      # action for a handful of lines; revisit if a third workflow needs it.
       - name: Select Xcode 26.3
         run: |
           XCODE_PATH=$(ls -d /Applications/Xcode_26.3*.app 2>/dev/null | sort -V | tail -1)
@@ -64,29 +97,32 @@ jobs:
       # by shared-core-tests.yml, so this job just trusts the committed
       # lib and builds/tests the Swift app on top of it.
       #
-      # Signing is fully disabled (CODE_SIGNING_ALLOWED=NO / _REQUIRED=NO /
-      # empty CODE_SIGN_IDENTITY) since this is a compile+test gate, not a
-      # release — no keychain, cert, or provisioning profile is available
-      # (or needed) here.
+      # NOTE: this compiles BOTH hyperwhisperTests and hyperwhisperUITests.
+      # -only-testing/-skip-testing are test-execution filters — per
+      # xcodebuild's documented behavior they constrain what runs during a
+      # test action, not what gets compiled — so `build-for-testing` builds
+      # every testable listed in the scheme's Test Action (both test
+      # targets here) regardless of any filter passed to a later step.
+      # There's no build-time flag to drop hyperwhisperUITests from this
+      # step; the "Run unit tests" step below is what excludes it, and only
+      # from execution, not from this build.
       - name: Build for testing
         run: |
           xcodebuild build-for-testing \
             -project app/macos/hyperwhisper.xcodeproj \
             -scheme hyperwhisper \
             -configuration Debug \
-            -destination "platform=macOS" \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGN_ENTITLEMENTS=""
+            -destination "platform=macOS"
 
       # ----------------------------------------------------------------
       # 4. Run unit tests
       # ----------------------------------------------------------------
-      # Scoped to hyperwhisperTests only. hyperwhisperUITests launches the
-      # full app UI and needs Accessibility/Input-Monitoring permissions
-      # that can't be granted non-interactively on a hosted runner, so it's
-      # excluded to keep this gate fast and non-flaky.
+      # Scoped to hyperwhisperTests only via -only-testing. hyperwhisperUITests
+      # launches the full app UI and needs Accessibility/Input-Monitoring
+      # permissions that can't be granted non-interactively on a hosted
+      # runner, so it's excluded from *running* here to keep this gate fast
+      # and non-flaky — note it was still compiled in the step above (see
+      # the comment there).
       - name: Run unit tests
         run: |
           xcodebuild test-without-building \
@@ -94,8 +130,4 @@ jobs:
             -scheme hyperwhisper \
             -configuration Debug \
             -destination "platform=macOS" \
-            -only-testing:hyperwhisperTests \
-            CODE_SIGNING_ALLOWED=NO \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGN_ENTITLEMENTS=""
+            -only-testing:hyperwhisperTests


### PR DESCRIPTION
## Why

PRs touching the macOS app (Swift) currently have no compile/test signal — reviews are code-review-only. This came up directly while working HYPERWHISPER-F4 (PR #50): the review sandbox has no macOS/Xcode toolchain, so a Swift-only fix could only be verified by code review, not by actually building it.

## What

New `.github/workflows/macos-ci.yml`, triggered on `pull_request`/`push` to `main` (path-filtered to `app/macos/**` and `shared-core-rs/**`), that:

- selects Xcode the same way `macos-release.yml` already does (pin 26.3, fall back sanely)
- runs `xcodebuild build-for-testing` + `test-without-building` against the `hyperwhisper` scheme, Debug config, with signing fully disabled (`CODE_SIGNING_ALLOWED=NO` etc — no keychain/cert/provisioning needed)
- scoped to the `hyperwhisperTests` unit test target only — `hyperwhisperUITests` needs Accessibility/Input-Monitoring permissions that can't be granted non-interactively on a hosted runner, so it's excluded to avoid a flaky/hanging gate
- trusts the committed prebuilt `libhyperwhisper_core.a` (Xcode has no build phase that rebuilds it from `shared-core-rs/`; Rust itself is already covered separately by `shared-core-tests.yml`)
- lets `xcodebuild`'s native exit code propagate — no `xcpretty` swallowing, so build/test failures actually fail the check

## Explicitly NOT included

No archiving, signing, notarization, DMG creation, or publishing — that's `macos-release.yml`'s job. This is purely a build+test gate, deliberately not a trimmed-down copy of the release workflow.

## Verification

No local Xcode/macOS toolchain available to test this workflow before pushing; the real test is whether it actually triggers and passes as a GitHub Actions check once this PR is open (path filters mean it should fire on this diff since it touches its own workflow file). Watching that live run's outcome next.

---
Requested in Slack. Opened by Claude running in a Percy sandbox.