### PR TITLE
ci(macos): rebuild the Rust core instead of trusting the committed lib

### DIFF
--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -83,15 +83,26 @@ jobs:
           xcodebuild -version
 
       # ----------------------------------------------------------------
-      # 3. Build (debug, unsigned)
+      # 3. Rebuild the Rust core (macOS universal static lib)
       # ----------------------------------------------------------------
-      # The Rust core is consumed as a committed prebuilt static lib
-      # (app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a) — the
-      # Xcode project links it directly and has no build phase that
-      # rebuilds it from shared-core-rs/. Rust itself is tested separately
-      # by shared-core-tests.yml, so this job just trusts the committed
-      # lib and builds/tests the Swift app on top of it.
-      #
+      # The Xcode project links a static lib
+      # (app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a) that is
+      # also committed to git for fast local Xcode builds. Rebuilding it
+      # fresh here — rather than trusting the committed copy — keeps it
+      # from silently drifting out of sync with the UniFFI bindings
+      # generated from the same shared-core-rs source, which otherwise
+      # only surfaces as an "Undefined symbols" link failure. Rust
+      # correctness itself (cargo test/clippy) is covered separately by
+      # shared-core-tests.yml; this step only needs the lib to link.
+      - name: Rebuild shared Rust core
+        working-directory: shared-core-rs
+        run: |
+          rustup show
+          ./build-apple.sh
+
+      # ----------------------------------------------------------------
+      # 4. Build (debug, unsigned)
+      # ----------------------------------------------------------------
       # NOTE: this compiles BOTH hyperwhisperTests and hyperwhisperUITests.
       # -only-testing/-skip-testing are test-execution filters — per
       # xcodebuild's documented behavior they constrain what runs during a
@@ -122,7 +133,7 @@ jobs:
             CODE_SIGN_ENTITLEMENTS=""
 
       # ----------------------------------------------------------------
-      # 4. Run unit tests
+      # 5. Run unit tests
       # ----------------------------------------------------------------
       # Scoped to hyperwhisperTests only via -only-testing. hyperwhisperUITests
       # launches the full app UI and needs Accessibility/Input-Monitoring


### PR DESCRIPTION
## What

`macos-ci.yml` linked whatever `libhyperwhisper_core.a` happened to be committed under `app/macos/hyperwhisper/Libraries/`. That committed copy exists so local Xcode builds are fast — but it means the CI gate was structurally unable to catch the case where the lib drifts out of sync with the UniFFI bindings generated from the same `shared-core-rs` source.

This adds a step that rebuilds the universal macOS static lib from source (`rustup show` + `./build-apple.sh`) before `build-for-testing`, so drift surfaces here as the "Undefined symbols" link failure it actually is.

## Notes

- Rust correctness (`cargo test` / `clippy`) stays where it is, in `shared-core-tests.yml`. This step only needs the lib to link.
- `rustup show` picks up the pinned toolchain from `shared-core-rs/rust-toolchain.toml` (1.86.0) along with both `aarch64-apple-darwin` and `x86_64-apple-darwin` targets, matching the pattern already used in `shared-core-tests.yml`.
- `shared-core-rs/**` is already in this workflow's path filter, so the new step runs on exactly the changes that can cause the drift.
- Step numbering in the comment headers renumbered 3→5 accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189yTpvDjMvP7PT5HAAtFQh