### PR TITLE
fix(windows): stop history from destroying completed transcriptions

### DIFF
--- a/app/windows/HyperWhisper.SmokeTests/Program.cs
+++ b/app/windows/HyperWhisper.SmokeTests/Program.cs
@@ -25,6 +25,7 @@ using HyperWhisper.Data.Entities;
 using HyperWhisper.Models;
 using HyperWhisper.Services;
 using HyperWhisper.Services.Transcription;
+using HyperWhisper.ViewModels;
 using HyperWhisper.Views.Pages.Settings;
 using uniffi.hyperwhisper_core;
 
@@ -364,6 +365,62 @@ internal static class Program
                 Assert(
                     !AssemblyAIService.IsSyncEligible(Result<double>.Success(cap - 1), cap, isMedicalModel: true),
                     "a medical model should NOT be sync-eligible even with an otherwise-eligible duration — sync has no medical/domain concept");
+            });
+
+            Run("TranscriptViewModel.ApplyUpdate never reverts the entity it wraps", () =>
+            {
+                // Reproduces the History clobber: MainViewModel creates a Processing
+                // transcript, HistoryViewModel wraps that exact instance, then
+                // MainViewModel completes the SAME instance and hands it back through
+                // HistoryService.TranscriptUpdated. Absorbing the update must not
+                // revert the entity to the snapshot taken at construction — the
+                // transcription flow's finally-block safety net reads that status and
+                // would overwrite a completed transcript with a failure.
+                var transcript = new Transcript
+                {
+                    Id = Guid.NewGuid(),
+                    Status = TranscriptStatus.Processing,
+                    Text = "Processing audio..."
+                };
+
+                var vm = new TranscriptViewModel(transcript);
+
+                transcript.Text = "the real transcription";
+                transcript.TranscribedText = "the real transcription";
+                transcript.Status = TranscriptStatus.Completed;
+                transcript.TranscriptionProvider = "Whisper large-v3-turbo";
+
+                vm.ApplyUpdate(transcript);
+
+                Assert(transcript.Status == TranscriptStatus.Completed,
+                    $"entity status was reverted to {transcript.Status}");
+                Assert(transcript.Text == "the real transcription",
+                    $"entity text was reverted to '{transcript.Text}'");
+                Assert(transcript.TranscribedText == "the real transcription",
+                    "entity raw text was discarded");
+                Assert(transcript.TranscriptionProvider == "Whisper large-v3-turbo",
+                    "entity provider was discarded");
+
+                Assert(vm.Status == TranscriptStatus.Completed,
+                    $"view model still shows {vm.Status}");
+                Assert(vm.Text == "the real transcription",
+                    $"view model still shows '{vm.Text}'");
+
+                // A distinct instance (e.g. re-read from the DB) must still land.
+                var reread = new Transcript
+                {
+                    Id = transcript.Id,
+                    Status = TranscriptStatus.Failed,
+                    Text = "No speech detected",
+                    FailedReason = "No speech detected",
+                    RetryCount = 2
+                };
+
+                vm.ApplyUpdate(reread);
+
+                Assert(vm.Status == TranscriptStatus.Failed, $"view model shows {vm.Status}");
+                Assert(vm.Text == "No speech detected", $"view model shows '{vm.Text}'");
+                Assert(vm.RetryCount == 2, $"view model shows retry count {vm.RetryCount}");
             });
 
             Run("BackupExportSettingsPage initializes under WPF", () =>

--- a/app/windows/HyperWhisper/ViewModels/HistoryViewModel.cs
+++ b/app/windows/HyperWhisper/ViewModels/HistoryViewModel.cs
@@ -853,19 +853,11 @@ public partial class HistoryViewModel : ViewModelBase
         {
             if (_transcriptLookup.TryGetValue(transcript.Id, out var vm))
             {
-                // Update the source and refresh
-                var entity = vm.ToEntity();
-                entity.Text = transcript.Text;
-                entity.TranscribedText = transcript.TranscribedText;
-                entity.PostProcessedText = transcript.PostProcessedText;
-                entity.Status = transcript.Status;
-                entity.FailedReason = transcript.FailedReason;
-                entity.TranscriptionProvider = transcript.TranscriptionProvider;
-                entity.PostProcessingProvider = transcript.PostProcessingProvider;
-                entity.RetryCount = transcript.RetryCount;
-                entity.LastRetryDate = transcript.LastRetryDate;
-
-                vm.Refresh();
+                // Absorb the fresh entity, then refresh. Do NOT reach for
+                // vm.ToEntity() here: it writes the view model's stale snapshot
+                // back into the entity, and `transcript` is usually that very
+                // instance — so the write reverted the update we were handling.
+                vm.ApplyUpdate(transcript);
 
                 // If this is the selected transcript, update detail view
                 if (SelectedTranscript?.Id == transcript.Id)

--- a/app/windows/HyperWhisper/ViewModels/MainViewModel.cs
+++ b/app/windows/HyperWhisper/ViewModels/MainViewModel.cs
@@ -3126,6 +3126,17 @@ public partial class MainViewModel : ViewModelBase
         try
         {
             var persisted = HistoryService.Instance.GetTranscript(transcript.Id);
+
+            // A persisted terminal status means some path already wrote a result,
+            // so there is nothing to repair — never downgrade it. The in-memory
+            // copy is not trustworthy on its own: it is shared with the History
+            // page's view model, which can revert it to Processing while the row
+            // in the database is already Completed.
+            if (persisted != null && persisted.Status != TranscriptStatus.Processing)
+            {
+                return;
+            }
+
             if (persisted?.Status == TranscriptStatus.Processing &&
                 transcript.Status != TranscriptStatus.Processing)
             {

--- a/app/windows/HyperWhisper/ViewModels/TranscriptViewModel.cs
+++ b/app/windows/HyperWhisper/ViewModels/TranscriptViewModel.cs
@@ -137,8 +137,46 @@ public partial class TranscriptViewModel : ObservableObject
     }
 
     /// <summary>
-    /// Gets the underlying Transcript entity.
-    /// Used when saving updates back to HistoryService.
+    /// Absorbs a freshly-persisted entity for this transcript and refreshes.
+    ///
+    /// Callers handling <c>HistoryService.TranscriptUpdated</c> MUST
+    /// use this instead of <see cref="ToEntity"/>. That event frequently carries the
+    /// very instance <see cref="_source"/> already points at — <c>MainViewModel</c>
+    /// passes its live transcript straight to <c>HistoryService.UpdateTranscript</c>,
+    /// which forwards it to subscribers — and <see cref="ToEntity"/> is a save-back:
+    /// it writes this view model's (stale) snapshot INTO the entity. On the aliased
+    /// path that reverts the entity to whatever it looked like when this view model
+    /// was constructed, i.e. Processing with no text.
+    /// </summary>
+    public void ApplyUpdate(Transcript updated)
+    {
+        ArgumentNullException.ThrowIfNull(updated);
+
+        // Self-assignment when aliased; a genuine copy otherwise (e.g. an entity
+        // re-read from the DB). Either way the source ends up holding the fresh
+        // values, never this view model's stale ones.
+        if (!ReferenceEquals(_source, updated))
+        {
+            _source.Text = updated.Text;
+            _source.TranscribedText = updated.TranscribedText;
+            _source.PostProcessedText = updated.PostProcessedText;
+            _source.Status = updated.Status;
+            _source.FailedReason = updated.FailedReason;
+            _source.TranscriptionProvider = updated.TranscriptionProvider;
+            _source.PostProcessingProvider = updated.PostProcessingProvider;
+            _source.RetryCount = updated.RetryCount;
+            _source.LastRetryDate = updated.LastRetryDate;
+        }
+
+        Refresh();
+    }
+
+    /// <summary>
+    /// Flushes this view model's state INTO the underlying entity and returns it.
+    /// Used when saving user edits back to HistoryService.
+    ///
+    /// WARNING: this is a write, not a getter. Never call it to obtain the entity
+    /// for a refresh — see <see cref="ApplyUpdate"/>.
     /// </summary>
     public Transcript ToEntity()
     {


### PR DESCRIPTION

Fixes #75

Completed transcriptions were being overwritten in History with **"Transcription did not finish"**, losing `Text`, `TranscribedText`, `PostProcessedText` and `TranscriptionProvider`. The transcription itself succeeded and the text pasted correctly; the row was destroyed about 400 ms later. A related variant left the row showing "Processing" forever. My database has 425 rows in this state, dated across the past month.

Only reproducible with the History page open — that's when `HistoryViewModel` exists to hold the entity.

### Cause

`HistoryViewModel.OnTranscriptUpdated` read the entity via `vm.ToEntity()`, but `ToEntity()` is a save-back: it writes the view model's own snapshot *into* the wrapped entity. And the entity it wraps is normally the same instance the event carries — `MainViewModel` passes its live `Transcript` to `HistoryService.UpdateTranscript`, which forwards that instance to subscribers, and `OnTranscriptAdded` wrapped it when the Processing row first appeared. So `entity` and `transcript` are aliases:

```csharp
var entity = vm.ToEntity();          // reverts the entity to the snapshot taken at
                                     // construction: Processing, no text
entity.Text = transcript.Text;       // entity IS transcript -> self-assignment
entity.Status = transcript.Status;   // ditto, for every field
vm.Refresh();                        // re-reads the reverted entity
```

Two consequences. `vm.Refresh()` re-reads the reverted entity, so the row keeps showing Processing. And the transcription flow's `finally`-block safety net (`EnsureTranscriptTerminalStatus`) reads the same reverted instance, sees `Processing`, and writes the failure over the row already saved as Completed.

The reverting callback is queued with `Dispatcher.BeginInvoke`; the flow's 400 ms success-overlay `await` is the window in which it runs, immediately before the `finally`. Whether it lands before or after that block is what decides between the "Failed" and "stuck on Processing" variants.

### Changes

Two commits, reviewable separately.

**1. Remove the cause.** New `TranscriptViewModel.ApplyUpdate(Transcript)` copies the incoming entity onto the source only when the two are distinct instances, then refreshes — so the aliased case is a no-op instead of a revert, and a re-read entity still lands. Same field set the handler used before. `ToEntity()` now documents that it is a write, not a getter.

**2. Make the safety net incapable of this.** `EnsureTranscriptTerminalStatus` decided what to write from the in-memory status alone, so it could downgrade a row the database already recorded as Completed. It now treats the persisted row as the authority: if it already holds a terminal status, return without writing. The repair path (persisted Processing, in-memory terminal) and the flip path (both Processing) are unchanged.

The second commit alone would have prevented all 425 destroyed rows, but the first is the actual bug — without it, History still displays stale Processing rows.

### Tests

Adds a check to `HyperWhisper.SmokeTests` that reproduces the aliased path: wrap a Processing transcript, complete that same instance, call `ApplyUpdate`, and assert the entity was not reverted and the view model reflects the result. Also covers the distinct-instance path.

### Verifying

1. Open History and leave it open.
2. Record any dictation and let it complete.
3. The row should show the transcribed text, not "Transcription did not finish" and not a stuck "Processing".
4. Log should contain `HistoryService: Updated transcript … (Status: Completed)` with no following `EnsureTranscriptTerminalStatus: Flipped orphaned transcript …` for the same id.

### Not covered here

Existing rows already destroyed are unrecoverable from the text side — the audio is retained, so Retry Transcription still works on them. Let me know if you'd want a one-time migration that re-marks them, though I'd guess not.
