### PR TITLE
fix(windows): let the mouse wheel scroll the Modes page

### DIFF
--- a/app/windows/HyperWhisper/Views/Pages/ModesPage.xaml
+++ b/app/windows/HyperWhisper/Views/Pages/ModesPage.xaml
@@ -51,8 +51,20 @@
                      Background="Transparent"
                      BorderThickness="0"
                      Margin="-4,0,-4,0"
-                     SelectionChanged="ModeListBox_SelectionChanged"
-                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                     SelectionChanged="ModeListBox_SelectionChanged">
+                <!-- Template without a ScrollViewer: the page ScrollViewer (Grid.Row="2") owns
+                     scrolling. A default ListBox brings its own ScrollViewer, and since the
+                     surrounding StackPanel measures it with infinite height it never has
+                     anything to scroll — yet it still marks the mouse wheel handled, leaving
+                     the page scroller wheel-dead. Model Library (#78) and Vocabulary (ca720fc)
+                     dropped the inner ScrollViewer by switching to ItemsControl; here selection
+                     is load-bearing (it sets the active mode and paints the accent border), so
+                     keep the ListBox and drop only the ScrollViewer. -->
+                <ListBox.Template>
+                    <ControlTemplate TargetType="ListBox">
+                        <ItemsPresenter/>
+                    </ControlTemplate>
+                </ListBox.Template>
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
                         <UniformGrid Columns="2" IsItemsHost="True"/>


### PR DESCRIPTION
Fixes #88.

## Problem

The Modes page could only be scrolled by dragging the scrollbar thumb — the wheel did nothing over the card grid.

`ModesPage.xaml` nests a `ListBox` inside the page's `ScrollViewer`, under a `StackPanel`. A default `ListBox` brings its own `ScrollViewer`; the `StackPanel` measures it with infinite height, so that inner scroller always has `viewport == extent` and nothing to scroll. WPF's `ScrollViewer.OnMouseWheel` marks the event handled regardless, so the page scroller never sees it.

## Fix

Give the `ListBox` a `ControlTemplate` that is just an `ItemsPresenter` — no inner `ScrollViewer`, so the wheel bubbles to the page scroller. The now-inert `ScrollViewer.HorizontalScrollBarVisibility="Disabled"` attached property is dropped with it.

Model Library (#78) and Vocabulary (ca720fc) fixed the same bug by swapping the items control for an `ItemsControl`. That swap is not safe here — selection is load-bearing twice over:

- clicking a card is how the active mode is set (`ModesPage.xaml.cs:88-91` → `ModeService.SetSelectedMode`), and selection is written back from the `ModeSelected` service event and on load;
- the `IsSelected` trigger paints the accent border on the active mode, and `IsSelected` only exists on `ListBoxItem`.

Keeping the `ListBox` preserves both. `UniformGrid` is still the items panel, so layout is unchanged, and nothing is lost by dropping the inner scroller: the panel is non-virtualizing either way, and `ScrollIntoView`/`BringIntoView` bubble a `RequestBringIntoView` that the page scroller handles.

## Testing

Windows CI (build + smoke suite) covers the XAML compile. Visual verification — wheel scrolls the grid, clicking a card still switches the active mode and moves the accent border — needs a Windows run; not done on this machine (macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AcBX4568kEpxKdDNtnd2B