### PR TITLE
fix(windows): drop Groq's decommissioned Llama 4 Maverick from the picker

### DIFF
--- a/app/windows/HyperWhisper/Models/LanguageModelInfo.cs
+++ b/app/windows/HyperWhisper/Models/LanguageModelInfo.cs
@@ -79,7 +79,6 @@ public class LanguageModelInfo
         // Ultra-fast inference via specialized hardware
         new("openai/gpt-oss-120b", "GPT OSS 120B", PostProcessingProvider.Groq, "Fast, high quality"),
         new("openai/gpt-oss-20b", "GPT OSS 20B", PostProcessingProvider.Groq, "Fast, lightweight"),
-        new("meta-llama/llama-4-maverick-17b-128e-instruct", "Llama 4 Maverick 17B", PostProcessingProvider.Groq, "Latest Llama 4, high quality"),
         new("moonshotai/kimi-k2-instruct", "Kimi K2", PostProcessingProvider.Groq, "Strong agentic reasoning"),
 
         // xAI Grok Models
@@ -133,6 +132,10 @@ public class LanguageModelInfo
         "claude-sonnet-4-5-latest" => "claude-sonnet-4-5",
         "claude-sonnet-4-6-latest" => "claude-sonnet-4-6",
         // Groq model removals
+        // Shut down by Groq 2026-03-09 → openai/gpt-oss-120b (GroqCloud deprecation notice).
+        // Missed when the 2026-07-17 removals were mapped below, so it stayed in the
+        // picker and every selection 404'd at post-processing time.
+        "meta-llama/llama-4-maverick-17b-128e-instruct" => "openai/gpt-oss-120b",
         // Decommissioned by Groq 2026-07-17 → openai/gpt-oss-120b (GroqCloud deprecation notice)
         "mixtral-8x7b-32768" => "openai/gpt-oss-120b",
         "llama-3.3-70b-versatile" => "openai/gpt-oss-120b",


### PR DESCRIPTION
Fixes #82

Selecting **Groq → Llama 4 Maverick 17B** made every transcription fall back to the raw transcript. Groq shut that model down on 2026-03-09 (replacement `openai/gpt-oss-120b`), so the request 404s:

```
12:06:18.351  PostProcessingService: Processing with Groq/meta-llama/llama-4-maverick-17b-128e-instruct
12:06:18.464  PostProcessingService: HTTP error: Response status code does not indicate success: 404 (Not Found).
```

113 ms, never reaches a model. The same key succeeds immediately on `openai/gpt-oss-20b`, so it isn't auth.

It's silent from the user's side: post-processing falls back to the original transcript, so a dead model looks like the AI step quietly doing nothing.

### Change

The March removal was missed when Groq's 2026-07-17 removals were mapped, so the id had neither a migration entry nor a place in the picker's retirement path.

- Remove it from `AvailableModels`.
- Add the migration entry alongside the July ones, so any mode already storing that id moves to `openai/gpt-oss-120b` on next load.

Verified against Groq's live catalog that the remaining three Groq entries (`gpt-oss-120b`, `gpt-oss-20b`, `kimi-k2-instruct`) are all still served.

### Verifying

Add a Groq key, set a mode's post-processing to Groq, and confirm Maverick is no longer offered. If you have a mode still storing the old id, it should load as GPT OSS 120B rather than failing.

### Not in this PR

The issue notes two follow-ups I couldn't verify from here: the map may be over-migrating `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` (both still appear live on Groq), and this class of bug is invisible until a transcription fails. Both are your call.
