### PR TITLE
fix(windows): model library scrolls with the mouse wheel

### DIFF
--- a/app/windows/HyperWhisper/Views/Pages/Settings/ModelsSettingsPage.xaml
+++ b/app/windows/HyperWhisper/Views/Pages/Settings/ModelsSettingsPage.xaml
@@ -373,38 +373,12 @@
                     </Grid>
                     <Border Height="1" Background="{DynamicResource BorderBrush}"/>
 
-                    <ListBox x:Name="LibraryRowsControl"
-                             ItemsSource="{Binding LibraryRows}"
-                             Background="Transparent"
-                             BorderThickness="0"
-                             Padding="0"
-                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                             ScrollViewer.VerticalScrollBarVisibility="Disabled"
-                             ScrollViewer.CanContentScroll="False"
-                             VirtualizingPanel.IsVirtualizing="True"
-                             VirtualizingPanel.VirtualizationMode="Recycling"
-                             VirtualizingPanel.ScrollUnit="Pixel">
-                        <ListBox.ItemContainerStyle>
-                            <Style TargetType="ListBoxItem">
-                                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                                <Setter Property="Padding" Value="0"/>
-                                <Setter Property="Margin" Value="0"/>
-                                <Setter Property="Focusable" Value="False"/>
-                                <Setter Property="Template">
-                                    <Setter.Value>
-                                        <ControlTemplate TargetType="ListBoxItem">
-                                            <ContentPresenter/>
-                                        </ControlTemplate>
-                                    </Setter.Value>
-                                </Setter>
-                            </Style>
-                        </ListBox.ItemContainerStyle>
-                        <ListBox.ItemsPanel>
-                            <ItemsPanelTemplate>
-                                <VirtualizingStackPanel/>
-                            </ItemsPanelTemplate>
-                        </ListBox.ItemsPanel>
-                        <ListBox.ItemTemplate>
+                    <ItemsControl x:Name="LibraryRowsControl"
+                                  ItemsSource="{Binding LibraryRows}"
+                                  Background="Transparent"
+                                  BorderThickness="0"
+                                  Padding="0">
+                        <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border BorderBrush="{DynamicResource BorderBrush}" BorderThickness="0,0,0,1">
                                     <Grid Margin="14,8">
@@ -563,8 +537,8 @@
                                     </Grid>
                                 </Border>
                             </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
 
                     <StackPanel x:Name="EmptyStatePanel"
                                 HorizontalAlignment="Center"


### PR DESCRIPTION

The Model Library page can only be scrolled by dragging the scrollbar thumb. The mouse wheel does nothing.

The model list is a `ListBox` nested inside the page's `ScrollViewer` with its own scrollbars disabled. A `ListBox` still creates an internal `ScrollViewer`, and that `ScrollViewer` handles `MouseWheel` and marks the event handled — so the wheel never reaches the page's `ScrollViewer`.

Swaps the `ListBox` for an `ItemsControl`, which has no internal `ScrollViewer`. Same approach as ca720fc, which fixed the identical problem on the Vocabulary page.

Everything removed alongside it was already inert or redundant:

- `ItemContainerStyle` existed only to erase `ListBoxItem` chrome — template replaced by a bare `ContentPresenter`, zero padding and margin, `Focusable` false. `ItemsControl` generates `ContentPresenter`s directly, so there's nothing to erase.
- The `VirtualizingPanel` settings and the explicit `VirtualizingStackPanel` never virtualized anything. Virtualization needs a constrained viewport, and `ScrollViewer.VerticalScrollBarVisibility="Disabled"` gives the `ListBox` an infinite vertical measure, so all 82 rows were realized either way.
- The `ScrollViewer.*` attached properties configured the internal `ScrollViewer` that no longer exists.

`x:Name="LibraryRowsControl"` is unreferenced in both XAML and code-behind, and there is no selection binding, so nothing depended on `Selector` behaviour. Row separators already live on the `DataTemplate`'s `Border`, so per-item appearance is unchanged.

### Verifying

Model Library → scroll wheel over the list. Rows should scroll, and separators, download progress bars and buttons should look the same as before.
