### PR TITLE
fix(cloud): give Chirp's inline sync recognize its own 45s timeout budget

### DIFF
--- a/hyperwhisper-cloud/CLAUDE.md
+++ b/hyperwhisper-cloud/CLAUDE.md
@@ -62,6 +62,8 @@ Delivery paths:
 - ≤ 9.5 MB AND ≤ ~55 s estimated → inline base64 → sync `recognize` (~5–15 s)
 - otherwise → GCS upload → `batchRecognize` LRO + polling (~15–300 s)
 
+Every Chirp network call carries an explicit timeout budget — none of them use the shared 15 s `DEFAULT_PROVIDER_TIMEOUT_MS` from `providers/utils.ts`, because 15 s sits at the top of the inline path's own normal range: `SYNC_RECOGNIZE_TIMEOUT_MS` 45 s (inline), `BATCH_POLL_FETCH_TIMEOUT_MS` 8 s per poll under a 300 s `BATCH_POLL_DEADLINE_MS`, GCS upload `max(30 s, 1 s/100 KB)`. Chirp is `selfOnly`, so a timeout is a hard 502 with no fallback provider to absorb it. Budget generously; don't "simplify" one of these back to the default.
+
 batchRecognize submits intentionally OMIT `processingStrategy`. The unset default is Google's IMMEDIATE path; the named `DYNAMIC_BATCHING` enum is the opposite — a deferred 24-hour queue. Don't re-add the field.
 
 `batchRecognize` result shape gotcha: `totalBilledDuration` lives on `fileResult.metadata`, NOT `fileResult.transcript.metadata`. `normalizeSpeechResults` merges all three candidate metadata levels (transcript, file, operation) — preserve the merge when refactoring.

--- a/hyperwhisper-cloud/src/providers/google-chirp.ts
+++ b/hyperwhisper-cloud/src/providers/google-chirp.ts
@@ -35,6 +35,20 @@ export const INLINE_AUDIO_MAX_BYTES = GOOGLE_CHIRP_INLINE_MAX_BYTES;
 // 10 MB byte cap. Use 55 s as the gate to leave headroom for the byte-rate
 // estimator being conservative on compressed audio.
 const INLINE_AUDIO_MAX_SECONDS = 55;
+// Sync `recognize` gets its own budget rather than the shared 15 s default in
+// providers/utils.ts. Two reasons that default is wrong here:
+//   1. Chirp's inline path is observed at ~5–15 s even for ~1 s of audio, so a
+//      15 s ceiling sits exactly at the top of the normal range — no headroom.
+//      Measured in CI on two adjacent ~1 s fixtures: ja-JP returned in 7.3 s,
+//      hi-IN blew the 15 s budget, purely on upstream variance.
+//   2. This branch admits up to INLINE_AUDIO_MAX_SECONDS (55 s) of audio, so
+//      the budget has to cover the *longest* clip we send inline, not the
+//      shortest. 45 s keeps margin at that cap while staying inside Fly's
+//      per-request budget.
+// Chirp is selfOnly, so a timeout here is a hard 502 with no fallback — worth
+// being generous. Mirrors the explicit budgets already used for batch polling
+// and GCS upload; only the inline call was left on the bare default.
+const SYNC_RECOGNIZE_TIMEOUT_MS = 45_000;
 const MAX_PHRASES = 1000;
 const MAX_PHRASE_LEN = 100;
 // batchRecognize polling. Real-world observed: a 90 s audio file on the
@@ -199,7 +213,7 @@ export async function transcribeWithGoogleChirp(
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(bodyObject),
-      }, context);
+      }, context, SYNC_RECOGNIZE_TIMEOUT_MS);
 
       if (!response.ok) {
         await throwForSpeechError(provider, response, startedAt, context);


### PR DESCRIPTION
## Problem

Google Chirp's inline `recognize` call was the only network call left in `google-chirp.ts` using the shared `DEFAULT_PROVIDER_TIMEOUT_MS` (15s) from `providers/utils.ts`. That default is wrong for this path on two counts.

**1. The budget equals the top of the path's own normal range.** `hyperwhisper-cloud/CLAUDE.md` documents inline sync as `~5–15 s`, so a 15s ceiling left zero headroom. The staging smoke gate caught it on run [30416648631](https://github.com/ray-amjad/hyperwhisper-app/actions/runs/30416648631):

```
✗ POST /transcribe google-chirp [hi-IN] — expected 200, got 502
  {"error":"google-chirp unavailable",
   "message":"google-chirp unavailable: timeout after 15000ms"}
```

Two adjacent fixtures of near-identical size, run sequentially, so the timestamps are true latencies:

| Check | Bytes | ≈ audio | Latency |
|---|---|---|---|
| `google-chirp [ja-JP]` ✓ | 17,572 | ~1.1s | **7.3s** |
| `google-chirp [hi-IN]` ✗ | 17,781 | ~1.1s | **>15s** (aborted) |

Nothing distinguishes them but upstream variance — and the *passing* case was only ~2× inside the limit while transcribing one second of audio.

**2. The bigger problem: this is a production failure mode.** The inline branch admits audio up to `INLINE_AUDIO_MAX_SECONDS` (55s). If ~1s of audio takes 7–15s, a clip near that cap will exceed a 15s budget routinely. `google-chirp` is `selfOnly: true`, so a timeout is a hard 502 with no fallback provider to absorb it.

## Fix

A dedicated `SYNC_RECOGNIZE_TIMEOUT_MS = 45_000`, passed as the `fetchWithTimeout` override on the inline call only. 45s covers the 55s-audio case with margin while staying inside Fly's per-request budget. No other provider's timeout changes.

This brings the call in line with the explicit budgets already used elsewhere in the same file — 8s per batch poll under a 300s deadline, `max(30s, 1s/100KB)` for GCS upload. Inline was the only one still on the bare default.

Also documents the full set of Chirp budgets in `hyperwhisper-cloud/CLAUDE.md` so the next person doesn't "simplify" one back to the default.

## Notes

- **Not a regression** — neither file has changed since the backend was vendored in `3b810e6`.
- **Unrelated to #64**; that PR touches the AssemblyAI path and the Rust core, and AssemblyAI passed cleanly in the same smoke run.
- Considered and rejected: setting `STT_PROVIDER_TIMEOUT_MS` (wired up in `utils.ts:31`, set nowhere) — it's global across all providers, too blunt. Also rejected adding a smoke-test retry, which would have hidden the production defect rather than fixed it.
- The production impact is inferred from the code (55s admissible audio vs a 15s response budget) plus two ~1s samples — it is not measured. The `provider.http_response` events carry `elapsedMs`, so the real latency distribution is checkable in the Fly logs.

## Testing

`bun --bun node_modules/typescript/bin/tsc --noEmit` → clean. The staging smoke gate on this PR's deploy exercises both Chirp rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189yTpvDjMvP7PT5HAAtFQh