### PR TITLE
fix(windows): stop Deepgram live streaming from timing out before it starts

### DIFF
--- a/app/windows/HyperWhisper.SmokeTests/Program.cs
+++ b/app/windows/HyperWhisper.SmokeTests/Program.cs
@@ -24,6 +24,7 @@ using HyperWhisper.Data;
 using HyperWhisper.Data.Entities;
 using HyperWhisper.Models;
 using HyperWhisper.Services;
+using HyperWhisper.Services.Streaming;
 using HyperWhisper.Services.Transcription;
 using HyperWhisper.Views.Pages.Settings;
 using uniffi.hyperwhisper_core;
@@ -112,6 +113,13 @@ internal static class Program
                     "OpenAI request should not contain max_tokens");
                 Assert(!request.RootElement.TryGetProperty("max_completion_tokens", out _),
                     "OpenAI request should not contain max_completion_tokens");
+            });
+
+            Run("Deepgram streaming starts its session on WebSocket open", () =>
+            {
+                Assert(new DeepgramStreamingStrategy().SessionStartsOnWebSocketOpen,
+                    "Deepgram sends nothing until it receives audio, so startup must not "
+                        + "block waiting for a provider message");
             });
 
             // These checks call straight into the generated FFI surface

--- a/app/windows/HyperWhisper/Services/Streaming/DeepgramStreamingStrategy.cs
+++ b/app/windows/HyperWhisper/Services/Streaming/DeepgramStreamingStrategy.cs
@@ -18,7 +18,11 @@ public sealed class DeepgramStreamingStrategy : IStreamingProviderStrategy
 
     public string TranscriptionProviderLabel => "Deepgram (Streaming)";
     public bool SupportsVocabulary => true;
-    public bool SessionStartsOnWebSocketOpen => false;
+
+    // Deepgram direct streaming is ready as soon as the WebSocket handshake
+    // completes. Metadata may arrive later, so startup should not block on it.
+    public bool SessionStartsOnWebSocketOpen => true;
+
     public int AudioSampleRate => 16000;
     public IReadOnlyList<(byte[] Data, WebSocketMessageType Type)> GetStartMessages(StreamingSessionConfig config) => [];
 


### PR DESCRIPTION
Fixes #100

Streaming mode with **Deepgram** failed after exactly 10 seconds, every time, with "Streaming session did not become ready" — no audio was ever transcribed:

```
11:01:22.933  KeyboardShortcutService: WM_HOTKEY triggered 'streaming' (Ctrl+Shift+Space)
11:01:22.952  RecordingOverlayWindow: Shown in streaming state (Deepgram (Streaming))
11:01:33.191  StreamingTranscriptionClient: connect failed for Deepgram (Streaming)
              Message: Streaming session did not become ready.
                at StreamingTranscriptionClient.WaitForSessionStartedAsync(...):line 540
                at StreamingTranscriptionClient.StartAsync(...):line 105
```

`DeepgramStreamingStrategy` declared `SessionStartsOnWebSocketOpen => false`, so `StartAsync` parked in `WaitForSessionStartedAsync` waiting for a first message from Deepgram, and the app doesn't start sending microphone audio until that wait returns. A wire test against the live API with a real key showed the other half of the deadlock:

| Step | Result |
|---|---|
| WebSocket handshake + `token` subprotocol auth | succeeds |
| 4 s of listening after open, no audio sent | **nothing received** |
| real audio streamed | `Results` messages arrive immediately |

Each side was waiting for the other, so the 10-second timeout was guaranteed. The API key was never involved.

### Change

Deepgram is ready as soon as the handshake completes; any metadata it sends is incidental and can arrive later. macOS already models it that way, with a comment stating the intent (`DeepgramStreamingStrategy.swift:322`):

```swift
/// Deepgram direct streaming is ready as soon as WebSocket handshake completes.
/// Metadata may arrive later, so startup should not block on it.
var sessionStartsOnWebSocketOpen: Bool { true }
```

The Windows port inverted it. Flipping the property to `true` (and carrying the comment across) makes the client start its receive loop and move to `Streaming` as soon as the socket opens.

The other Windows strategies keep `false` correctly — their providers do speak first: ElevenLabs sends `session_started`, xAI sends `transcript.created`, HyperWhisper Cloud sends `ready`, and OpenAI answers the session update the client sends with `session.updated`. Deepgram's only session-shaped message is `Metadata`, which never arrives before audio does.

Windows only; macOS needs no change.

### Verifying

1. Settings → Streaming: enable, provider **Deepgram**, enter a Deepgram API key.
2. Press the streaming hotkey and talk → text appears live (was: nothing, then a "Streaming session did not become ready" toast after 10 s).

Done on a local Debug build against a live Deepgram key. Connection now completes in ~250 ms instead of timing out:

```
13:20:13.498  KeyboardShortcutService: WM_HOTKEY triggered 'streaming'
13:20:13.541  RecordingOverlayWindow: Shown in streaming state (Deepgram (Streaming))
13:20:13.755  StreamingTranscriptionClient: connected to Deepgram (Streaming)
13:20:13.756  StreamingAudioCapture: Starting capture on device #0 (1 channel(s))
```

Two live dictations (13.5 s and 18.9 s) transcribed correctly end to end.

### Tests

New smoke test asserts `DeepgramStreamingStrategy.SessionStartsOnWebSocketOpen` is true, so a refactor can't silently restore the deadlock. Full smoke suite green on a local .NET 10 build.

One unrelated observation, left alone deliberately: now that sessions actually run, the log shows `DeepgramStreamingStrategy: failed to parse message ... Path: $.channel` a few times per dictation. That's a pre-existing typing bug — `DeepgramMessage.Channel` is a `DeepgramChannel` object, but Deepgram's `SpeechStarted` and `UtteranceEnd` frames send `"channel":[0,1]`, so deserialization throws before the `switch` and the `"UtteranceEnd" or "SpeechStarted"` branch never runs. It's harmless (transcripts come from `Results`, which parses fine) and it was simply invisible before, because the session never started. Happy to file it separately.
