### PR TITLE
fix(cloud): cap Groq's post-processing output so long dictations survive

### DIFF
--- a/hyperwhisper-cloud/src/lib/llm-token-limits.ts
+++ b/hyperwhisper-cloud/src/lib/llm-token-limits.ts
@@ -1,4 +1,14 @@
 // Anthropic's Messages API requires an explicit output ceiling. Providers with
-// optional limit fields omit them and use their model/API defaults instead.
+// optional limit fields omit them and use their model/API defaults instead —
+// except where a provider's default is too low to fit a cleaned transcript
+// (see GROQ_MAX_COMPLETION_TOKENS).
 export const ANTHROPIC_MAX_TOKENS = 8192;
 
+// Groq is the one provider whose default is not a usable ceiling: when the
+// request omits a cap it applies a low default (its reasoning docs cite 1,024),
+// and openai/gpt-oss-120b spends reasoning tokens from that same budget. Long
+// dictations therefore come back finish_reason=length, which the completion
+// policy rejects — the caller falls back to the raw transcript and the user is
+// still billed for the call. 4,096 rather than 8,192 because Groq's TPM
+// admission check counts prompt + requested cap, not actual usage.
+export const GROQ_MAX_COMPLETION_TOKENS = 4096;

--- a/hyperwhisper-cloud/src/providers/groq-llm.ts
+++ b/hyperwhisper-cloud/src/providers/groq-llm.ts
@@ -1,6 +1,7 @@
 // GROQ LLM CLIENT (CHAT COMPLETIONS)
 
 import { computeGroqChatCost, estimateUsageFromChars, type GroqUsage } from '../lib/cost-calculator';
+import { GROQ_MAX_COMPLETION_TOKENS } from '../lib/llm-token-limits';
 import { isRecord } from '../lib/utils';
 import { requestOpenAICompatibleChat } from './openai-compat-chat';
 
@@ -16,6 +17,22 @@ export type CorrectionRequestPayload = {
   messages: ChatMessage[];
   temperature: number;
 };
+
+/**
+ * Groq is the one hosted provider that needs an explicit output ceiling: its
+ * default cap is too low for a cleaned transcript, and openai/gpt-oss-120b
+ * spends reasoning tokens from the same budget, so omitting it returns
+ * finish_reason=length on long dictations. See GROQ_MAX_COMPLETION_TOKENS.
+ */
+export function buildGroqBody(payload: CorrectionRequestPayload, model: string): Record<string, unknown> {
+  return {
+    model,
+    ...payload,
+    max_completion_tokens: GROQ_MAX_COMPLETION_TOKENS,
+    reasoning_effort: 'low',
+    stream: false,
+  };
+}
 
 export async function requestGroqChat(
   payload: CorrectionRequestPayload,
@@ -33,7 +50,7 @@ export async function requestGroqChat(
       providerTag: 'groq',
       errorLogLabel: 'Groq LLM API',
       errorChatLabel: 'Groq chat',
-      buildBody: (body, model) => ({ model, ...body, reasoning_effort: 'low', stream: false }),
+      buildBody: buildGroqBody,
       computeCost: computeGroqChatCost,
     },
     payload,

--- a/hyperwhisper-cloud/src/providers/llm-request-policy.test.ts
+++ b/hyperwhisper-cloud/src/providers/llm-request-policy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
 
-import { ANTHROPIC_MAX_TOKENS } from '../lib/llm-token-limits';
+import { ANTHROPIC_MAX_TOKENS, GROQ_MAX_COMPLETION_TOKENS } from '../lib/llm-token-limits';
 import { ANTHROPIC_WRAPPER_INSTRUCTION } from './anthropic';
-import { buildCorrectionRequest } from './groq-llm';
+import { buildCorrectionRequest, buildGroqBody } from './groq-llm';
 import { buildOpenAIBody } from './openai-llm';
 
 describe('hosted LLM output-limit policy', () => {
@@ -18,6 +18,21 @@ describe('hosted LLM output-limit policy', () => {
 
     expect(body).not.toHaveProperty('max_tokens');
     expect(body).not.toHaveProperty('max_completion_tokens');
+  });
+
+  // Groq is the documented exception to the omit-optional-caps rule: its
+  // default ceiling is too low for a cleaned transcript once gpt-oss reasoning
+  // tokens are drawn from the same budget.
+  test('sends an explicit completion cap on the Groq request', () => {
+    const body = buildGroqBody(buildCorrectionRequest('system', 'transcript'), 'openai/gpt-oss-120b');
+
+    expect(body.max_completion_tokens).toBe(GROQ_MAX_COMPLETION_TOKENS);
+    expect(body).not.toHaveProperty('max_tokens');
+  });
+
+  test('keeps the Groq cap under the free-tier TPM ceiling', () => {
+    expect(GROQ_MAX_COMPLETION_TOKENS).toBe(4096);
+    expect(GROQ_MAX_COMPLETION_TOKENS).toBeLessThan(8000);
   });
 
   test('keeps Anthropic required max_tokens at 8192', () => {


### PR DESCRIPTION
Companion to #99, which caps Groq's output tokens on Windows and macOS. The cloud backend is the third member of that family and was left uncapped — and `providers/llm-request-policy.test.ts` asserted the omission was correct, so the gap was locked in by a passing test.

## Why Groq is the exception

`lib/llm-token-limits.ts` states the rule: *"Providers with optional limit fields omit them and use their model/API defaults instead."* That holds everywhere except Groq, whose default is not a usable ceiling:

- Groq applies a low default when the request omits a cap — its [reasoning docs](https://console.groq.com/docs/reasoning) cite 1,024, and the API reference documents no default at all.
- `providers/groq-llm.ts` sends `openai/gpt-oss-120b`, a reasoning model, and reasoning tokens spend from that same completion budget.

Long dictations therefore come back `finish_reason: "length"`.

## What that costs today

`evaluateCompletionResponse` classifies it as `output_limit` and correctly falls back to the raw transcript (`routes/post-process.ts`) — the user's dictation is never truncated. But `deductCredits` runs unconditionally afterwards, so **the user is billed for post-processing that returned their transcript unchanged**, with only a `post_process.llm_incomplete` log line to show for it.

Groq is reachable both directly via `X-LLM-Provider: groq` and as the fallback target for `cerebras` and `mistral`.

## Scope

**Groq only.** Cerebras runs the same `gpt-oss-120b` but documents no low default — [max output 32k free / 40k paid](https://inference-docs.cerebras.ai/models/openai-oss) — so capping it would lower a ceiling that is not causing truncation. Every other provider keeps the omit-optional-caps rule; this is now the one documented exception to it, and the policy comment says so.

**4,096, not 8,192**, matching #99: Groq's TPM admission check counts prompt + requested cap rather than actual usage, against a per-model free-tier ceiling of 8,000 for `openai/gpt-oss-120b`.

## Changes

- `lib/llm-token-limits.ts` — add `GROQ_MAX_COMPLETION_TOKENS`, and amend the policy comment so the exception is stated where the rule is.
- `providers/groq-llm.ts` — extract `buildGroqBody` (mirroring `buildOpenAIBody`) so the body is testable without a network call, and send the cap.
- `providers/llm-request-policy.test.ts` — assert Groq now carries the cap and stays under the TPM ceiling, while keeping the existing no-cap assertions for the shared payload and for OpenAI.

## Verification

`bun test` — 211 pass, up from 209, no new failures. The one failing test (`src/middleware/auth.test.ts`, "fails closed on a network error without caching the result") fails identically on `main` and passes in isolation; it is a pre-existing order-dependent mock leak, untouched by this change.

## Residual

A transcript long enough to need more than 4,096 output tokens will still truncate and fall back. The route caps input `text` at 100,000 chars but does not cap the assembled prompt, so that ceiling is reachable in principle — worth a follow-up, but strictly better than the current low default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQq6iNDyapSgbAd5kD4xkg