### PR TITLE
chore(macos): build libhyperwhisper_core.a from source instead of committing it

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -196,6 +196,37 @@ jobs:
           app/macos/strip_whisper_signatures.sh
 
       # ----------------------------------------------------------------
+      # 5b. Rebuild the Rust core (macOS universal static lib)
+      # ----------------------------------------------------------------
+      # The Xcode project links libhyperwhisper_core.a out of
+      # app/macos/hyperwhisper/Libraries/, which is NOT committed (see that
+      # directory's README). Without this step the Archive below has nothing
+      # to link against.
+      #
+      # This step is also why the lib stopped being committed. While it was
+      # in git, the release shipped whatever binary happened to be checked
+      # in, and a rebuild was a manual step someone had to remember. Two ways
+      # that went wrong:
+      #   - loud:   the FFI surface moved, so the archive failed to link with
+      #             "Undefined symbols" (what PR #64 hit).
+      #   - silent: only a function *body* changed, so the UniFFI checksums
+      #             still matched, the archive linked clean, and the release
+      #             shipped stale Rust with no signal at all.
+      # Building from source here makes both impossible by construction.
+      #
+      # Deliberately uncached, unlike macos-ci.yml: releases are
+      # workflow_dispatch-only and rare, so ~5 min of cold compile is a fair
+      # price for an artifact that ships to users with no cache in its
+      # provenance.
+      - name: Rebuild shared Rust core
+        working-directory: shared-core-rs
+        run: |
+          rustup show
+          ./build-apple.sh
+          ls -lh ../app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a
+          lipo -info ../app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a
+
+      # ----------------------------------------------------------------
       # 6. Build (xcodebuild archive)
       # ----------------------------------------------------------------
       - name: Archive

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,14 @@ obj/
 # Rust build output
 shared-core-rs/target/
 target/
+
+# Built Rust core for macOS. Deliberately NOT committed: it is a 65 MB
+# universal static lib, and the 11 versions that were tracked accounted for
+# 52% of the whole repository. Xcode's "Ensure Rust Core" build phase builds
+# it on demand; CI rebuilds it from source on every run. Mirrors the Windows
+# side, which tracks only .gitkeep under Resources/rust-core/.
+# The generated hyperwhisper_coreFFI.h alongside it IS committed.
+app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a
 .vs/
 *.DotSettings.user
 

--- a/app/macos/AGENTS.md
+++ b/app/macos/AGENTS.md
@@ -22,6 +22,14 @@ HyperWhisper macOS — Swift 5 + SwiftUI app, MVVM, macOS 14+ deployment target.
 
 Dependencies resolve via Swift Package Manager (no manual install step).
 
+`hyperwhisper/Libraries/libhyperwhisper_core.a` is **not** committed — build it
+once with `cd shared-core-rs && ./build-apple.sh`. On a fresh clone the first
+Xcode build intentionally fails after building it, asking for one more build:
+Xcode resolves `LIBRARY_SEARCH_PATHS` at plan time, so a lib created mid-build
+never reaches the link line. If you ever see a wall of `Undefined symbols` for
+`_uniffi_hyperwhisper_core_*`, the lib is missing or stale — rebuild it rather
+than chasing the Swift side. Details: `hyperwhisper/Libraries/README.md`.
+
 Do not run the full `xcodebuild ... test` action or broad UI/screenshot/launch-performance tests for narrow macOS code changes unless the user explicitly asks for that level of verification or the change directly touches UI-test-covered behavior. For PR merge lanes and small Swift changes, prefer the strongest targeted build/typecheck that matches the touched code, plus specific unit tests only when they are clearly relevant. The macOS UI test suite is permission- and environment-sensitive and can produce noisy accessibility/appearance-mode failures unrelated to the change.
 </important>
 

--- a/app/macos/hyperwhisper.xcodeproj/project.pbxproj
+++ b/app/macos/hyperwhisper.xcodeproj/project.pbxproj
@@ -6,6 +6,20 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXAggregateTarget section */
+		71F2A2EB2E5E4B1F0048B2D7 /* RustCore */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 71F2A2EE2E5E4B220048B2DA /* Build configuration list for PBXAggregateTarget "RustCore" */;
+			buildPhases = (
+				71F2A2EA2E5E4B1E0048B2D6 /* Ensure Rust Core */,
+			);
+			dependencies = (
+			);
+			name = RustCore;
+			productName = RustCore;
+		};
+/* End PBXAggregateTarget section */
+
 /* Begin PBXBuildFile section */
 		716D3E1C2E52BB340018DCF5 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 716D3DE12E52B8910018DCF5 /* KeyboardShortcuts */; };
 		71805AD02EDDE90D00E7A29A /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 71805ACF2EDDE90D00E7A29A /* LaunchAtLogin */; };
@@ -26,6 +40,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		71F2A2EC2E5E4B200048B2D8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7142EF072E50808900DA9A2D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 71F2A2EB2E5E4B1F0048B2D7;
+			remoteInfo = RustCore;
+		};
 		7142EF1E2E50808B00DA9A2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7142EF072E50808900DA9A2D /* Project object */;
@@ -182,6 +203,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				71F2A2ED2E5E4B210048B2D9 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				7142EF112E50808900DA9A2D /* hyperwhisper */,
@@ -330,6 +352,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				71F2A2EB2E5E4B1F0048B2D7 /* RustCore */,
 				7142EF0E2E50808900DA9A2D /* hyperwhisper */,
 				7142EF1C2E50808B00DA9A2D /* hyperwhisperTests */,
 				7142EF262E50808B00DA9A2D /* hyperwhisperUITests */,
@@ -424,6 +447,26 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\n# Code sign all Runtime binaries (llama-server and dylibs) with Hardened Runtime\nRUNTIME_DIR=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/Runtime\"\nRESOURCES_DIR=\"$TARGET_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\"\n\nif [ -d \"$RUNTIME_DIR\" ]; then\n  echo \"Code signing Runtime binaries in $RUNTIME_DIR\"\n  \n  # Sign all dylibs\n  find \"$RUNTIME_DIR\" -name \"*.dylib\" -type f | while read binary; do\n    echo \"Code signing $binary with Hardened Runtime\"\n    /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --options runtime --timestamp \"$binary\" || true\n  done\n  \n  # Sign llama-server in Runtime/\n  find \"$RUNTIME_DIR\" -name \"llama-server\" -type f | while read binary; do\n    echo \"Code signing $binary with Hardened Runtime\"\n    /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --options runtime --timestamp \"$binary\" || true\n  done\n  \n  echo \"Runtime binaries code signing complete\"\nfi\n\n# Also sign top-level llama-server if Xcode copied it to Resources/\nif [ -f \"$RESOURCES_DIR/llama-server\" ]; then\n  echo \"Code signing top-level llama-server in Resources\"\n  /usr/bin/codesign --force --sign \"$EXPANDED_CODE_SIGN_IDENTITY\" --options runtime --timestamp \"$RESOURCES_DIR/llama-server\" || true\nfi\n";
 		};
+		71F2A2EA2E5E4B1E0048B2D6 /* Ensure Rust Core */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Ensure Rust Core";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/hyperwhisper/Libraries/libhyperwhisper_core.a",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nLIB=\"$SRCROOT/hyperwhisper/Libraries/libhyperwhisper_core.a\"\nCORE=\"$SRCROOT/../../shared-core-rs\"\n\n# libhyperwhisper_core.a is built from source, not committed: 11 versions of a\n# 65 MB binary had reached 52% of the repository. See Libraries/README.md.\n#\n# This lives in its own aggregate target that the app target depends on, so it\n# is guaranteed to finish before the app links. It deliberately does NOT build\n# the lib and carry on: Xcode resolves LIBRARY_SEARCH_PATHS when it *plans* the\n# build, so a lib that appears mid-build never makes it onto the link line and\n# the app fails with a wall of confusing \\\"Undefined symbols\\\" errors instead.\n# Building it and asking for one more build is the honest version of that.\nif [ ! -f \"$LIB\" ]; then\n  if ! command -v cargo > /dev/null 2>&1; then\n    echo \"error: libhyperwhisper_core.a is missing and cargo was not found. The Rust core is built from source and is not committed to git. Install Rust from https://rustup.rs, then build again. See app/macos/hyperwhisper/Libraries/README.md.\"\n    exit 1\n  fi\n  echo \"note: libhyperwhisper_core.a not present - building it now, this takes a few minutes\"\n  \"$CORE/build-apple.sh\"\n  echo \"error: Built the Rust core at $LIB. Xcode had already planned this build without it, so please build again - it will link this time.\"\n  exit 1\nfi\n\n# Warn rather than rebuild: a stale lib whose FFI surface moved fails loudly at\n# link time anyway, but one where only a function body changed links clean and\n# silently runs old Rust. A warning catches that without hijacking every\n# incremental build with a multi-minute compile.\nSTALE=$(find \"$CORE/crates\" -name '*.rs' -newer \"$LIB\" -print -quit 2>/dev/null || true)\nif [ -n \"$STALE\" ]; then\n  echo \"warning: libhyperwhisper_core.a is older than the Rust sources in shared-core-rs/crates - run shared-core-rs/build-apple.sh to rebuild, otherwise you are linking stale Rust.\"\nfi\n";
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -451,6 +494,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		71F2A2ED2E5E4B210048B2D9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 71F2A2EB2E5E4B1F0048B2D7 /* RustCore */;
+			targetProxy = 71F2A2EC2E5E4B200048B2D8 /* PBXContainerItemProxy */;
+		};
 		7142EF1F2E50808B00DA9A2D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 7142EF0E2E50808900DA9A2D /* hyperwhisper */;
@@ -464,6 +512,22 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		71F2A2EF2E5E4B230048B2DB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		71F2A2F02E5E4B240048B2DC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		7142EF2F2E50808B00DA9A2D /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -745,6 +809,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		71F2A2EE2E5E4B220048B2DA /* Build configuration list for PBXAggregateTarget "RustCore" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				71F2A2EF2E5E4B230048B2DB /* Debug */,
+				71F2A2F02E5E4B240048B2DC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7142EF0A2E50808900DA9A2D /* Build configuration list for PBXProject "hyperwhisper" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/app/macos/hyperwhisper/Libraries/README.md
+++ b/app/macos/hyperwhisper/Libraries/README.md
@@ -1,0 +1,67 @@
+# Libraries/
+
+This directory is on `LIBRARY_SEARCH_PATHS` for the `hyperwhisper` target.
+
+| File | Tracked in git? |
+|---|---|
+| `hyperwhisper_coreFFI.h` | yes — generated UniFFI header, small, reviewable in diffs |
+| `libhyperwhisper_core.a` | **no** — built from source |
+
+## Why the static lib isn't committed
+
+It's a 65 MB universal (`arm64` + `x86_64`) release build. Binaries don't
+delta-compress, so every rebuild appended another ~65 MB blob to history that
+nothing could ever reclaim. By the time it was removed, 11 versions of this one
+file were **247 MB — 52% of the entire repository**.
+
+Committing it also made the release wrong in a way that was hard to see.
+`macos-release.yml` linked whatever `.a` happened to be checked in, and keeping
+it fresh was a manual step. That failed two ways:
+
+- **Loud** — the FFI surface moved, so the archive failed to link with
+  `Undefined symbols`. This is what PR #64 hit.
+- **Silent** — only a Rust function *body* changed, so the UniFFI checksums
+  still matched, the archive linked clean, and the release shipped stale Rust
+  with no signal at all.
+
+Both are impossible now: CI and the release workflow each rebuild from source.
+
+## Building it
+
+Either run it yourself once after cloning:
+
+```bash
+cd shared-core-rs && ./build-apple.sh
+```
+
+…or just build in Xcode and let it tell you. The **RustCore** aggregate target
+(which `hyperwhisper` depends on) runs an *Ensure Rust Core* phase that builds
+the lib when it's missing, then stops with:
+
+> error: Built the Rust core at … Xcode had already planned this build without
+> it, so please build again — it will link this time.
+
+**A fresh clone therefore takes two builds, and that's deliberate.** Xcode
+resolves `LIBRARY_SEARCH_PATHS` when it *plans* a build, not when it links: if
+the `.a` isn't on disk at planning time, `-lhyperwhisper_core` never reaches
+the link command, and the build dies in a wall of `Undefined symbols` that says
+nothing about the real cause. Building the lib and asking for one more pass is
+the honest version of that. It's why the phase lives in its own target — the
+app target never starts, so you get one clear line instead of hundreds of
+misleading ones.
+
+The Rust build takes a few minutes; the workspace pins `lto = true` /
+`codegen-units = 1`.
+
+If you change anything under `shared-core-rs/crates/`, run that — the build
+phase will warn that the lib is older than the sources, but it won't rebuild
+for you (a multi-minute compile on every incremental build would be worse than
+the warning).
+
+Requires a Rust toolchain: https://rustup.rs
+
+## See also
+
+- `shared-core-rs/README.md` — crate layout and binding generation
+- `app/windows/HyperWhisper/Resources/rust-core/` — the Windows equivalent,
+  which has always tracked only `.gitkeep` placeholders

--- a/shared-core-rs/README.md
+++ b/shared-core-rs/README.md
@@ -76,6 +76,12 @@ lipo -create \
 
 Helper: `./build-apple.sh` does the two builds + `lipo` and copies the result.
 
+The resulting `.a` is **not** committed. Run this once after cloning; CI and the
+release workflow rebuild it from source on every run. If you skip it, Xcode's
+`RustCore` target builds it for you and then asks for one more build (Xcode
+resolves `LIBRARY_SEARCH_PATHS` at plan time, so a lib created mid-build isn't
+linked). See `app/macos/hyperwhisper/Libraries/README.md`.
+
 ### Windows DLL (both architectures)
 
 Cross-compiling the MSVC DLL from macOS is not supported; build on Windows or in
@@ -188,7 +194,18 @@ that principle. Left as a known limitation.
 
 ## Distribution
 
-- **Milestones 0–4 (now):** build locally, commit the prebuilt binaries + pilot
-  bindings (the same hybrid pattern `rphonetic-ffi` used).
-- **Milestone 5+:** a GitHub Actions matrix cross-compiles every target; binaries
-  leave git history and are pulled at app-build time.
+Generated bindings (`bindings/`) and the UniFFI headers are committed — they're
+text, they diff, and reviewing them is how binding drift gets caught.
+
+Compiled binaries are **not**:
+
+| Target | Artifact | How it's obtained |
+|---|---|---|
+| macOS | `libhyperwhisper_core.a` | Xcode "Ensure Rust Core" phase, or `./build-apple.sh`; rebuilt from source in `macos-ci.yml` + `macos-release.yml` |
+| Windows | `hyperwhisper_core.dll` | built in `windows-ci.yml` / `windows-release.yml`; only `.gitkeep` is tracked |
+
+The macOS lib was committed through milestone 4 (the hybrid pattern
+`rphonetic-ffi` used) and left git history in 2026-07 — 11 versions of a 65 MB
+binary had reached 52% of the repository, and linking the committed copy at
+release time let stale Rust ship silently whenever the FFI checksums happened
+to still match. Both platforms now build from source on every run.

--- a/shared-core-rs/build-apple.sh
+++ b/shared-core-rs/build-apple.sh
@@ -6,11 +6,13 @@ cd "$(dirname "$0")"
 
 DEST="../app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a"
 
-# Strip local filesystem paths out of the committed artifact: panic/debug
-# metadata otherwise embeds $HOME and the workspace path, and this repo is
-# public. (`trim-paths = "all"` in Cargo.toml would replace this once it
-# stabilizes on the pinned toolchain; also remap the cargo registry src dir
-# that dependency paths resolve under.)
+# Strip local filesystem paths out of the artifact: panic/debug metadata
+# otherwise embeds $HOME and the workspace path. The lib is no longer committed
+# (see app/macos/hyperwhisper/Libraries/README.md), but this still matters —
+# it links into the app bundle shipped to users, so a builder's home directory
+# would otherwise travel inside every release. (`trim-paths = "all"` in
+# Cargo.toml would replace this once it stabilizes on the pinned toolchain;
+# also remap the cargo registry src dir that dependency paths resolve under.)
 export RUSTFLAGS="${RUSTFLAGS:-} --remap-path-prefix=$PWD=/build --remap-path-prefix=$HOME/.cargo=/cargo --remap-path-prefix=$HOME=~"
 
 echo "==> building aarch64-apple-darwin"


### PR DESCRIPTION
## What

Stops tracking `app/macos/hyperwhisper/Libraries/libhyperwhisper_core.a` and builds it from source everywhere instead.

## Why size was the symptom, not the bug

The 65 MB universal static lib was committed. Binaries don't delta-compress, so every rebuild appended another ~65 MB blob that nothing could ever reclaim:

| path | packed | versions |
|---|---|---|
| `libhyperwhisper_core.a` | **247 MB** | **11** |
| all whisper dSYMs combined | ~32 MB | 1 each |
| all parakeet-engine DLLs | ~75 MB | 1 each |

It's the only tracked binary that churns — everything else was committed once and never touched. 247 MB is **52% of the entire repository**.

The real problem was the release path. `macos-release.yml` linked whatever `.a` happened to be checked in, and keeping it fresh was a manual step. Two failure modes:

- **loud** — the FFI surface moved, so the archive failed to link with `Undefined symbols`. This is what #64 hit.
- **silent** — only a Rust function *body* changed, so the UniFFI checksums still matched, the archive linked clean, and the release shipped stale Rust with no signal at all.

`macos-ci.yml` already rebuilt from source, which is precisely why CI stayed green while the committed copy rotted — CI structurally could not see this class of drift. The release workflow now rebuilds too, making both modes unreachable.

## Local development

A `RustCore` aggregate target (which `hyperwhisper` depends on) builds the lib when missing, then stops and asks for one more build.

**That second build is deliberate, not a race.** Xcode resolves `LIBRARY_SEARCH_PATHS` when it *plans* a build — a lib created mid-build never reaches the link line, and the app dies in a wall of `Undefined symbols` naming no cause. Putting the check in its own target means the app target never starts, so you get one clear line instead of hundreds of misleading ones.

A stale lib **warns** rather than rebuilding; a multi-minute compile on every incremental build would be worse than the warning.

Mirrors Windows, which has always tracked only `.gitkeep` under `Resources/rust-core/`.

## Verification

Simulated fresh clone, all three paths:

| scenario | result |
|---|---|
| lib absent | clear error, lib built, **0** Undefined-symbol lines |
| lib present | `** BUILD SUCCEEDED **` |
| touched `.rs` | staleness warning, build still succeeds |

## Incidental

`project.pbxproj` had `skip-worktree` set — the only file in the repo with it — so **any** local pbxproj change was being silently dropped from every commit. Cleared. The working copy matched `HEAD` exactly, so nothing unrelated came along with it.

## Not in this PR

History still carries the 247 MB; reclaiming it needs a force-push rewrite, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189yTpvDjMvP7PT5HAAtFQh