### PR TITLE
fix(cloud): make redis test mocks order-independent (unblocks prod deploy)

### DIFF
--- a/hyperwhisper-cloud/src/routes/transcribe.test.ts
+++ b/hyperwhisper-cloud/src/routes/transcribe.test.ts
@@ -28,6 +28,7 @@ describe('estimateCreditsForProviderFallbacks', () => {
 // A valid, well-funded licensed user so auth + credit checks pass entirely
 // in-memory (no network) and the route reaches the provider fallback loop.
 mock.module('../lib/redis', () => ({
+  redis: {}, // satisfies static `import { redis }` in google-auth (via google-chirp)
   isIPBlocked: async () => false,
   getCachedLicense: async () => ({ isValid: true, credits: 1000, cachedAt: 'cached' }),
   cacheLicense: async () => {},

--- a/hyperwhisper-cloud/src/routes/usage.test.ts
+++ b/hyperwhisper-cloud/src/routes/usage.test.ts
@@ -6,6 +6,7 @@ const originalFetch = globalThis.fetch;
 const cacheWrites: Array<{ licenseKey: string; license: { isValid: boolean; credits: number; cachedAt: string } }> = [];
 
 mock.module('../lib/redis', () => ({
+  redis: {}, // satisfies static `import { redis }` in google-auth (via google-chirp)
   getCachedLicense: async () => ({ isValid: true, credits: 12, cachedAt: 'cached' }),
   cacheLicense: async (licenseKey: string, license: { isValid: boolean; credits: number; cachedAt: string }) => {
     cacheWrites.push({ licenseKey, license });


### PR DESCRIPTION
## Why

Redeploying HyperWhisper Cloud to prod (to pick up the rotated Deepgram API key from Infisical) failed at the **Typecheck + unit tests** gate — deterministically on the prod runner, while the **identical commit passed on staging** minutes earlier.

## Root cause

`usage.test.ts` and `transcribe.test.ts` mock `../lib/redis` but omit the `redis` export; `transcribe-multi-provider.test.ts` includes it. Bun's `mock.module` is process-global, so whichever file registers its mock **last** wins. When an incomplete mock lands last, any static `import { redis }` (`google-auth` via `google-chirp`) fails to load:

```
SyntaxError: Export named 'redis' not found in module '.../src/lib/redis.ts'
```

Test-file execution order differs per runner (filesystem readdir order), which is why staging and prod diverged on the same SHA.

## Fix

Add `redis: {}` to both incomplete mocks — matching the comment already in `transcribe-multi-provider.test.ts`. Makes the suite order-independent.

## Verification

- `bun run typecheck` — clean
- `bun test src` — 129 pass / 0 fail
- Forced the prod ordering (`usage` → `transcribe` → `multi-provider`) — 35 pass / 0 fail (previously failed to load)

Once merged, the push to `main` auto-triggers `cloud-deploy-prod.yml` (staging → smoke test → prod → smoke test), which ships the new Deepgram key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XkfdfqkJ2Ri34LdYEvn82n