### PR TITLE
fix(windows): keep Deepgram's endpointing events from failing to parse

### DIFF
--- a/app/windows/HyperWhisper.SmokeTests/Program.cs
+++ b/app/windows/HyperWhisper.SmokeTests/Program.cs
@@ -24,6 +24,7 @@ using HyperWhisper.Data;
 using HyperWhisper.Data.Entities;
 using HyperWhisper.Models;
 using HyperWhisper.Services;
+using HyperWhisper.Services.Streaming;
 using HyperWhisper.Services.Transcription;
 using HyperWhisper.Views.Pages.Settings;
 using uniffi.hyperwhisper_core;
@@ -112,6 +113,25 @@ internal static class Program
                     "OpenAI request should not contain max_tokens");
                 Assert(!request.RootElement.TryGetProperty("max_completion_tokens", out _),
                     "OpenAI request should not contain max_completion_tokens");
+            });
+
+            Run("Deepgram parses every message shape of its \"channel\" field", () =>
+            {
+                var strategy = new DeepgramStreamingStrategy();
+
+                // "channel":[0,1] — the array form used by the endpointing frames.
+                Assert(strategy.ParseMessage("""{"type":"SpeechStarted","channel":[0,1],"timestamp":1.2}""")
+                        is StreamingProviderEvent.Metadata,
+                    "SpeechStarted should parse to a Metadata event");
+                Assert(strategy.ParseMessage("""{"type":"UtteranceEnd","channel":[0,1],"last_word_end":2.5}""")
+                        is StreamingProviderEvent.Metadata,
+                    "UtteranceEnd should parse to a Metadata event");
+
+                // "channel":{...} — the transcript form, which must keep working.
+                Assert(strategy.ParseMessage(
+                        """{"type":"Results","is_final":true,"channel":{"alternatives":[{"transcript":"hello"}]}}""")
+                        is StreamingProviderEvent.FinalTranscript { Text: "hello" },
+                    "Results should still yield its transcript");
             });
 
             // These checks call straight into the generated FFI surface

--- a/app/windows/HyperWhisper/Services/Streaming/DeepgramStreamingStrategy.cs
+++ b/app/windows/HyperWhisper/Services/Streaming/DeepgramStreamingStrategy.cs
@@ -162,6 +162,7 @@ public sealed class DeepgramStreamingStrategy : IStreamingProviderStrategy
         public string? RequestId { get; set; }
 
         [JsonPropertyName("channel")]
+        [JsonConverter(typeof(DeepgramChannelConverter))]
         public DeepgramChannel? Channel { get; set; }
 
         [JsonPropertyName("is_final")]
@@ -178,5 +179,30 @@ public sealed class DeepgramStreamingStrategy : IStreamingProviderStrategy
     {
         [JsonPropertyName("transcript")]
         public string? Transcript { get; set; }
+    }
+
+    // Deepgram overloads "channel": "Results" carries the transcript object, but
+    // "SpeechStarted" and "UtteranceEnd" carry a channel-index array ("channel":[0,1]).
+    // Deserializing the array into DeepgramChannel throws, which would take the whole
+    // message down before ParseMessage can route it, so treat any non-object as absent.
+    private sealed class DeepgramChannelConverter : JsonConverter<DeepgramChannel?>
+    {
+        public override DeepgramChannel? Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                reader.Skip();
+                return null;
+            }
+
+            return JsonSerializer.Deserialize<DeepgramChannel>(ref reader, options);
+        }
+
+        public override void Write(Utf8JsonWriter writer, DeepgramChannel? value, JsonSerializerOptions options) =>
+            throw new NotSupportedException("DeepgramMessage is deserialize-only.");
     }
 }


### PR DESCRIPTION
Fixes #106

Every Deepgram streaming dictation logs a handful of these — a few per session, more the longer you talk:

```
13:21:09.201  DeepgramStreamingStrategy: failed to parse message: The JSON value could not be
              converted to HyperWhisper.Services.Streaming.DeepgramStreamingStrategy+DeepgramChannel.
              Path: $.channel | LineNumber: 0 | BytePositionInLine: 35.
13:21:27.721  DeepgramStreamingStrategy: failed to parse message: ... BytePositionInLine: 34.
```

Deepgram overloads the `channel` field. A `Results` frame carries the transcript object the DTO expects:

```json
{"type":"Results","channel":{"alternatives":[{"transcript":"..."}]},"is_final":true}
```

but the two endpointing frames carry a channel-index **array**:

```json
{"type":"SpeechStarted","channel":[0,1],"timestamp":1.2}
{"type":"UtteranceEnd","channel":[0,1],"last_word_end":2.5}
```

`DeepgramMessage.Channel` is typed as `DeepgramChannel`, so the array throws inside `JsonSerializer.Deserialize` before `ParseMessage` can read the `type` field. The `try/catch` swallows it and logs, which means the `"UtteranceEnd" or "SpeechStarted"` arm of the switch has **never executed** on Windows. The two logged byte positions are exactly where `"channel":[` starts in each frame — 34 for `UtteranceEnd`, 35 for `SpeechStarted`.

Both frames are requested deliberately (`vad_events=true`, `utterance_end_ms=1500` in `BuildWebSocketUri`). Nothing consumes them today — both map to a `Metadata` event the client only forwards, and transcripts come from `Results` — so the damage is limited to log noise. But anything built on speech-start or utterance-end would silently never fire.

### Change

Read `channel` through a converter that yields `null` for any non-object token, so a message routes on its `type` instead of dying on a field only `Results` uses. `Results` parsing is untouched.

### Verifying

1. Settings → Streaming: enable, provider **Deepgram**, key entered.
2. Dictate for ~20 s, then check `%LOCALAPPDATA%\HyperWhisper\Logs\hyperwhisper-<date>.log`.
3. No `failed to parse message ... Path: $.channel` lines; transcription behaves exactly as before.

### Tests

New smoke test feeds `ParseMessage` a `SpeechStarted` frame, an `UtteranceEnd` frame, and a `Results` frame, asserting the first two now produce `Metadata` events and the third still yields its transcript. Confirmed it fails on the unpatched DTO and passes with the converter. Full smoke suite green on a local .NET 10 build.

### Notes

Independent of #101 — different lines, applies cleanly on its own — but the warnings only become observable once that deadlock is fixed, since no Deepgram session previously ran long enough to receive these frames.

macOS looks like it has the same bug by inspection: `let channel: Channel?` in `DeepgramMessage` (`DeepgramStreamingStrategy.swift:368`) makes `JSONDecoder` throw the same type mismatch, so its `case "UtteranceEnd", "SpeechStarted"` should be equally unreachable. I can't verify that at runtime from a Windows machine, so I've left macOS alone rather than ship an unverified Swift change — happy to add it if you'd like.
