### PR TITLE
fix(windows): remove startup Run key and close running app on uninstall

### DIFF
--- a/app/windows/setup-arm64.iss
+++ b/app/windows/setup-arm64.iss
@@ -113,6 +113,14 @@ end;
 // UNINSTALL CLEANUP - PROMPT USER TO REMOVE DATA (KEEP RECORDINGS)
 // =============================================================================
 
+procedure KillProcess(const ExeName: String);
+var
+  ResultCode: Integer;
+begin
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM ' + ExeName, '', SW_HIDE,
+    ewWaitUntilTerminated, ResultCode);
+end;
+
 procedure DeleteFolder(const FolderPath: String);
 var
   FindRec: TFindRec;
@@ -140,7 +148,20 @@ procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var
   AppDataPath: String;
 begin
+  if CurUninstallStep = usUninstall then begin
+    // The app lives in the tray, so it is usually still running when the user
+    // uninstalls. A locked HyperWhisper.exe survives file removal and gets
+    // relaunched by the startup Run key on next login.
+    KillProcess('{#MyAppExeName}');
+    KillProcess('parakeet-engine.exe');
+  end;
+
   if CurUninstallStep = usPostUninstall then begin
+    // The app registers launch-at-startup itself at first run (HKCU Run key),
+    // so Inno doesn't know about it and won't undo it — remove it explicitly.
+    RegDeleteValue(HKEY_CURRENT_USER,
+      'SOFTWARE\Microsoft\Windows\CurrentVersion\Run', '{#MyAppName}');
+
     AppDataPath := ExpandConstant('{localappdata}\HyperWhisper');
 
     // Check if app data folder exists

--- a/app/windows/setup-x64.iss
+++ b/app/windows/setup-x64.iss
@@ -101,6 +101,14 @@ end;
 // UNINSTALL CLEANUP - PROMPT USER TO REMOVE DATA (KEEP RECORDINGS)
 // =============================================================================
 
+procedure KillProcess(const ExeName: String);
+var
+  ResultCode: Integer;
+begin
+  Exec(ExpandConstant('{sys}\taskkill.exe'), '/F /IM ' + ExeName, '', SW_HIDE,
+    ewWaitUntilTerminated, ResultCode);
+end;
+
 procedure DeleteFolder(const FolderPath: String);
 var
   FindRec: TFindRec;
@@ -129,7 +137,20 @@ var
   AppDataPath: String;
   ModelsSize: String;
 begin
+  if CurUninstallStep = usUninstall then begin
+    // The app lives in the tray, so it is usually still running when the user
+    // uninstalls. A locked HyperWhisper.exe survives file removal and gets
+    // relaunched by the startup Run key on next login.
+    KillProcess('{#MyAppExeName}');
+    KillProcess('parakeet-engine.exe');
+  end;
+
   if CurUninstallStep = usPostUninstall then begin
+    // The app registers launch-at-startup itself at first run (HKCU Run key),
+    // so Inno doesn't know about it and won't undo it — remove it explicitly.
+    RegDeleteValue(HKEY_CURRENT_USER,
+      'SOFTWARE\Microsoft\Windows\CurrentVersion\Run', '{#MyAppName}');
+
     AppDataPath := ExpandConstant('{localappdata}\HyperWhisper');
 
     // Check if app data folder exists


### PR DESCRIPTION
## Problem

Customer report: after uninstalling the Windows app, HyperWhisper still launches at every PC restart.

Root cause is a two-part gap in the Inno Setup uninstaller:

1. On first launch the app registers itself for launch-at-startup by writing `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Run\HyperWhisper` (`App.xaml.cs` → `StartupService.Enable()`). Since the installer never wrote that value, Inno doesn't undo it on uninstall — the Run entry is orphaned.
2. The app lives in the system tray, so it's usually still running during uninstall. The locked `HyperWhisper.exe` survives file removal, and the leftover Run key relaunches it on every login — exactly the reported behavior.

## Fix

In both `setup-x64.iss` and `setup-arm64.iss`:

- **`usUninstall` step:** force-close `HyperWhisper.exe` and `parakeet-engine.exe` via `taskkill` before files are removed, so nothing stays locked.
- **`usPostUninstall` step:** unconditionally delete the `HyperWhisper` value from the HKCU Run key (independent of the optional "remove app data?" prompt).

## Testing

- Script changes only; verified the Pascal section follows existing `CurUninstallStepChanged` structure in both architectures' scripts. Needs a Windows smoke test on the next release build: install → launch once → uninstall while app is in tray → confirm no Run key entry (`Task Manager → Startup apps`) and no relaunch after reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019L19xC6WoRdjLPULaJSuwQ