### PR TITLE
fix(macos): History search shows stale row labels under new section headers

### DIFF
--- a/app/macos/hyperwhisper/Views/HistoryView.swift
+++ b/app/macos/hyperwhisper/Views/HistoryView.swift
@@ -301,6 +301,16 @@ private final class HistoryViewModel: ObservableObject {
         }
     }
     @Published private(set) var sections: [HistorySectionSnapshot] = []
+    /// Identity key of the query whose results are currently in `sections`,
+    /// updated atomically with them. The List's `.id` must key off this — not
+    /// the live `searchText`, which changes on every keystroke, ~180ms before
+    /// the debounced results land. Keying off the live text rebuilds the list
+    /// too early (while it still shows the old result set) and then lets
+    /// SwiftUI diff two unrelated result sets inside one NSTableView when the
+    /// results do arrive — which mis-reuses cells: stale row content under new
+    /// section headers and selection tags (the row/detail mismatch bug).
+    /// Excludes fetchLimit so pagination doesn't rebuild the list.
+    @Published private(set) var appliedQueryKey: String = ""
     @Published private(set) var loadedObjectIDs: Set<NSManagedObjectID> = []
     @Published private(set) var hasMoreResults: Bool = false
     @Published private(set) var availableModes: [Mode] = []
@@ -412,6 +422,7 @@ private final class HistoryViewModel: ObservableObject {
         // so the result always belongs to the newest applied query — no
         // staleness guard needed.
         sections = result.sections
+        appliedQueryKey = "\(query.searchText)|\(query.dateFilter)"
         loadedObjectIDs = result.objectIDs
         hasMoreResults = result.hasMoreResults
         isLoading = false
@@ -577,7 +588,11 @@ private struct HistoryScreen: View, Equatable {
             .listStyle(.sidebar)
             // Cheap insurance: rebuild the NSTableView-backed List when the query
             // changes rather than diffing rows across unrelated result sets.
-            .id("\(viewModel.searchText)|\(viewModel.dateFilter)")
+            // Keyed off the query that PRODUCED the current sections (set
+            // atomically with them), not the live searchText — see
+            // appliedQueryKey for why keystroke-time rebuilds don't protect
+            // the dangerous transition.
+            .id(viewModel.appliedQueryKey)
             .background(
                 Group {
                     Button("") {


### PR DESCRIPTION
## Problem

Typing in History search could leave the list showing **stale row labels from the previous result set** under the **new** result set's section headers and selection tags. Clicking a row then opened a detail pane for a different recording than the row's label (e.g. a row labeled "16:58 / 0m 11s" opening a "6 July at 23:08 / 0m 24s" detail). Verified against the Core Data store: the search hits and the detail pane were correct — only the visible row content was stale.

## Root cause

The list's rebuild insurance was keyed off the **live** `searchText`:

```swift
.id("\(viewModel.searchText)|\(viewModel.dateFilter)")
```

`searchText` changes on every keystroke, but `sections` only updates ~180ms later when the debounced query completes. So the full rebuild fired too early — while the list still displayed the old, unfiltered rows — and when the search results actually landed, the identity string was unchanged, letting SwiftUI diff two unrelated result sets inside the same NSTableView. The sectioned macOS List mis-reuses cells on that diff: row content stays stale while headers and selection tags take the new data. That is exactly the transition the `.id` was meant to prevent; it just fired at the wrong moment.

## Fix

Publish an `appliedQueryKey` from `HistoryViewModel.perform(_:)`, set in the same main-actor turn as `sections = result.sections`, and key the List's `.id` off it. The rebuild now happens exactly when the displayed result set swaps, so the cross-result-set diff never occurs. The key excludes `fetchLimit`, so pagination ("load more") keeps diffing within the same list identity and preserves scroll position; save-triggered refreshes of the same query likewise keep the same key.

## Verification

- `xcodebuild -scheme hyperwhisper -configuration Debug build` — BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCke66cEK27mBWmvjFHSbc