### PR TITLE
fix(windows, macos): cap Groq post-processing output so long dictations survive

### DIFF
--- a/app/macos/hyperwhisper/Managers/Transcription/PostProcessing/AIPostProcessor.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/PostProcessing/AIPostProcessor.swift
@@ -82,6 +82,11 @@ class AIPostProcessor: ObservableObject {
     /// Max output tokens requested from any LLM (local or cloud) during post-processing.
     private let maxOutputTokens = 8_192
 
+    /// Output-token cap for Groq requests — see the comment at the Groq branch
+    /// in performAIPostProcessing's request assembly for why this is lower
+    /// than maxOutputTokens.
+    private let groqMaxCompletionTokens = 4_096
+
     /// Resolver for on-device local models
     weak var localModelManager: LocalModelManager?
 
@@ -364,6 +369,15 @@ class AIPostProcessor: ObservableObject {
         if provider == .localLLM {
             localLLMSamplingParameters.forEach { requestBody[$0.key] = $0.value }
             requestBody["max_tokens"] = maxOutputTokens
+        }
+
+        // Groq defaults to 2,048 completion tokens when the request omits a cap,
+        // and gpt-oss reasoning tokens spend from that same budget, so long
+        // dictations truncate (finish_reason=length). Kept at 4,096 — not
+        // maxOutputTokens (8,192) — because Groq's free-tier TPM admission check
+        // (8,000) counts prompt + requested cap, not actual usage.
+        if provider == .groq {
+            requestBody["max_completion_tokens"] = groqMaxCompletionTokens
         }
 
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)

--- a/app/macos/hyperwhisper/Managers/Transcription/PostProcessing/AIPostProcessor.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/PostProcessing/AIPostProcessor.swift
@@ -371,11 +371,12 @@ class AIPostProcessor: ObservableObject {
             requestBody["max_tokens"] = maxOutputTokens
         }
 
-        // Groq defaults to 2,048 completion tokens when the request omits a cap,
-        // and gpt-oss reasoning tokens spend from that same budget, so long
-        // dictations truncate (finish_reason=length). Kept at 4,096 — not
-        // maxOutputTokens (8,192) — because Groq's free-tier TPM admission check
-        // (8,000) counts prompt + requested cap, not actual usage.
+        // Groq applies a low default completion cap when the request omits one
+        // (its reasoning docs cite 1,024), and gpt-oss reasoning tokens spend
+        // from that same budget, so long dictations truncate
+        // (finish_reason=length). Kept at 4,096 — not maxOutputTokens (8,192) —
+        // because Groq's free-tier TPM ceiling for openai/gpt-oss-120b is 8,000
+        // and the admission check counts prompt + requested cap, not actual usage.
         if provider == .groq {
             requestBody["max_completion_tokens"] = groqMaxCompletionTokens
         }

--- a/app/windows/HyperWhisper.SmokeTests/Program.cs
+++ b/app/windows/HyperWhisper.SmokeTests/Program.cs
@@ -105,13 +105,26 @@ internal static class Program
             Run("OpenAI post-processing omits an output-token cap", () =>
             {
                 var requestJson = PostProcessingService.BuildOpenAIRequestJson(
-                    "gpt-4.1-nano", "system", "user");
+                    OpenAICompatibleProvider.OpenAI, "gpt-4.1-nano", "system", "user");
                 using var request = JsonDocument.Parse(requestJson);
 
                 Assert(!request.RootElement.TryGetProperty("max_tokens", out _),
                     "OpenAI request should not contain max_tokens");
                 Assert(!request.RootElement.TryGetProperty("max_completion_tokens", out _),
                     "OpenAI request should not contain max_completion_tokens");
+            });
+
+            Run("Groq post-processing sends an explicit output-token cap", () =>
+            {
+                var requestJson = PostProcessingService.BuildOpenAIRequestJson(
+                    OpenAICompatibleProvider.Groq, "openai/gpt-oss-20b", "system", "user");
+                using var request = JsonDocument.Parse(requestJson);
+
+                Assert(request.RootElement.GetProperty("max_completion_tokens").GetInt32()
+                        == PostProcessingService.GroqMaxCompletionTokens,
+                    "Groq request should cap completions at GroqMaxCompletionTokens");
+                Assert(!request.RootElement.TryGetProperty("max_tokens", out _),
+                    "Groq request should use max_completion_tokens, not max_tokens");
             });
 
             // These checks call straight into the generated FFI surface

--- a/app/windows/HyperWhisper/Services/PostProcessingService.cs
+++ b/app/windows/HyperWhisper/Services/PostProcessingService.cs
@@ -367,11 +367,12 @@ public class PostProcessingService : IDisposable
     }
 
     /// <summary>
-    /// Output-token cap sent to Groq. Groq defaults to 2,048 completion tokens
-    /// when the request omits a cap, and gpt-oss reasoning tokens spend from
-    /// that same budget, so long dictations truncate (finish_reason=length).
-    /// Kept at 4,096 — not 8,192 like Anthropic — because Groq's free-tier TPM
-    /// admission check (8,000) counts prompt + requested cap, not actual usage.
+    /// Output-token cap sent to Groq. Groq applies a low default completion cap
+    /// when the request omits one (its reasoning docs cite 1,024), and gpt-oss
+    /// reasoning tokens spend from that same budget, so long dictations truncate
+    /// (finish_reason=length). Kept at 4,096 — not 8,192 like Anthropic — because
+    /// Groq's free-tier TPM ceiling for openai/gpt-oss-120b is 8,000 and the
+    /// admission check counts prompt + requested cap, not actual usage.
     /// </summary>
     internal const int GroqMaxCompletionTokens = 4096;
 

--- a/app/windows/HyperWhisper/Services/PostProcessingService.cs
+++ b/app/windows/HyperWhisper/Services/PostProcessingService.cs
@@ -355,7 +355,7 @@ public class PostProcessingService : IDisposable
         using var request = new HttpRequestMessage(System.Net.Http.HttpMethod.Post, provider.Endpoint());
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
         request.Content = new StringContent(
-            BuildOpenAIRequestJson(model, systemPrompt, userMessage),
+            BuildOpenAIRequestJson(provider, model, systemPrompt, userMessage),
             Encoding.UTF8,
             "application/json"
         );
@@ -366,23 +366,53 @@ public class PostProcessingService : IDisposable
         return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 
+    /// <summary>
+    /// Output-token cap sent to Groq. Groq defaults to 2,048 completion tokens
+    /// when the request omits a cap, and gpt-oss reasoning tokens spend from
+    /// that same budget, so long dictations truncate (finish_reason=length).
+    /// Kept at 4,096 — not 8,192 like Anthropic — because Groq's free-tier TPM
+    /// admission check (8,000) counts prompt + requested cap, not actual usage.
+    /// </summary>
+    internal const int GroqMaxCompletionTokens = 4096;
+
     internal static string BuildOpenAIRequestJson(
+        OpenAICompatibleProvider provider,
         string model,
         string systemPrompt,
         string userMessage)
     {
-        var requestBody = new
+        var requestBody = BaseOpenAIRequestBody(model, systemPrompt, userMessage);
+
+        if (provider == OpenAICompatibleProvider.Groq)
         {
-            model,
-            messages = new[]
-            {
-                new { role = "system", content = systemPrompt },
-                new { role = "user", content = userMessage }
-            }
-        };
+            requestBody["max_completion_tokens"] = GroqMaxCompletionTokens;
+        }
 
         return JsonSerializer.Serialize(requestBody);
     }
+
+    /// <summary>
+    /// Request JSON for custom OpenAI-compatible endpoints: no provider-specific
+    /// fields, because the server behind a user-supplied URL is unknown.
+    /// </summary>
+    internal static string BuildOpenAIRequestJson(
+        string model,
+        string systemPrompt,
+        string userMessage)
+        => JsonSerializer.Serialize(BaseOpenAIRequestBody(model, systemPrompt, userMessage));
+
+    private static Dictionary<string, object> BaseOpenAIRequestBody(
+        string model,
+        string systemPrompt,
+        string userMessage) => new()
+    {
+        ["model"] = model,
+        ["messages"] = new object[]
+        {
+            new { role = "system", content = systemPrompt },
+            new { role = "user", content = userMessage }
+        }
+    };
 
     /// <summary>
     /// Maps the OpenAI-compatible subset of <see cref="PostProcessingProvider"/> to the


### PR DESCRIPTION
Fixes #98

A ~3-minute dictation (2,100 chars) through **Groq → GPT OSS 20B** came back `finish_reason: "length"`, so the completion policy rejected it (`OutputLimit`) and fell back to the raw transcript. Short dictations through the same mode kept working:

```
21:43:39.958  PostProcessingService: Processing with Groq/openai/gpt-oss-20b
21:43:42.514  PostProcessingService: Response rejected (OutputLimit); keeping original transcription
```

Neither app sends `max_tokens` on OpenAI-compatible requests — safe on OpenAI, where omitting it means "model maximum", but Groq's undocumented default is **2,048 completion tokens**, and gpt-oss spends its hidden reasoning tokens from that same budget. Replaying the exact failed request (same transcript, prompt, and vocabulary) reproduced it 2/2:

| Replay | completion_tokens | of which reasoning | visible output |
|---|---|---|---|
| no cap #1 | 2048 (exactly) | 1,734 | 1,483 chars, truncated |
| no cap #2 | 2048 (exactly) | 2,046 | empty |
| `max_completion_tokens: 4096` #1 | 3,445 | 3,021 | complete, `finish_reason=stop` |
| `max_completion_tokens: 4096` #2 | 1,736 | 1,332 | complete, `finish_reason=stop` |

### Change

Send `max_completion_tokens: 4096` on Groq requests only; every other provider keeps today's request shape. One commit per platform, reviewable separately.

Two values that look more obvious were tried and rejected against the live API:

- **8,192** (parity with the Anthropic path): Groq's free-tier TPM admission check (8,000 for gpt-oss-20b) counts **prompt + requested cap**, not actual usage — with 8,192 every request 413s before generation even starts. 4,096 accommodated every observed reasoning run with the cleaned output on top, and keeps prompt + cap admissible for dictations up to roughly seven minutes.
- **`reasoning_effort: "low"`**: collapsed reasoning to ~33 tokens and halved latency, but cleanup quality dropped to near-verbatim — fillers kept, no punctuation restored. Not worth it.

## Windows

`BuildOpenAIRequestJson` takes the `OpenAICompatibleProvider` and adds the cap for Groq. Custom OpenAI-compatible endpoints keep the uncapped shape via a provider-less overload — the server behind a user-supplied URL is unknown.

## macOS

Same cap in `AIPostProcessor`'s request assembly. All cloud providers route through the non-streaming `performAIPostProcessing` path (streaming is local-LLM-only), so the single site covers every Groq model.

### Verifying

1. Mode with post-processing set to **Groq → GPT OSS 20B**.
2. Dictate ~3 minutes of continuous speech → cleaned text is pasted (was: "Post-processing failed, using original text" toast and the raw transcript).
3. A short dictation still cleans up as before.

Done on Windows with a real 3m15s dictation through a live Groq key — cleaned text pasted where the same length previously failed.

### Tests

New Windows smoke test asserts the Groq request carries `max_completion_tokens` (and no deprecated `max_tokens`); the existing "OpenAI omits an output-token cap" check still passes with the provider argument. Full smoke suite green on a local .NET 10 build.

The macOS change structurally mirrors the Windows one but was written from a Windows machine — it's 14 additive lines against the verified `.groq` enum case, but worth an `xcodebuild` and the dictation walkthrough above before merge.

Residual limitation, deliberate: dictations much past ~5 minutes can still occasionally truncate at 4,096 (gpt-oss reasoning length is highly variable — 1,332 to 3,021 tokens across four runs on the same prompt), and free-tier admission blocks any larger cap. The completion policy's fallback to the raw transcript covers that case.
