### PR TITLE
fix(windows): dispose WhisperProcessor asynchronously so cancels don't surface as failures

### DIFF
--- a/app/windows/HyperWhisper/Services/TranscriptionService.cs
+++ b/app/windows/HyperWhisper/Services/TranscriptionService.cs
@@ -407,9 +407,12 @@ public class TranscriptionService : ITranscriptionProvider, IDisposable
     /// <returns>Transcribed text.</returns>
     public string TranscribeFile(string audioPath, string? language = null)
     {
-        // Go through TranscribeFileAsync so the body runs on a thread-pool thread with
-        // no SynchronizationContext — blocking on it from the UI thread would otherwise
-        // risk deadlocking on the processor's `await using` DisposeAsync continuation.
+        // Go through TranscribeFileAsync so the body runs on a thread-pool thread with no
+        // SynchronizationContext. Not fixing a live deadlock — today's first suspension
+        // point already uses ConfigureAwait(false), so nothing captures the UI context.
+        // It's belt-and-braces: neither `await using` nor Whisper.net's DisposeAsync uses
+        // ConfigureAwait(false), so a future edit that reaches the dispose with a captured
+        // context would deadlock any UI-thread caller blocking on this wrapper.
         return TranscribeFileAsync(audioPath, language)
             .GetAwaiter()
             .GetResult();
@@ -722,14 +725,29 @@ public class TranscriptionService : ITranscriptionProvider, IDisposable
                 arm64Factory?.Dispose();
             }
         }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        catch (Exception ex) when (cancellationToken.IsCancellationRequested)
         {
-            // User pressed Escape / hit Cancel. Not a failure — let it propagate as a
+            // User pressed Escape / hit Cancel. Not a failure — surface it as a
             // cancellation so the callers' OperationCanceledException handlers run and
             // the user sees "Recording cancelled" instead of an error toast.
+            //
+            // The filter is deliberately broad. Whisper.net 1.9.0 races here: its abort
+            // callback is wired to our token, so whisper_full returns non-zero and the
+            // background task faults with WhisperProcessingException. If that fault lands
+            // before ProcessAsync's iterator observes the token, the iterator's
+            // `ThrowIfCancellationRequested()` guard is skipped (processingTask.IsCompleted
+            // is already true and the segment buffer is empty) and `await processingTask`
+            // rethrows WhisperProcessingException instead of TaskCanceledException.
+            // Cancelling during the encode pass hits that path; cancelling at a segment
+            // boundary hits the OperationCanceledException path. Both mean "user cancelled".
             totalStopwatch.Stop();
-            LoggingService.Info($"TranscriptionService: File transcription cancelled after {totalStopwatch.ElapsedMilliseconds}ms");
-            throw;
+            LoggingService.Info($"TranscriptionService: File transcription cancelled after {totalStopwatch.ElapsedMilliseconds}ms ({ex.GetType().Name})");
+            if (ex is OperationCanceledException)
+            {
+                throw;
+            }
+
+            throw new OperationCanceledException(ex.Message, ex, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/app/windows/HyperWhisper/Services/TranscriptionService.cs
+++ b/app/windows/HyperWhisper/Services/TranscriptionService.cs
@@ -660,14 +660,17 @@ public class TranscriptionService : ITranscriptionProvider, IDisposable
                 // Whisper.net's WhisperProcessor.Dispose() throws
                 //   "Cannot dispose while processing, please use DisposeAsync instead."
                 // whenever its processing semaphore is still held — which is exactly
-                // the case when the caller cancels mid-transcription: ProcessAsync
-                // throws TaskCanceledException as soon as the token trips, while the
-                // native whisper_full call is still unwinding on its own thread.
-                // The synchronous Dispose then threw from the `using` unwind, replacing
-                // the cancellation with a raw Exception (surfaced to users as
-                // "Transcription failed: Cannot dispose while processing...") and
-                // leaking the processor's pinned GCHandles / unmanaged strings.
-                // DisposeAsync waits for the (already aborting) native task first.
+                // the case when the caller cancels mid-transcription: ProcessAsync stops
+                // enumerating as soon as it observes the cancellation, while the native
+                // whisper_full call is still unwinding on its own thread and holding the
+                // semaphore. The synchronous Dispose then threw from the `using` unwind,
+                // replacing the real outcome with a raw Exception (surfaced to users as
+                // "Transcription failed: Cannot dispose while processing...") and leaking
+                // the processor's pinned GCHandles / unmanaged strings, which Dispose
+                // never reached. DisposeAsync waits for the (already aborting) native
+                // task first. See the cancellation catch below for how ProcessAsync
+                // actually surfaces that cancellation — it races between two exception
+                // types, which is why that filter is broad.
                 await using var processor = builder.Build();
                 stepStopwatch.Stop();
                 LoggingService.Debug($"Step 2: Complete ({stepStopwatch.ElapsedMilliseconds}ms)");

--- a/app/windows/HyperWhisper/Services/TranscriptionService.cs
+++ b/app/windows/HyperWhisper/Services/TranscriptionService.cs
@@ -407,7 +407,10 @@ public class TranscriptionService : ITranscriptionProvider, IDisposable
     /// <returns>Transcribed text.</returns>
     public string TranscribeFile(string audioPath, string? language = null)
     {
-        return TranscribeFileInternalAsync(audioPath, language, CancellationToken.None)
+        // Go through TranscribeFileAsync so the body runs on a thread-pool thread with
+        // no SynchronizationContext — blocking on it from the UI thread would otherwise
+        // risk deadlocking on the processor's `await using` DisposeAsync continuation.
+        return TranscribeFileAsync(audioPath, language)
             .GetAwaiter()
             .GetResult();
     }
@@ -650,7 +653,19 @@ public class TranscriptionService : ITranscriptionProvider, IDisposable
                     LoggingService.Debug("  Language: auto-detect");
                 }
 
-                using var processor = builder.Build();
+                // MUST be `await using` (IAsyncDisposable), not `using`.
+                // Whisper.net's WhisperProcessor.Dispose() throws
+                //   "Cannot dispose while processing, please use DisposeAsync instead."
+                // whenever its processing semaphore is still held — which is exactly
+                // the case when the caller cancels mid-transcription: ProcessAsync
+                // throws TaskCanceledException as soon as the token trips, while the
+                // native whisper_full call is still unwinding on its own thread.
+                // The synchronous Dispose then threw from the `using` unwind, replacing
+                // the cancellation with a raw Exception (surfaced to users as
+                // "Transcription failed: Cannot dispose while processing...") and
+                // leaking the processor's pinned GCHandles / unmanaged strings.
+                // DisposeAsync waits for the (already aborting) native task first.
+                await using var processor = builder.Build();
                 stepStopwatch.Stop();
                 LoggingService.Debug($"Step 2: Complete ({stepStopwatch.ElapsedMilliseconds}ms)");
 
@@ -706,6 +721,15 @@ public class TranscriptionService : ITranscriptionProvider, IDisposable
                 // Dispose ARM64 per-transcription factory
                 arm64Factory?.Dispose();
             }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // User pressed Escape / hit Cancel. Not a failure — let it propagate as a
+            // cancellation so the callers' OperationCanceledException handlers run and
+            // the user sees "Recording cancelled" instead of an error toast.
+            totalStopwatch.Stop();
+            LoggingService.Info($"TranscriptionService: File transcription cancelled after {totalStopwatch.ElapsedMilliseconds}ms");
+            throw;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Problem

User report (Windows 1.8.0):

> Transcription failed: Cannot dispose while processing, please use DisposeAsync instead.

## Root cause

`TranscriptionService.cs` built the Whisper processor with a synchronous `using`:

```csharp
using var processor = builder.Build();
await foreach (var _ in processor.ProcessAsync(audioStream, cancellationToken)...)
```

Whisper.net 1.9.0's `WhisperProcessor.Dispose()` opens with a hard guard:

```csharp
if (processingSemaphore.CurrentCount == 0)
    throw new Exception("Cannot dispose while processing, please use DisposeAsync instead.");
```

That semaphore is held by the background task running native `whisper_full`. When the cancellation token trips, `ProcessAsync` throws `TaskCanceledException` immediately — it does **not** wait for that native task to unwind. The `using` then calls the sync `Dispose()`, the semaphore is still held, and the raw `Exception` replaces the cancellation.

Downstream, `MainViewModel` has a clean `catch (OperationCanceledException)` handler that would have shown "Recording cancelled". The swapped exception falls through to the generic `catch (Exception ex)` instead, producing `errors.transcriptionFailed` with the dispose message and marking the transcript Failed in History.

Secondary damage: `Dispose()` threw before freeing the processor's pinned `GCHandle`s and unmanaged strings, so every cancelled local transcription leaked them.

Triggers: Escape while transcribing, the file-transcription progress Cancel button, and app shutdown mid-transcription.

## Fix

- `await using var processor` — `DisposeAsync()` waits on the semaphore first. The native call is already aborting via Whisper.net's `OnAbort` callback (wired to the same token), so it returns promptly rather than blocking for the full inference.
- Added `catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)` in `TranscribeFileInternalAsync` so cancels log at Info instead of Error and propagate as cancellations.
- Routed the sync `TranscribeFile()` wrapper through `TranscribeFileAsync` (already `Task.Run`-wrapped) so the new `DisposeAsync` continuation can't deadlock if a caller blocks on it from the UI thread.

## Verification

`dotnet build -c Debug` compiles clean — `HyperWhisper -> bin/Debug/net10.0-windows10.0.19041.0/HyperWhisper.dll`. The build then stops on the pre-existing `hyperwhisper_core.dll (x64) is missing from Resources\rust-core\x64\` packaging check, which is unrelated to this change and expected on a machine without the Rust core built.

Not runtime-tested on Windows — the analysis is source-level against Whisper.net 1.9.0 plus the compile check. Worth a manual pass: start a local Whisper transcription, hit Escape mid-flight, confirm the overlay shows "Recording cancelled" and no Failed row lands in History.

## Note

Sentry has no matching issue (searched `ray-amjad/hyperwhisper`, 90d) — this exception is caught and toasted, never captured, so there's no telemetry on blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W52sLtKvaSwcvrLYyb8bJ7