### PR TITLE
fix(windows, macos): keep vocabulary replacements when AI post-processing is off

### DIFF
--- a/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Transcription.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Pipeline/TranscriptionPipeline+Transcription.swift
@@ -263,7 +263,14 @@ extension TranscriptionPipeline {
                 // Honor dictated break commands ("new line" / "new paragraph")
                 // in the batch path too — they were streaming-only, so with AI
                 // post-processing off they were silently dropped (issue #1).
-                finalText = TranscriptionTextProcessing.processVoiceCommands(withoutFillers)
+                let withCommands = TranscriptionTextProcessing.processVoiceCommands(withoutFillers)
+                // Vocabulary replacements are the user's own spelling corrections and
+                // are independent of any AI step, so they must apply here too (issue
+                // #80). Applied last, mirroring the two post-processing branches
+                // above; deliberately not hoisted out of the if/else, because those
+                // branches would then run replacements twice and pairs aren't
+                // guaranteed idempotent when one entry's output is another's input.
+                finalText = vocabularyProcessor.applyVocabularyReplacements(withCommands, mode: mode)
             }
 
             markStage("cache_result")

--- a/app/windows/HyperWhisper/Services/Transcription/TranscriptionOrchestrator.cs
+++ b/app/windows/HyperWhisper/Services/Transcription/TranscriptionOrchestrator.cs
@@ -270,6 +270,11 @@ public class TranscriptionOrchestrator : IDisposable
             // batch path too — they were streaming-only, so with AI post-processing
             // off they were silently dropped (issue #1).
             finalText = TranscriptionTextProcessing.ProcessVoiceCommands(finalText);
+            // Vocabulary replacements are the user's own spelling corrections, not
+            // part of AI post-processing — turning post-processing off must not
+            // discard them. Applied last, mirroring the post-processing branch
+            // above where it is the final transformation.
+            finalText = _vocabularyProcessor.ApplyReplacements(finalText);
         }
 
         return new TranscriptionResult(


### PR DESCRIPTION
Fixes #80

Turning AI post-processing off on a mode silently discarded every vocabulary replacement the user had configured. Both platforms have the same gap, and both are fixed here — one commit each, reviewable separately.

## Windows

`TranscriptionOrchestrator` applies replacements inside the post-processing branch only:

```csharp
if (applyPostProcessing && mode.PostProcessingMode != 0)
{
    ...
    // "Apply vocabulary replacements whether or not AI post-processing succeeded."
    finalText = _vocabularyProcessor.ApplyReplacements(postProcessingResult.Text);
}
else if (applyPostProcessing)
{
    // filler words + voice commands only — replacements never run
}
```

The existing comment states the intent the code doesn't quite implement. It covers post-processing *failing or being skipped at runtime* — there `ProcessPreservingBreaksAsync` returns the original text and the call still happens. A mode with post-processing **switched off** takes the `else if` branch and never reaches it.

Vocabulary replacements are the user's own spelling corrections, independent of any AI step, so this applies them in the no-AI branch too — last, mirroring the post-processing branch where they're the final transformation.

Deliberately **not** hoisted above the `if`/`else`: the post-processing branch would then apply them twice, and replacement pairs aren't guaranteed idempotent when one entry's output is another entry's input.

Streaming (`applyPostProcessing` false) is untouched — it applies replacements on its own path.

## macOS

Same shape, confirmed at `TranscriptionPipeline+Transcription.swift:224-267` — three branches, and only two of them apply vocabulary:

| Branch | Applies vocabulary? |
|---|---|
| `hyperwhisperCloudAIText` — server-side AI already applied (line 227) | yes |
| `shouldRunPostProcessing` — client-side AI post-processing (line 252) | yes |
| `else` — no post-processing (lines 253-267) | **no** |

The no-AI branch ended at `TranscriptionTextProcessing.processVoiceCommands(withoutFillers)`. Those two were the only `applyVocabularyReplacements` call sites in the app, so with post-processing off nothing applied the user's corrections at all.

Fixed the same way as the Windows side: replacements run last in that branch, after `processVoiceCommands`, and are not hoisted out of the `if`/`else` for the same double-application reason.

Streaming is likewise untouched on macOS — `RecordingTranscriptionFlow.applyStreamingVocabulary` is its own path, and `VocabularyProcessor.applyHardenedReplacement` is the shared per-word logic behind both, so batch and streaming stay consistent.

### Verifying

1. Add a vocabulary entry with a replacement, e.g. `Purcell` → `Vercel`.
2. Mode with post-processing **on**, dictate "deploy to Purcell" → "deploy to Vercel".
3. Same mode with post-processing **off**, dictate the same → "deploy to Vercel" (was "deploy to Purcell").

Same three steps on each platform.

### Tests

No smoke-test check added on Windows: the change is a branch inside an async orchestrator method that the smoke harness can't construct without a full service graph, and the alternative was refactoring the pipeline purely to make it reachable. `ApplyHardenedReplacement` itself is already covered there.

The Windows side compiles clean and the existing smoke suite passes on a local .NET 10 build. The macOS side builds clean (`xcodebuild -scheme hyperwhisper -configuration Debug`, arm64). Neither change is covered by an automated end-to-end check — both were verified by reading the branch structure, so the dictation walkthrough above is worth running before merge.
