### PR TITLE
chore: gitignore bug-hunt/ and .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,8 @@ plans/
 notes/
 tasks/
 app/ios/
+bug-hunt/
+.playwright-mcp/
 # Local agent tooling & internal-only skills/worktrees — never part of the public repo
 # ...except .claude/skills/, which holds repo-shareable skills that ship with the project.
 .claude/*


### PR DESCRIPTION
Both directories existed locally as **untracked but not excluded**, so a `git add .` would have committed local bug-hunt reports and Playwright MCP scratch output to this public repo.

Nothing under either path was ever committed, so there's no history to scrub — this is purely preventative. Grouped with the existing internal-only block (`plans/`, `notes/`, `tasks/`, `app/ios/`).

Also normalizes the missing trailing newline at EOF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2EYiqZ4U6p13Pw39S4FgR
