### PR TITLE
Fix unusable shortcut recorder on macOS 26 (Tahoe)

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -54,7 +54,7 @@ NAudio (MIT), and `silero_vad.onnx` (CC-BY-4.0). No Parakeet weights are bundled
 | swift-atomics | Apache-2.0 | Apple |
 | FlyingFox | MIT | Simon Whitty |
 | AXSwift | MIT | Tyler Mandry et al. |
-| KeyboardShortcuts | MIT | Sindre Sorhus |
+| KeyboardShortcuts (vendored at `app/macos/Vendor/KeyboardShortcuts`, 2.4.0 + macOS 26 recorder fixes) | MIT | Sindre Sorhus |
 | KeySender | MIT | Sindre Sorhus |
 | LaunchAtLogin-Modern | MIT | Sindre Sorhus |
 | SelectedTextKit | MIT | — |

--- a/app/macos/Vendor/KeyboardShortcuts/Package.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:6.1
+import PackageDescription
+
+let package = Package(
+	name: "KeyboardShortcuts",
+	defaultLocalization: "en",
+	platforms: [
+		.macOS(.v10_15)
+	],
+	products: [
+		.library(
+			name: "KeyboardShortcuts",
+			targets: [
+				"KeyboardShortcuts"
+			]
+		)
+	],
+	targets: [
+		.target(
+			name: "KeyboardShortcuts",
+			swiftSettings: [
+				.swiftLanguageMode(.v5)
+			]
+		),
+		.testTarget(
+			name: "KeyboardShortcutsTests",
+			dependencies: [
+				"KeyboardShortcuts"
+			],
+			swiftSettings: [
+				.swiftLanguageMode(.v5)
+			]
+		)
+	]
+)

--- a/app/macos/Vendor/KeyboardShortcuts/README-VENDORED.md
+++ b/app/macos/Vendor/KeyboardShortcuts/README-VENDORED.md
@@ -1,0 +1,49 @@
+# Vendored: sindresorhus/KeyboardShortcuts
+
+This is a vendored copy of
+[sindresorhus/KeyboardShortcuts](https://github.com/sindresorhus/KeyboardShortcuts)
+at tag `2.4.0`, with three small fixes applied on top. License: MIT (see `license`).
+
+## Why it is vendored
+
+On macOS 26 (Tahoe) and later, the shortcut recorder in every released version of the
+package (verified on 0.7.1 through 3.0.1) is unusable:
+
+- Clicking **Record Shortcut** focuses the field, but key presses type characters
+  into the search field instead of recording a shortcut.
+- The clear (x) button highlights but never fires.
+- The user gets no error or message of any kind.
+
+The root causes are three independent defects in the package, diagnosed in
+[upstream issue #241](https://github.com/sindresorhus/KeyboardShortcuts/issues/241).
+Upstream has not shipped a fix yet. This vendored copy carries the three fixes,
+backported from the issue author's fork onto the `2.4.0` code the app already used
+(so there is no 2.x → 3.x API jump):
+
+| # | Defect | Fix location |
+|---|--------|--------------|
+| 1 | `LocalEventMonitor` held its `NSEvent.addLocalMonitorForEvents` token **weakly**, so the monitor deallocated when the autorelease pool drained — before the user could press anything. | `Sources/KeyboardShortcuts/Utilities.swift` |
+| 2 | `becomeFirstResponder` mutates `cancelButtonCell` while the field editor is installed, which makes AppKit end/restart editing; the resulting `controlTextDidEndEditing` tore down the key monitor right after it was armed. | `Sources/KeyboardShortcuts/RecorderCocoa.swift` |
+| 3 | The recorder's event monitor swallowed `mouseUp` inside the field, so the clear button could be pressed but never fired. | `Sources/KeyboardShortcuts/RecorderCocoa.swift` |
+
+Original fix commits (written against 3.0.1, backported here to 2.4.0):
+[c3f86c6](https://github.com/ppardi/KeyboardShortcuts/commit/c3f86c6),
+[3f517c0](https://github.com/ppardi/KeyboardShortcuts/commit/3f517c0),
+[d4bd30d](https://github.com/ppardi/KeyboardShortcuts/commit/d4bd30d).
+
+One extra hardening change not in the upstream fork: `LocalEventMonitor.stop()` now
+nils its token after `removeMonitor`, so the `deinit → stop()` path cannot remove the
+same token twice once the reference is strong.
+
+## How to remove this vendored copy
+
+When upstream ships a release that fixes issue #241:
+
+1. Delete `app/macos/Vendor/KeyboardShortcuts/`.
+2. In `hyperwhisper.xcodeproj`, replace the local package reference
+   `Vendor/KeyboardShortcuts` with the upstream URL
+   `https://github.com/sindresorhus/KeyboardShortcuts` at the fixed version.
+
+Every patched line is marked with a comment linking to upstream issue #241, so the
+delta against stock `2.4.0` is easy to audit: `git diff` this directory against the
+`2.4.0` tag of the upstream repository.

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/CarbonKeyboardShortcuts.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/CarbonKeyboardShortcuts.swift
@@ -1,0 +1,351 @@
+#if os(macOS)
+import Carbon.HIToolbox
+
+private func carbonKeyboardShortcutsEventHandler(eventHandlerCall: EventHandlerCallRef?, event: EventRef?, userData: UnsafeMutableRawPointer?) -> OSStatus {
+	CarbonKeyboardShortcuts.handleEvent(event)
+}
+
+enum CarbonKeyboardShortcuts {
+	private final class HotKey {
+		let shortcut: KeyboardShortcuts.Shortcut
+		let carbonHotKeyId: Int
+		var carbonHotKey: EventHotKeyRef?
+		let onKeyDown: (KeyboardShortcuts.Shortcut) -> Void
+		let onKeyUp: (KeyboardShortcuts.Shortcut) -> Void
+
+		init(
+			shortcut: KeyboardShortcuts.Shortcut,
+			carbonHotKeyID: Int,
+			carbonHotKey: EventHotKeyRef,
+			onKeyDown: @escaping (KeyboardShortcuts.Shortcut) -> Void,
+			onKeyUp: @escaping (KeyboardShortcuts.Shortcut) -> Void
+		) {
+			self.shortcut = shortcut
+			self.carbonHotKeyId = carbonHotKeyID
+			self.carbonHotKey = carbonHotKey
+			self.onKeyDown = onKeyDown
+			self.onKeyUp = onKeyUp
+		}
+	}
+
+	private static var hotKeys = [Int: HotKey]()
+
+	// `SSKS` is just short for `Sindre Sorhus Keyboard Shortcuts`.
+	// Using an integer now that `UTGetOSTypeFromString("SSKS" as CFString)` is deprecated.
+	// swiftlint:disable:next number_separator
+	private static let hotKeySignature: UInt32 = 1397967699 // OSType => "SSKS"
+
+	private static var hotKeyId = 0
+	private static var eventHandler: EventHandlerRef?
+
+	private static let hotKeyEventTypes = [
+		EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed)),
+		EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyReleased))
+	]
+	private static let rawKeyEventTypes = [
+		EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventRawKeyDown)),
+		EventTypeSpec(eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventRawKeyUp))
+	]
+
+	private static let keyEventMonitor = RunLoopLocalEventMonitor(events: [.keyDown, .keyUp], runLoopMode: .eventTracking) { event in
+		guard
+			let eventRef = OpaquePointer(event.eventRef),
+			handleRawKeyEvent(eventRef) == noErr
+		else {
+			return event
+		}
+
+		return nil
+	}
+
+	private static func setUpEventHandlerIfNeeded() {
+		guard
+			eventHandler == nil,
+			let dispatcher = GetEventDispatcherTarget()
+		else {
+			return
+		}
+
+		var handler: EventHandlerRef?
+		let error = InstallEventHandler(
+			dispatcher,
+			carbonKeyboardShortcutsEventHandler,
+			0,
+			nil,
+			nil,
+			&handler
+		)
+
+		guard
+			error == noErr,
+			let handler
+		else {
+			return
+		}
+
+		eventHandler = handler
+
+		updateEventHandler()
+	}
+
+	static func updateEventHandler() {
+		guard eventHandler != nil else {
+			return
+		}
+
+		if KeyboardShortcuts.isEnabled {
+			if KeyboardShortcuts.isMenuOpen {
+				softUnregisterAll()
+				RemoveEventTypesFromHandler(eventHandler, hotKeyEventTypes.count, hotKeyEventTypes)
+
+				if #available(macOS 14, *) {
+					keyEventMonitor.start()
+				} else {
+					AddEventTypesToHandler(eventHandler, rawKeyEventTypes.count, rawKeyEventTypes)
+				}
+			} else {
+				softRegisterAll()
+
+				if #available(macOS 14, *) {
+					keyEventMonitor.stop()
+				} else {
+					RemoveEventTypesFromHandler(eventHandler, rawKeyEventTypes.count, rawKeyEventTypes)
+				}
+
+				AddEventTypesToHandler(eventHandler, hotKeyEventTypes.count, hotKeyEventTypes)
+			}
+		} else {
+			softUnregisterAll()
+			RemoveEventTypesFromHandler(eventHandler, hotKeyEventTypes.count, hotKeyEventTypes)
+
+			if #available(macOS 14, *) {
+				keyEventMonitor.stop()
+			} else {
+				RemoveEventTypesFromHandler(eventHandler, rawKeyEventTypes.count, rawKeyEventTypes)
+			}
+		}
+	}
+
+	static func register(
+		_ shortcut: KeyboardShortcuts.Shortcut,
+		onKeyDown: @escaping (KeyboardShortcuts.Shortcut) -> Void,
+		onKeyUp: @escaping (KeyboardShortcuts.Shortcut) -> Void
+	) {
+		hotKeyId += 1
+
+		var eventHotKey: EventHotKeyRef?
+		let registerError = RegisterEventHotKey(
+			UInt32(shortcut.carbonKeyCode),
+			UInt32(shortcut.carbonModifiers),
+			EventHotKeyID(signature: hotKeySignature, id: UInt32(hotKeyId)),
+			GetEventDispatcherTarget(),
+			0,
+			&eventHotKey
+		)
+
+		guard
+			registerError == noErr,
+			let carbonHotKey = eventHotKey
+		else {
+			print("Error registering hotkey \(shortcut):", registerError)
+			return
+		}
+
+		hotKeys[hotKeyId] = HotKey(
+			shortcut: shortcut,
+			carbonHotKeyID: hotKeyId,
+			carbonHotKey: carbonHotKey,
+			onKeyDown: onKeyDown,
+			onKeyUp: onKeyUp
+		)
+
+		setUpEventHandlerIfNeeded()
+	}
+
+	private static func softRegisterAll() {
+		for hotKey in hotKeys.values {
+			guard hotKey.carbonHotKey == nil else {
+				continue
+			}
+
+			var eventHotKey: EventHotKeyRef?
+			let error = RegisterEventHotKey(
+				UInt32(hotKey.shortcut.carbonKeyCode),
+				UInt32(hotKey.shortcut.carbonModifiers),
+				EventHotKeyID(signature: hotKeySignature, id: UInt32(hotKey.carbonHotKeyId)),
+				GetEventDispatcherTarget(),
+				0,
+				&eventHotKey
+			)
+
+			guard
+				error == noErr,
+				let eventHotKey
+			else {
+				print("Error registering hotkey \(hotKey.shortcut):", error)
+				hotKeys.removeValue(forKey: hotKey.carbonHotKeyId)
+				continue
+			}
+
+			hotKey.carbonHotKey = eventHotKey
+		}
+	}
+
+	private static func unregisterHotKey(_ hotKey: HotKey) {
+		UnregisterEventHotKey(hotKey.carbonHotKey)
+		hotKeys.removeValue(forKey: hotKey.carbonHotKeyId)
+	}
+
+	static func unregister(_ shortcut: KeyboardShortcuts.Shortcut) {
+		for hotKey in hotKeys.values where hotKey.shortcut == shortcut {
+			unregisterHotKey(hotKey)
+		}
+	}
+
+	static func unregisterAll() {
+		for hotKey in hotKeys.values {
+			unregisterHotKey(hotKey)
+		}
+	}
+
+	private static func softUnregisterAll() {
+		for hotKey in hotKeys.values {
+			UnregisterEventHotKey(hotKey.carbonHotKey)
+			hotKey.carbonHotKey = nil
+		}
+	}
+
+	fileprivate static func handleEvent(_ event: EventRef?) -> OSStatus {
+		guard let event else {
+			return OSStatus(eventNotHandledErr)
+		}
+
+		switch Int(GetEventKind(event)) {
+		case kEventHotKeyPressed, kEventHotKeyReleased:
+			return handleHotKeyEvent(event)
+		case kEventRawKeyDown, kEventRawKeyUp:
+			return handleRawKeyEvent(event)
+		default:
+			break
+		}
+
+		return OSStatus(eventNotHandledErr)
+	}
+
+	private static func handleHotKeyEvent(_ event: EventRef) -> OSStatus {
+		var eventHotKeyId = EventHotKeyID()
+		let error = GetEventParameter(
+			event,
+			UInt32(kEventParamDirectObject),
+			UInt32(typeEventHotKeyID),
+			nil,
+			MemoryLayout<EventHotKeyID>.size,
+			nil,
+			&eventHotKeyId
+		)
+
+		guard error == noErr else {
+			return error
+		}
+
+		guard
+			eventHotKeyId.signature == hotKeySignature,
+			let hotKey = hotKeys[Int(eventHotKeyId.id)]
+		else {
+			return OSStatus(eventNotHandledErr)
+		}
+
+		switch Int(GetEventKind(event)) {
+		case kEventHotKeyPressed:
+			hotKey.onKeyDown(hotKey.shortcut)
+			return noErr
+		case kEventHotKeyReleased:
+			hotKey.onKeyUp(hotKey.shortcut)
+			return noErr
+		default:
+			break
+		}
+
+		return OSStatus(eventNotHandledErr)
+	}
+
+	private static func handleRawKeyEvent(_ event: EventRef) -> OSStatus {
+		var eventKeyCode = UInt32()
+		let keyCodeError = GetEventParameter(
+			event,
+			UInt32(kEventParamKeyCode),
+			typeUInt32,
+			nil,
+			MemoryLayout<UInt32>.size,
+			nil,
+			&eventKeyCode
+		)
+
+		guard keyCodeError == noErr else {
+			return keyCodeError
+		}
+
+		var eventKeyModifiers = UInt32()
+		let keyModifiersError = GetEventParameter(
+			event,
+			UInt32(kEventParamKeyModifiers),
+			typeUInt32,
+			nil,
+			MemoryLayout<UInt32>.size,
+			nil,
+			&eventKeyModifiers
+		)
+
+		guard keyModifiersError == noErr else {
+			return keyModifiersError
+		}
+
+		let shortcut = KeyboardShortcuts.Shortcut(carbonKeyCode: Int(eventKeyCode), carbonModifiers: Int(eventKeyModifiers))
+
+		guard let hotKey = (hotKeys.values.first { $0.shortcut == shortcut }) else {
+			return OSStatus(eventNotHandledErr)
+		}
+
+		switch Int(GetEventKind(event)) {
+		case kEventRawKeyDown:
+			hotKey.onKeyDown(hotKey.shortcut)
+			return noErr
+		case kEventRawKeyUp:
+			hotKey.onKeyUp(hotKey.shortcut)
+			return noErr
+		default:
+			break
+		}
+
+		return OSStatus(eventNotHandledErr)
+	}
+}
+
+extension CarbonKeyboardShortcuts {
+	static var system: [KeyboardShortcuts.Shortcut] {
+		var shortcutsUnmanaged: Unmanaged<CFArray>?
+		guard
+			CopySymbolicHotKeys(&shortcutsUnmanaged) == noErr,
+			let shortcuts = shortcutsUnmanaged?.takeRetainedValue() as? [[String: Any]]
+		else {
+			assertionFailure("Could not get system keyboard shortcuts")
+			return []
+		}
+
+		return shortcuts.compactMap {
+			guard
+				($0[kHISymbolicHotKeyEnabled] as? Bool) == true,
+				let carbonKeyCode = $0[kHISymbolicHotKeyCode] as? Int,
+				let carbonModifiers = $0[kHISymbolicHotKeyModifiers] as? Int
+			else {
+				return nil
+			}
+
+			return KeyboardShortcuts.Shortcut(
+				carbonKeyCode: carbonKeyCode,
+				carbonModifiers: carbonModifiers
+			)
+		}
+	}
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Key.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Key.swift
@@ -1,0 +1,196 @@
+#if os(macOS)
+import Carbon.HIToolbox
+
+extension KeyboardShortcuts {
+	// swiftlint:disable identifier_name
+	/**
+	Represents a key on the keyboard.
+	*/
+	public struct Key: Hashable, RawRepresentable, Sendable {
+		// MARK: Letters
+
+		public static let a = Self(kVK_ANSI_A)
+		public static let b = Self(kVK_ANSI_B)
+		public static let c = Self(kVK_ANSI_C)
+		public static let d = Self(kVK_ANSI_D)
+		public static let e = Self(kVK_ANSI_E)
+		public static let f = Self(kVK_ANSI_F)
+		public static let g = Self(kVK_ANSI_G)
+		public static let h = Self(kVK_ANSI_H)
+		public static let i = Self(kVK_ANSI_I)
+		public static let j = Self(kVK_ANSI_J)
+		public static let k = Self(kVK_ANSI_K)
+		public static let l = Self(kVK_ANSI_L)
+		public static let m = Self(kVK_ANSI_M)
+		public static let n = Self(kVK_ANSI_N)
+		public static let o = Self(kVK_ANSI_O)
+		public static let p = Self(kVK_ANSI_P)
+		public static let q = Self(kVK_ANSI_Q)
+		public static let r = Self(kVK_ANSI_R)
+		public static let s = Self(kVK_ANSI_S)
+		public static let t = Self(kVK_ANSI_T)
+		public static let u = Self(kVK_ANSI_U)
+		public static let v = Self(kVK_ANSI_V)
+		public static let w = Self(kVK_ANSI_W)
+		public static let x = Self(kVK_ANSI_X)
+		public static let y = Self(kVK_ANSI_Y)
+		public static let z = Self(kVK_ANSI_Z)
+		// swiftlint:enable identifier_name
+
+		// MARK: Numbers
+
+		public static let zero = Self(kVK_ANSI_0)
+		public static let one = Self(kVK_ANSI_1)
+		public static let two = Self(kVK_ANSI_2)
+		public static let three = Self(kVK_ANSI_3)
+		public static let four = Self(kVK_ANSI_4)
+		public static let five = Self(kVK_ANSI_5)
+		public static let six = Self(kVK_ANSI_6)
+		public static let seven = Self(kVK_ANSI_7)
+		public static let eight = Self(kVK_ANSI_8)
+		public static let nine = Self(kVK_ANSI_9)
+
+		// MARK: Modifiers
+
+		public static let capsLock = Self(kVK_CapsLock)
+		public static let shift = Self(kVK_Shift)
+		public static let function = Self(kVK_Function)
+		public static let control = Self(kVK_Control)
+		public static let option = Self(kVK_Option)
+		public static let command = Self(kVK_Command)
+		public static let rightCommand = Self(kVK_RightCommand)
+		public static let rightOption = Self(kVK_RightOption)
+		public static let rightControl = Self(kVK_RightControl)
+		public static let rightShift = Self(kVK_RightShift)
+
+		// MARK: Miscellaneous
+
+		public static let `return` = Self(kVK_Return)
+		public static let backslash = Self(kVK_ANSI_Backslash)
+		public static let backtick = Self(kVK_ANSI_Grave)
+		public static let comma = Self(kVK_ANSI_Comma)
+		public static let equal = Self(kVK_ANSI_Equal)
+		public static let minus = Self(kVK_ANSI_Minus)
+		public static let period = Self(kVK_ANSI_Period)
+		public static let quote = Self(kVK_ANSI_Quote)
+		public static let semicolon = Self(kVK_ANSI_Semicolon)
+		public static let slash = Self(kVK_ANSI_Slash)
+		public static let space = Self(kVK_Space)
+		public static let tab = Self(kVK_Tab)
+		public static let leftBracket = Self(kVK_ANSI_LeftBracket)
+		public static let rightBracket = Self(kVK_ANSI_RightBracket)
+		public static let pageUp = Self(kVK_PageUp)
+		public static let pageDown = Self(kVK_PageDown)
+		public static let home = Self(kVK_Home)
+		public static let end = Self(kVK_End)
+		public static let upArrow = Self(kVK_UpArrow)
+		public static let rightArrow = Self(kVK_RightArrow)
+		public static let downArrow = Self(kVK_DownArrow)
+		public static let leftArrow = Self(kVK_LeftArrow)
+		public static let escape = Self(kVK_Escape)
+		public static let delete = Self(kVK_Delete)
+		public static let deleteForward = Self(kVK_ForwardDelete)
+		public static let help = Self(kVK_Help)
+		public static let mute = Self(kVK_Mute)
+		public static let volumeUp = Self(kVK_VolumeUp)
+		public static let volumeDown = Self(kVK_VolumeDown)
+
+		// MARK: Function
+
+		public static let f1 = Self(kVK_F1)
+		public static let f2 = Self(kVK_F2)
+		public static let f3 = Self(kVK_F3)
+		public static let f4 = Self(kVK_F4)
+		public static let f5 = Self(kVK_F5)
+		public static let f6 = Self(kVK_F6)
+		public static let f7 = Self(kVK_F7)
+		public static let f8 = Self(kVK_F8)
+		public static let f9 = Self(kVK_F9)
+		public static let f10 = Self(kVK_F10)
+		public static let f11 = Self(kVK_F11)
+		public static let f12 = Self(kVK_F12)
+		public static let f13 = Self(kVK_F13)
+		public static let f14 = Self(kVK_F14)
+		public static let f15 = Self(kVK_F15)
+		public static let f16 = Self(kVK_F16)
+		public static let f17 = Self(kVK_F17)
+		public static let f18 = Self(kVK_F18)
+		public static let f19 = Self(kVK_F19)
+		public static let f20 = Self(kVK_F20)
+
+		// MARK: Keypad
+
+		public static let keypad0 = Self(kVK_ANSI_Keypad0)
+		public static let keypad1 = Self(kVK_ANSI_Keypad1)
+		public static let keypad2 = Self(kVK_ANSI_Keypad2)
+		public static let keypad3 = Self(kVK_ANSI_Keypad3)
+		public static let keypad4 = Self(kVK_ANSI_Keypad4)
+		public static let keypad5 = Self(kVK_ANSI_Keypad5)
+		public static let keypad6 = Self(kVK_ANSI_Keypad6)
+		public static let keypad7 = Self(kVK_ANSI_Keypad7)
+		public static let keypad8 = Self(kVK_ANSI_Keypad8)
+		public static let keypad9 = Self(kVK_ANSI_Keypad9)
+		public static let keypadClear = Self(kVK_ANSI_KeypadClear)
+		public static let keypadDecimal = Self(kVK_ANSI_KeypadDecimal)
+		public static let keypadDivide = Self(kVK_ANSI_KeypadDivide)
+		public static let keypadEnter = Self(kVK_ANSI_KeypadEnter)
+		public static let keypadEquals = Self(kVK_ANSI_KeypadEquals)
+		public static let keypadMinus = Self(kVK_ANSI_KeypadMinus)
+		public static let keypadMultiply = Self(kVK_ANSI_KeypadMultiply)
+		public static let keypadPlus = Self(kVK_ANSI_KeypadPlus)
+
+		// MARK: Properties
+
+		/**
+		The raw key code.
+		*/
+		public let rawValue: Int
+
+		// MARK: Initializers
+
+		/**
+		Create a `Key` from a key code.
+		*/
+		public init(rawValue: Int) {
+			self.rawValue = rawValue
+		}
+
+		private init(_ value: Int) {
+			self.init(rawValue: value)
+		}
+	}
+}
+
+extension KeyboardShortcuts.Key {
+	/**
+	All the function keys.
+	*/
+	static let functionKeys: Set<Self> = [
+		.f1,
+		.f2,
+		.f3,
+		.f4,
+		.f5,
+		.f6,
+		.f7,
+		.f8,
+		.f9,
+		.f10,
+		.f11,
+		.f12,
+		.f13,
+		.f14,
+		.f15,
+		.f16,
+		.f17,
+		.f18,
+		.f19,
+		.f20
+	]
+
+	/**
+	Returns true if the key is a function key. For example, `F1`.
+	*/
+	var isFunctionKey: Bool { Self.functionKeys.contains(self) }
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/KeyboardShortcuts.swift
@@ -1,0 +1,638 @@
+#if os(macOS)
+import AppKit.NSMenu
+
+/**
+Global keyboard shortcuts for your macOS app.
+*/
+public enum KeyboardShortcuts {
+	private static var registeredShortcuts = Set<Shortcut>()
+
+	private static var legacyKeyDownHandlers = [Name: [() -> Void]]()
+	private static var legacyKeyUpHandlers = [Name: [() -> Void]]()
+
+	private static var streamKeyDownHandlers = [Name: [UUID: () -> Void]]()
+	private static var streamKeyUpHandlers = [Name: [UUID: () -> Void]]()
+
+	private static var shortcutsForLegacyHandlers: Set<Shortcut> {
+		let shortcuts = [legacyKeyDownHandlers.keys, legacyKeyUpHandlers.keys]
+			.flatMap { $0 }
+			.compactMap(\.shortcut)
+
+		return Set(shortcuts)
+	}
+
+	private static var shortcutsForStreamHandlers: Set<Shortcut> {
+		let shortcuts = [streamKeyDownHandlers.keys, streamKeyUpHandlers.keys]
+			.flatMap { $0 }
+			.compactMap(\.shortcut)
+
+		return Set(shortcuts)
+	}
+
+	private static var shortcutsForHandlers: Set<Shortcut> {
+		shortcutsForLegacyHandlers.union(shortcutsForStreamHandlers)
+	}
+
+	private static var isInitialized = false
+
+	private static var openMenuObserver: NSObjectProtocol?
+	private static var closeMenuObserver: NSObjectProtocol?
+
+	/**
+	When `true`, event handlers will not be called for registered keyboard shortcuts.
+	*/
+	static var isPaused = false
+
+	/**
+	Enable/disable monitoring of all keyboard shortcuts.
+
+	The default is `true`.
+	*/
+	public static var isEnabled = true {
+		didSet {
+			guard isEnabled != oldValue else {
+				return
+			}
+
+			CarbonKeyboardShortcuts.updateEventHandler()
+		}
+	}
+
+	static var allNames: Set<Name> {
+		UserDefaults.standard.dictionaryRepresentation()
+			.compactMap { key, _ in
+				guard key.hasPrefix(userDefaultsPrefix) else {
+					return nil
+				}
+
+				let name = key.replacingPrefix(userDefaultsPrefix, with: "")
+				return .init(name)
+			}
+			.toSet()
+	}
+
+	/**
+	Enable keyboard shortcuts to work even when an `NSMenu` is open by setting this property when the menu opens and closes.
+
+	`NSMenu` runs in a tracking run mode that blocks keyboard shortcuts events. When you set this property to `true`, it switches to a different kind of event handler, which does work when the menu is open.
+
+	The main use-case for this is toggling the menu of a menu bar app with a keyboard shortcut.
+	*/
+	private(set) static var isMenuOpen = false {
+		didSet {
+			guard isMenuOpen != oldValue else {
+				return
+			}
+
+			CarbonKeyboardShortcuts.updateEventHandler()
+		}
+	}
+
+	private static func register(_ shortcut: Shortcut) {
+		guard !registeredShortcuts.contains(shortcut) else {
+			return
+		}
+
+		CarbonKeyboardShortcuts.register(
+			shortcut,
+			onKeyDown: handleOnKeyDown,
+			onKeyUp: handleOnKeyUp
+		)
+
+		registeredShortcuts.insert(shortcut)
+	}
+
+	/**
+	Register the shortcut for the given name if it has a shortcut.
+	*/
+	private static func registerShortcutIfNeeded(for name: Name) {
+		guard let shortcut = getShortcut(for: name) else {
+			return
+		}
+
+		register(shortcut)
+	}
+
+	private static func unregister(_ shortcut: Shortcut) {
+		CarbonKeyboardShortcuts.unregister(shortcut)
+		registeredShortcuts.remove(shortcut)
+	}
+
+	/**
+	Unregister the given shortcut if it has no handlers.
+	*/
+	private static func unregisterIfNeeded(_ shortcut: Shortcut) {
+		guard !shortcutsForHandlers.contains(shortcut) else {
+			return
+		}
+
+		unregister(shortcut)
+	}
+
+	/**
+	Unregister the shortcut for the given name if it has no handlers.
+	*/
+	private static func unregisterShortcutIfNeeded(for name: Name) {
+		guard let shortcut = name.shortcut else {
+			return
+		}
+
+		unregisterIfNeeded(shortcut)
+	}
+
+	private static func unregisterAll() {
+		CarbonKeyboardShortcuts.unregisterAll()
+		registeredShortcuts.removeAll()
+
+		// TODO: Should remove user defaults too.
+	}
+
+	static func initialize() {
+		guard !isInitialized else {
+			return
+		}
+
+		openMenuObserver = NotificationCenter.default.addObserver(forName: NSMenu.didBeginTrackingNotification, object: nil, queue: nil) { _ in
+			isMenuOpen = true
+		}
+
+		closeMenuObserver = NotificationCenter.default.addObserver(forName: NSMenu.didEndTrackingNotification, object: nil, queue: nil) { _ in
+			isMenuOpen = false
+		}
+
+		isInitialized = true
+	}
+
+	/**
+	Remove all handlers receiving keyboard shortcuts events.
+
+	This can be used to reset the handlers before re-creating them to avoid having multiple handlers for the same shortcut.
+
+	- Note: This method does not affect listeners using ``events(for:)``.
+	*/
+	public static func removeAllHandlers() {
+		let shortcutsToUnregister = shortcutsForLegacyHandlers.subtracting(shortcutsForStreamHandlers)
+
+		for shortcut in shortcutsToUnregister {
+			unregister(shortcut)
+		}
+
+		legacyKeyDownHandlers = [:]
+		legacyKeyUpHandlers = [:]
+	}
+
+	/**
+	Remove the keyboard shortcut handler for the given name.
+
+	This can be used to reset the handler before re-creating it to avoid having multiple handlers for the same shortcut.
+
+	- Parameter name: The name of the keyboard shortcut to remove handlers for.
+
+	- Note: This method does not affect listeners using ``events(for:)``.
+	*/
+	public static func removeHandler(for name: Name) {
+		legacyKeyDownHandlers[name] = nil
+		legacyKeyUpHandlers[name] = nil
+
+		// Make sure not to unregister stream handlers.
+		guard
+			let shortcut = getShortcut(for: name),
+			!shortcutsForStreamHandlers.contains(shortcut)
+		else {
+			return
+		}
+
+		unregister(shortcut)
+	}
+
+	/**
+	Returns whether the keyboard shortcut for the given name is enabled.
+
+	This checks if the shortcut is registered and will trigger handlers. It respects the global ``isEnabled``.
+
+	```swift
+	let isEnabled = KeyboardShortcuts.isEnabled(for: .toggleUnicornMode)
+	```
+
+	- Tip: Use ``disable(_:)-(Name...)`` and ``enable(_:)-(Name...)`` to change the status.
+	*/
+	public static func isEnabled(for name: Name) -> Bool {
+		guard
+			isEnabled,
+			let shortcut = getShortcut(for: name)
+		else {
+			return false
+		}
+
+		return registeredShortcuts.contains(shortcut)
+	}
+
+	/**
+	Disable the keyboard shortcut for one or more names.
+	*/
+	public static func disable(_ names: [Name]) {
+		for name in names {
+			guard let shortcut = getShortcut(for: name) else {
+				continue
+			}
+
+			unregister(shortcut)
+		}
+	}
+
+	/**
+	Disable the keyboard shortcut for one or more names.
+	*/
+	public static func disable(_ names: Name...) {
+		disable(names)
+	}
+
+	/**
+	Enable the keyboard shortcut for one or more names.
+	*/
+	public static func enable(_ names: [Name]) {
+		for name in names {
+			guard let shortcut = getShortcut(for: name) else {
+				continue
+			}
+
+			register(shortcut)
+		}
+	}
+
+	/**
+	Enable the keyboard shortcut for one or more names.
+	*/
+	public static func enable(_ names: Name...) {
+		enable(names)
+	}
+
+	/**
+	Reset the keyboard shortcut for one or more names.
+
+	If the `Name` has a default shortcut, it will reset to that.
+
+	- Note: This overload exists as Swift doesn't support splatting.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct SettingsScreen: View {
+		var body: some View {
+			VStack {
+				// …
+				Button("Reset") {
+					KeyboardShortcuts.reset(.toggleUnicornMode)
+				}
+			}
+		}
+	}
+	```
+	*/
+	public static func reset(_ names: [Name]) {
+		for name in names {
+			setShortcut(name.defaultShortcut, for: name)
+		}
+	}
+
+	/**
+	Reset the keyboard shortcut for one or more names.
+
+	If the `Name` has a default shortcut, it will reset to that.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct SettingsScreen: View {
+		var body: some View {
+			VStack {
+				// …
+				Button("Reset") {
+					KeyboardShortcuts.reset(.toggleUnicornMode)
+				}
+			}
+		}
+	}
+	```
+	*/
+	public static func reset(_ names: Name...) {
+		reset(names)
+	}
+
+	/**
+	Reset the keyboard shortcut for all the names.
+
+	Unlike `reset(…)`, this resets all the shortcuts to `nil`, not the `defaultValue`.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct SettingsScreen: View {
+		var body: some View {
+			VStack {
+				// …
+				Button("Reset All") {
+					KeyboardShortcuts.resetAll()
+				}
+			}
+		}
+	}
+	```
+	*/
+	public static func resetAll() {
+		reset(allNames.toArray())
+	}
+
+	/**
+	Set the keyboard shortcut for a name.
+
+	Setting it to `nil` removes the shortcut, even if the `Name` has a default shortcut defined. Use `.reset()` if you want it to respect the default shortcut.
+
+	You would usually not need this as the user would be the one setting the shortcut in a settings user-interface, but it can be useful when, for example, migrating from a different keyboard shortcuts package.
+	*/
+	public static func setShortcut(_ shortcut: Shortcut?, for name: Name) {
+		if let shortcut {
+			userDefaultsSet(name: name, shortcut: shortcut)
+		} else {
+			if name.defaultShortcut != nil {
+				userDefaultsDisable(name: name)
+			} else {
+				userDefaultsRemove(name: name)
+			}
+		}
+	}
+
+	/**
+	Get the keyboard shortcut for a name.
+	*/
+	public static func getShortcut(for name: Name) -> Shortcut? {
+		guard
+			let data = UserDefaults.standard.string(forKey: userDefaultsKey(for: name))?.data(using: .utf8),
+			let decoded = try? JSONDecoder().decode(Shortcut.self, from: data)
+		else {
+			return nil
+		}
+
+		return decoded
+	}
+
+	private static func handleOnKeyDown(_ shortcut: Shortcut) {
+		guard !isPaused else {
+			return
+		}
+
+		for (name, handlers) in legacyKeyDownHandlers {
+			guard getShortcut(for: name) == shortcut else {
+				continue
+			}
+
+			for handler in handlers {
+				handler()
+			}
+		}
+
+		for (name, handlers) in streamKeyDownHandlers {
+			guard getShortcut(for: name) == shortcut else {
+				continue
+			}
+
+			for handler in handlers.values {
+				handler()
+			}
+		}
+	}
+
+	private static func handleOnKeyUp(_ shortcut: Shortcut) {
+		guard !isPaused else {
+			return
+		}
+
+		for (name, handlers) in legacyKeyUpHandlers {
+			guard getShortcut(for: name) == shortcut else {
+				continue
+			}
+
+			for handler in handlers {
+				handler()
+			}
+		}
+
+		for (name, handlers) in streamKeyUpHandlers {
+			guard getShortcut(for: name) == shortcut else {
+				continue
+			}
+
+			for handler in handlers.values {
+				handler()
+			}
+		}
+	}
+
+	/**
+	Listen to the keyboard shortcut with the given name being pressed.
+
+	You can register multiple listeners.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	- Important: This will be deprecated in the future. Prefer ``events(for:)`` for new code.
+
+	```swift
+	import AppKit
+	import KeyboardShortcuts
+
+	@main
+	final class AppDelegate: NSObject, NSApplicationDelegate {
+		func applicationDidFinishLaunching(_ notification: Notification) {
+			KeyboardShortcuts.onKeyDown(for: .toggleUnicornMode) { [self] in
+				isUnicornMode.toggle()
+			}
+		}
+	}
+	```
+	*/
+	public static func onKeyDown(for name: Name, action: @escaping () -> Void) {
+		legacyKeyDownHandlers[name, default: []].append(action)
+		registerShortcutIfNeeded(for: name)
+	}
+
+	/**
+	Listen to the keyboard shortcut with the given name being pressed.
+
+	You can register multiple listeners.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	- Important: This will be deprecated in the future. Prefer ``events(for:)`` for new code.
+
+	```swift
+	import AppKit
+	import KeyboardShortcuts
+
+	@main
+	final class AppDelegate: NSObject, NSApplicationDelegate {
+		func applicationDidFinishLaunching(_ notification: Notification) {
+			KeyboardShortcuts.onKeyUp(for: .toggleUnicornMode) { [self] in
+				isUnicornMode.toggle()
+			}
+		}
+	}
+	```
+	*/
+	public static func onKeyUp(for name: Name, action: @escaping () -> Void) {
+		legacyKeyUpHandlers[name, default: []].append(action)
+		registerShortcutIfNeeded(for: name)
+	}
+
+	private static let userDefaultsPrefix = "KeyboardShortcuts_"
+
+	private static func userDefaultsKey(for shortcutName: Name) -> String { "\(userDefaultsPrefix)\(shortcutName.rawValue)"
+	}
+
+	static func userDefaultsDidChange(name: Name) {
+		// TODO: Use proper UserDefaults observation instead of this.
+		NotificationCenter.default.post(name: .shortcutByNameDidChange, object: nil, userInfo: ["name": name])
+	}
+
+	static func userDefaultsSet(name: Name, shortcut: Shortcut) {
+		guard let encoded = try? JSONEncoder().encode(shortcut).toString else {
+			return
+		}
+
+		if let oldShortcut = getShortcut(for: name) {
+			unregister(oldShortcut)
+		}
+
+		register(shortcut)
+		UserDefaults.standard.set(encoded, forKey: userDefaultsKey(for: name))
+		userDefaultsDidChange(name: name)
+	}
+
+	static func userDefaultsDisable(name: Name) {
+		guard let shortcut = getShortcut(for: name) else {
+			return
+		}
+
+		UserDefaults.standard.set(false, forKey: userDefaultsKey(for: name))
+		unregister(shortcut)
+		userDefaultsDidChange(name: name)
+	}
+
+	static func userDefaultsRemove(name: Name) {
+		guard let shortcut = getShortcut(for: name) else {
+			return
+		}
+
+		UserDefaults.standard.removeObject(forKey: userDefaultsKey(for: name))
+		unregister(shortcut)
+		userDefaultsDidChange(name: name)
+	}
+
+	static func userDefaultsContains(name: Name) -> Bool {
+		UserDefaults.standard.object(forKey: userDefaultsKey(for: name)) != nil
+	}
+}
+
+extension KeyboardShortcuts {
+	public enum EventType: Sendable {
+		case keyDown
+		case keyUp
+	}
+
+	/**
+	Listen to the keyboard shortcut with the given name being pressed.
+
+	You can register multiple listeners.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	Ending the async sequence will stop the listener. For example, in the below example, the listener will stop when the view disappears.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct ContentView: View {
+		@State private var isUnicornMode = false
+
+		var body: some View {
+			Text(isUnicornMode ? "🦄" : "🐴")
+				.task {
+					for await event in KeyboardShortcuts.events(for: .toggleUnicornMode) where event == .keyUp {
+						isUnicornMode.toggle()
+					}
+				}
+		}
+	}
+	```
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
+	public static func events(for name: Name) -> AsyncStream<KeyboardShortcuts.EventType> {
+		AsyncStream { continuation in
+			let id = UUID()
+
+			DispatchQueue.main.async {
+				streamKeyDownHandlers[name, default: [:]][id] = {
+					continuation.yield(.keyDown)
+				}
+
+				streamKeyUpHandlers[name, default: [:]][id] = {
+					continuation.yield(.keyUp)
+				}
+
+				registerShortcutIfNeeded(for: name)
+			}
+
+			continuation.onTermination = { _ in
+				DispatchQueue.main.async {
+					streamKeyDownHandlers[name]?[id] = nil
+					streamKeyUpHandlers[name]?[id] = nil
+
+					unregisterShortcutIfNeeded(for: name)
+				}
+			}
+		}
+	}
+
+	/**
+	Listen to keyboard shortcut events with the given name and type.
+
+	You can register multiple listeners.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	Ending the async sequence will stop the listener. For example, in the below example, the listener will stop when the view disappears.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct ContentView: View {
+		@State private var isUnicornMode = false
+
+		var body: some View {
+			Text(isUnicornMode ? "🦄" : "🐴")
+				.task {
+					for await event in KeyboardShortcuts.events(for: .toggleUnicornMode) where event == .keyUp {
+						isUnicornMode.toggle()
+					}
+				}
+		}
+	}
+	```
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
+	public static func events(_ type: EventType, for name: Name) -> AsyncFilterSequence<AsyncStream<EventType>> {
+		events(for: name).filter { $0 == type }
+	}
+}
+
+extension Notification.Name {
+	static let shortcutByNameDidChange = Self("KeyboardShortcuts_shortcutByNameDidChange")
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ar.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ar.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "سجل اختصاراً";
+"press_shortcut" = "اضغط على الاختصار";
+"keyboard_shortcut_used_by_menu_item" = "لا يمكن استخدام اختصار لوحة المفاتيح هذا لأنه مستخدم بواسطة عنصر القائمة “%@”.";
+"keyboard_shortcut_used_by_system" = "لا يمكن استخدام اختصار لوحة المفاتيح هذا لأنه مستخدم مسبقاً على مستوى النظام.";
+"keyboard_shortcuts_can_be_changed" = "يمكن تغيير معظم اختصارات لوحة المفاتيح على مستوى النظام في "إعدادات النظام › لوحة المفاتيح › اختصارات لوحة المفاتيح".";
+"keyboard_shortcut_disallowed" = "يجب دمج مفتاح Option مع Command أو Control.";
+"force_use_shortcut" = "استخدم على أي حال";
+"ok" = "موافق";
+"space_key" = "مسافة";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/cs.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/cs.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Přidat zkratku";
+"press_shortcut" = "Zadejte klávesy";
+"keyboard_shortcut_used_by_menu_item" = "Tuto zkratku nelze použít, protože je již využívána položkou „%@“";
+"keyboard_shortcut_used_by_system" = "Tuto zkratku nelze použít, protože už ji používá systém.";
+"keyboard_shortcuts_can_be_changed" = "Většinu systémových zkratek můžete změnit v „Nastavení systému › Klávesnice › Klávesové zkratky“.";
+"keyboard_shortcut_disallowed" = "Modifikátor Option musí být kombinován s klávesou Command nebo Control.";
+"force_use_shortcut" = "Přesto použít";
+"ok" = "OK";
+"space_key" = "Mezera";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/de.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/de.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Kurzbefehl aufnehmen";
+"press_shortcut" = "Kurzbefehl wählen…";
+"keyboard_shortcut_used_by_menu_item" = "Dieses Tastaturkürzel kann nicht verwendet werden, da es bereits durch den Menüpunkt „%@” belegt ist.";
+"keyboard_shortcut_used_by_system" = "Dieses Tastaturkürzel kann nicht verwendet werden, da es bereits systemweit verwendet wird.";
+"keyboard_shortcuts_can_be_changed" = "Die meisten systemweiten Tastaturkürzel können unter „Systemeinstellungen › Tastatur › Tastaturkurzbefehle“ geändert werden.";
+"keyboard_shortcut_disallowed" = "Die Option-Taste muss mit der Befehlstaste oder der Steuerungstaste kombiniert werden.";
+"force_use_shortcut" = "Trotzdem verwenden";
+"ok" = "OK";
+"space_key" = "Leer";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/en.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Record Shortcut";
+"press_shortcut" = "Press Shortcut";
+"keyboard_shortcut_used_by_menu_item" = "This keyboard shortcut cannot be used as it’s already used by the “%@” menu item.";
+"keyboard_shortcut_used_by_system" = "This keyboard shortcut cannot be used as it’s already a system-wide keyboard shortcut.";
+"keyboard_shortcuts_can_be_changed" = "Most system-wide keyboard shortcuts can be changed in “System Settings › Keyboard › Keyboard Shortcuts”.";
+"keyboard_shortcut_disallowed" = "Option modifier must be combined with Command or Control.";
+"force_use_shortcut" = "Use Anyway";
+"ok" = "OK";
+"space_key" = "Space";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/es.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/es.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Grabar atajo";
+"press_shortcut" = "Pulsar atajo";
+"keyboard_shortcut_used_by_menu_item" = "Este atajo de teclado no se puede utilizar ya que está siendo utilizado por el elemento de menú “%@”.";
+"keyboard_shortcut_used_by_system" = "Este atajo de teclado no se puede utilizar ya que está siendo utilizado por un atajo del sistema operativo.";
+"keyboard_shortcuts_can_be_changed" = "La mayoría de los atajos de teclado del sistema operativo pueden ser modificados en “Configuración del sistema › Teclado › Atajos de teclado“.";
+"keyboard_shortcut_disallowed" = "El modificador Option debe combinarse con Command o Control.";
+"force_use_shortcut" = "Usar de todos modos";
+"ok" = "Aceptar";
+"space_key" = "Espacio";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/fr.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/fr.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Enregistrer le raccourci";
+"press_shortcut" = "Saisir un raccourci";
+"keyboard_shortcut_used_by_menu_item" = "Ce raccourci ne peut pas être utilisé, car il est déjà utilisé par le menu “%@”.";
+"keyboard_shortcut_used_by_system" = "Ce raccourci ne peut pas être utilisé car il s'agit d'un raccourci déjà présent dans le système.";
+"keyboard_shortcuts_can_be_changed" = "La plupart des raccourcis clavier de l'ensemble du système peuvent être modifiés en “Réglages du système… › Clavier › Raccourcis clavier…”.";
+"keyboard_shortcut_disallowed" = "Le modificateur Option doit être combiné avec Command ou Control.";
+"force_use_shortcut" = "Utiliser quand même";
+"ok" = "OK";
+"space_key" = "Espace";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/hu.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/hu.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Billentyűparancs rögzítése";
+"press_shortcut" = "Nyomja meg a billentyűparancsot";
+"keyboard_shortcut_used_by_menu_item" = "Ez a billentyűparancs nem használható mert már a “%@” menü elem használja.";
+"keyboard_shortcut_used_by_system" = "Ez a billentyűparancs nem használható mert már egy rendszerszintü billentyűparancs.";
+"keyboard_shortcuts_can_be_changed" = "A legtöbb rendszerszintü billentyűparancsot a “Rendszerbeállítások › Billentyűzet › Billentyűparancsok” menüben meg lehet változtatni";
+"keyboard_shortcut_disallowed" = "Az Option módosítót a Command vagy Control billentyűvel együtt kell használni.";
+"force_use_shortcut" = "Használat mindenképp";
+"ok" = "OK";
+"space_key" = "Szóköz";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/it.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/it.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Registra scorciatoia";
+"press_shortcut" = "Premi scorciatoia";
+"keyboard_shortcut_used_by_menu_item" = "Questa scorciatoia da tastiera non può essere utilizzata perché è già assegnata alla voce di menu “%@”.";
+"keyboard_shortcut_used_by_system" = "Questa scorciatoia da tastiera non può essere utilizzata perché è già una scorciatoia di sistema.";
+"keyboard_shortcuts_can_be_changed" = "La maggior parte delle scorciatoie di sistema può essere modificata in “Impostazioni di Sistema › Tastiera › Scorciatoie da tastiera”.";
+"keyboard_shortcut_disallowed" = "Il modificatore Opzione deve essere combinato con Comando o Controllo.";
+"force_use_shortcut" = "Usa comunque";
+"ok" = "OK";
+"space_key" = "Spazio";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ja.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ja.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "キーを記録";
+"press_shortcut" = "キーを押してください";
+"keyboard_shortcut_used_by_menu_item" = "このショートカットは既に“%@”で使われており使えません。";
+"keyboard_shortcut_used_by_system" = "このショートカットキーは既にシステムで使われており使えません。";
+"keyboard_shortcuts_can_be_changed" = "システムで設定されているショートカットキーは“システム設定 › キーボード › キーボードショートカット”で変更できます。";
+"keyboard_shortcut_disallowed" = "Optionキーは、CommandキーまたはControlキーと組み合わせる必要があります。";
+"force_use_shortcut" = "強制使用";
+"ok" = "OK";
+"space_key" = "スペース";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ko.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ko.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "단축키 등록";
+"press_shortcut" = "단축키 입력";
+"keyboard_shortcut_used_by_menu_item" = "이 키보드 단축키는 이미 “%@” 메뉴 항목에 사용되고 있으므로 등록할 수 없습니다.";
+"keyboard_shortcut_used_by_system" = "이 키보드 단축키는 이미 시스템상에서 사용되고 있으므로 등록할 수 없습니다.";
+"keyboard_shortcuts_can_be_changed" = "대부분의 시스템 키보드 단축키는 “시스템 설정 › 키보드 › 키보드 단축키”에서 변경 가능합니다.";
+"keyboard_shortcut_disallowed" = "Option 수정자는 Command 또는 Control과 함께 사용해야 합니다.";
+"force_use_shortcut" = "그래도 사용";
+"ok" = "확인";
+"space_key" = "빈칸";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/nl.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/nl.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Toetscombinatie opnemen";
+"press_shortcut" = "Voer toetscombinatie in";
+"keyboard_shortcut_used_by_menu_item" = "Deze toetscombinatie kan niet worden gebruikt omdat hij al wordt gebruikt door het menu item “%@”.";
+"keyboard_shortcut_used_by_system" = "Deze toetscombinatie kan niet worden gebruikt omdat hij al door het systeem gebruikt wordt.";
+"keyboard_shortcuts_can_be_changed" = "De meeste systeem toetscombinaties kunnen onder “Systeeminstellingen… > Toetsenbord > Toetscombinaties…” veranderd worden.";
+"keyboard_shortcut_disallowed" = "De Option-toets moet worden gecombineerd met Command of Control.";
+"force_use_shortcut" = "Toch gebruiken";
+"ok" = "OK";
+"space_key" = "spatie";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/pt-BR.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/pt-BR.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Gravar Atalho";
+"press_shortcut" = "Digite o Atalho";
+"keyboard_shortcut_used_by_menu_item" = "Este atalho não pode ser usado porque ele já é usado pelo item de menu “%@”.";
+"keyboard_shortcut_used_by_system" = "Este atalho não pode ser usado porque ele já é usado por um atalho do sistema.";
+"keyboard_shortcuts_can_be_changed" = "A maioria dos atalhos do sistema podem ser alterados em “Ajustes do Sistema › Teclado › Atalhos de Teclado”.";
+"keyboard_shortcut_disallowed" = "O modificador Option deve ser combinado com Command ou Control.";
+"force_use_shortcut" = "Usar mesmo assim";
+"ok" = "OK";
+"space_key" = "Espaço";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ru.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/ru.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Добавить";
+"press_shortcut" = "Запись…";
+"keyboard_shortcut_used_by_menu_item" = "Это сочетание клавиш нельзя использовать, так как оно уже используется в пункте меню «%@».";
+"keyboard_shortcut_used_by_system" = "Это сочетание клавиш нельзя использовать, поскольку оно является системным.";
+"keyboard_shortcuts_can_be_changed" = "Большинство системных сочетаний клавиш можно изменить в «Настройки системы › Клавиатура › Сочетания клавиш».";
+"keyboard_shortcut_disallowed" = "Клавиша Option должна использоваться в сочетании с Command или Control.";
+"force_use_shortcut" = "Все равно использовать";
+"ok" = "OK";
+"space_key" = "Пробел";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/sk.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/sk.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "Nahraj skratku";
+"press_shortcut" = "Stlač skratku";
+"keyboard_shortcut_used_by_menu_item" = "Túto klávesovú skratku nemožno použiť, pretože ju už používa položka menu “%@”.";
+"keyboard_shortcut_used_by_system" = "Túto klávesovú skratku nemožno použiť, pretože je už použivaná pre celý systém.";
+"keyboard_shortcuts_can_be_changed" = "Väčšinu systémových klávesových skratiek môžeš zmeniť v “Systémové nastavenia › Klávesnica › Klávesové skratky”.";
+"keyboard_shortcut_disallowed" = "Modifikátor Option musí byť kombinovaný s klávesmi Command alebo Control.";
+"force_use_shortcut" = "Použiť napriek tomu";
+"ok" = "OK";
+"space_key" = "Medzerník";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/zh-Hans.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "设置快捷键";
+"press_shortcut" = "按下快捷键";
+"keyboard_shortcut_used_by_menu_item" = "当前快捷键无法使用，因为它已被用作菜单项“%@”的快捷键。";
+"keyboard_shortcut_used_by_system" = "当前快捷键无法使用，因为它已被用作系统快捷键。";
+"keyboard_shortcuts_can_be_changed" = "可以在“系统设置 › 键盘 › 键盘快捷键”中更改大多数系统快捷键。";
+"keyboard_shortcut_disallowed" = "Option键必须与Command键或Control键组合使用。";
+"force_use_shortcut" = "强制使用";
+"ok" = "好";
+"space_key" = "空格";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/zh-TW.lproj/Localizable.strings
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Localization/zh-TW.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+"record_shortcut" = "設定快速鍵";
+"press_shortcut" = "按下快速鍵";
+"keyboard_shortcut_used_by_menu_item" = "此快速鍵無法使用，因為它已被選單項目「%@」使用。";
+"keyboard_shortcut_used_by_system" = "此快速鍵無法使用，因為它已被系統使用。";
+"keyboard_shortcuts_can_be_changed" = "可以在「系統設定 › 鍵盤 › 鍵盤快速鍵」中更改大多數的系統快速鍵。";
+"keyboard_shortcut_disallowed" = "Option鍵必須與Command鍵或Control鍵組合使用。";
+"force_use_shortcut" = "強制使用";
+"ok" = "好";
+"space_key" = "空格";

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/NSMenuItem++.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/NSMenuItem++.swift
@@ -1,0 +1,107 @@
+#if os(macOS)
+import AppKit
+
+extension NSMenuItem {
+	private enum AssociatedKeys {
+		@MainActor
+		static let observer = ObjectAssociation<NSObjectProtocol>()
+	}
+
+	@MainActor
+	private func clearShortcut() {
+		keyEquivalent = ""
+		keyEquivalentModifierMask = []
+
+		if #available(macOS 12, *) {
+			allowsAutomaticKeyEquivalentLocalization = true
+		}
+	}
+
+	// TODO: Make this a getter/setter. We must first add the ability to create a `Shortcut` from a `keyEquivalent`.
+	/**
+	Show a recorded keyboard shortcut in a `NSMenuItem`.
+
+	The menu item will automatically be kept up to date with changes to the keyboard shortcut.
+
+	Pass in `nil` to clear the keyboard shortcut.
+
+	This method overrides `.keyEquivalent` and `.keyEquivalentModifierMask`.
+
+	```swift
+	import AppKit
+	import KeyboardShortcuts
+
+	extension KeyboardShortcuts.Name {
+		static let toggleUnicornMode = Self("toggleUnicornMode")
+	}
+
+	// … `Recorder` logic for recording the keyboard shortcut …
+
+	let menuItem = NSMenuItem()
+	menuItem.title = "Toggle Unicorn Mode"
+	menuItem.setShortcut(for: .toggleUnicornMode)
+	```
+
+	You can test this method in the example project. Run it, record a shortcut and then look at the “Test” menu in the app's main menu.
+
+	- Important: You will have to disable the global keyboard shortcut while the menu is open, as otherwise, the keyboard events will be buffered up and triggered when the menu closes. This is because `NSMenu` puts the thread in tracking-mode, which prevents the keyboard events from being received. You can listen to whether a menu is open by implementing `NSMenuDelegate#menuWillOpen` and `NSMenuDelegate#menuDidClose`. You then use `KeyboardShortcuts.disable` and `KeyboardShortcuts.enable`.
+	*/
+	@MainActor
+	public func setShortcut(for name: KeyboardShortcuts.Name?) {
+		guard let name else {
+			clearShortcut()
+			NotificationCenter.default.removeObserver(AssociatedKeys.observer[self] as Any)
+			AssociatedKeys.observer[self] = nil
+			return
+		}
+
+		func set() {
+			let shortcut = KeyboardShortcuts.Shortcut(name: name)
+			setShortcut(shortcut)
+		}
+
+		set()
+
+		// TODO: Use AsyncStream when targeting macOS 15.
+		AssociatedKeys.observer[self] = NotificationCenter.default.addObserver(forName: .shortcutByNameDidChange, object: nil, queue: nil) { notification in
+			guard
+				let nameInNotification = notification.userInfo?["name"] as? KeyboardShortcuts.Name,
+				nameInNotification == name
+			else {
+				return
+			}
+
+			DispatchQueue.main.async { // TODO: Use `Task { @MainActor`
+				set()
+			}
+		}
+	}
+
+	/**
+	Add a keyboard shortcut to a `NSMenuItem`.
+
+	This method is only recommended for dynamic shortcuts. In general, it's preferred to create a static shortcut name and use `NSMenuItem.setShortcut(for:)` instead.
+
+	Pass in `nil` to clear the keyboard shortcut.
+
+	This method overrides `.keyEquivalent` and `.keyEquivalentModifierMask`.
+
+	- Important: You will have to disable the global keyboard shortcut while the menu is open, as otherwise, the keyboard events will be buffered up and triggered when the menu closes. This is because `NSMenu` puts the thread in tracking-mode, which prevents the keyboard events from being received. You can listen to whether a menu is open by implementing `NSMenuDelegate#menuWillOpen` and `NSMenuDelegate#menuDidClose`. You then use `KeyboardShortcuts.disable` and `KeyboardShortcuts.enable`.
+	*/
+	@_disfavoredOverload
+	@MainActor
+	public func setShortcut(_ shortcut: KeyboardShortcuts.Shortcut?) {
+		guard let shortcut else {
+			clearShortcut()
+			return
+		}
+
+		keyEquivalent = shortcut.nsMenuItemKeyEquivalent ?? ""
+		keyEquivalentModifierMask = shortcut.modifiers
+
+		if #available(macOS 12, *) {
+			allowsAutomaticKeyEquivalentLocalization = false
+		}
+	}
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Name.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Name.swift
@@ -1,0 +1,60 @@
+#if os(macOS)
+extension KeyboardShortcuts {
+	/**
+	The strongly-typed name of the keyboard shortcut.
+
+	After registering it, you can use it in, for example, `KeyboardShortcut.Recorder` and `KeyboardShortcut.onKeyUp()`.
+
+	```swift
+	import KeyboardShortcuts
+
+	extension KeyboardShortcuts.Name {
+		static let toggleUnicornMode = Self("toggleUnicornMode")
+	}
+	```
+	*/
+	public struct Name: Hashable, Sendable {
+		// This makes it possible to use `Shortcut` without the namespace.
+		/// :nodoc:
+		public typealias Shortcut = KeyboardShortcuts.Shortcut
+
+		public let rawValue: String
+		public let defaultShortcut: Shortcut?
+
+		/**
+		The keyboard shortcut assigned to the name.
+		*/
+		public var shortcut: Shortcut? {
+			get { KeyboardShortcuts.getShortcut(for: self) }
+			nonmutating set {
+				KeyboardShortcuts.setShortcut(newValue, for: self)
+			}
+		}
+
+		/**
+		- Parameter name: Name of the shortcut.
+		- Parameter initialShortcut: Optional default key combination. Do not set this unless it's essential. Users find it annoying when random apps steal their existing keyboard shortcuts. It's generally better to show a welcome screen on the first app launch that lets the user set the shortcut.
+		*/
+		public init(_ name: String, default initialShortcut: Shortcut? = nil) {
+			self.rawValue = name
+			self.defaultShortcut = initialShortcut
+
+			if
+				let initialShortcut,
+				!userDefaultsContains(name: self)
+			{
+				setShortcut(initialShortcut, for: self)
+			}
+
+			KeyboardShortcuts.initialize()
+		}
+	}
+}
+
+extension KeyboardShortcuts.Name: RawRepresentable {
+	/// :nodoc:
+	public init?(rawValue: String) {
+		self.init(rawValue)
+	}
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Recorder.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Recorder.swift
@@ -1,0 +1,186 @@
+#if os(macOS)
+import SwiftUI
+
+extension KeyboardShortcuts {
+	private struct _Recorder: NSViewRepresentable { // swiftlint:disable:this type_name
+		typealias NSViewType = RecorderCocoa
+
+		let name: Name
+		let onChange: ((_ shortcut: Shortcut?) -> Void)?
+
+		func makeNSView(context: Context) -> NSViewType {
+			.init(for: name, onChange: onChange)
+		}
+
+		func updateNSView(_ nsView: NSViewType, context: Context) {
+			nsView.shortcutName = name
+		}
+	}
+
+	/**
+	A SwiftUI `View` that lets the user record a keyboard shortcut.
+
+	You would usually put this in your settings window.
+
+	It automatically prevents choosing a keyboard shortcut that is already taken by the system or by the app's main menu by showing a user-friendly alert to the user.
+
+	It takes care of storing the keyboard shortcut in `UserDefaults` for you.
+
+	```swift
+	import SwiftUI
+	import KeyboardShortcuts
+
+	struct SettingsScreen: View {
+		var body: some View {
+			Form {
+				KeyboardShortcuts.Recorder("Toggle Unicorn Mode:", name: .toggleUnicornMode)
+			}
+		}
+	}
+	```
+
+	- Note: Since macOS 15, for sandboxed apps, it's [no longer possible](https://developer.apple.com/forums/thread/763878?answerId=804374022#804374022) to specify the `Option` key without also using `Command` or `Control`.
+	*/
+	public struct Recorder<Label: View>: View { // swiftlint:disable:this type_name
+		private let name: Name
+		private let onChange: ((Shortcut?) -> Void)?
+		private let hasLabel: Bool
+		private let label: Label
+
+		init(
+			for name: Name,
+			onChange: ((Shortcut?) -> Void)? = nil,
+			hasLabel: Bool,
+			@ViewBuilder label: () -> Label
+		) {
+			self.name = name
+			self.onChange = onChange
+			self.hasLabel = hasLabel
+			self.label = label()
+		}
+
+		public var body: some View {
+			if hasLabel {
+				if #available(macOS 13, *) {
+					LabeledContent {
+						_Recorder(
+							name: name,
+							onChange: onChange
+						)
+					} label: {
+						label
+					}
+				} else {
+					_Recorder(
+						name: name,
+						onChange: onChange
+					)
+						.formLabel {
+							label
+						}
+				}
+			} else {
+				_Recorder(
+					name: name,
+					onChange: onChange
+				)
+			}
+		}
+	}
+}
+
+extension KeyboardShortcuts.Recorder<EmptyView> {
+	/**
+	- Parameter name: Strongly-typed keyboard shortcut name.
+	- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+	*/
+	public init(
+		for name: KeyboardShortcuts.Name,
+		onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+	) {
+		self.init(
+			for: name,
+			onChange: onChange,
+			hasLabel: false
+		) {}
+	}
+}
+
+extension KeyboardShortcuts.Recorder<Text> {
+	/**
+	- Parameter title: The title of the keyboard shortcut recorder, describing its purpose.
+	- Parameter name: Strongly-typed keyboard shortcut name.
+	- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+	*/
+	public init(
+		_ title: LocalizedStringKey,
+		name: KeyboardShortcuts.Name,
+		onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+	) {
+		self.init(
+			for: name,
+			onChange: onChange,
+			hasLabel: true
+		) {
+			Text(title)
+		}
+	}
+}
+
+extension KeyboardShortcuts.Recorder<Text> {
+	/**
+	- Parameter title: The title of the keyboard shortcut recorder, describing its purpose.
+	- Parameter name: Strongly-typed keyboard shortcut name.
+	- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+	*/
+	@_disfavoredOverload
+	public init(
+		_ title: String,
+		name: KeyboardShortcuts.Name,
+		onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil
+	) {
+		self.init(
+			for: name,
+			onChange: onChange,
+			hasLabel: true
+		) {
+			Text(title)
+		}
+	}
+}
+
+extension KeyboardShortcuts.Recorder {
+	/**
+	- Parameter name: Strongly-typed keyboard shortcut name.
+	- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+	- Parameter label: A view that describes the purpose of the keyboard shortcut recorder.
+	*/
+	public init(
+		for name: KeyboardShortcuts.Name,
+		onChange: ((KeyboardShortcuts.Shortcut?) -> Void)? = nil,
+		@ViewBuilder label: () -> Label
+	) {
+		self.init(
+			for: name,
+			onChange: onChange,
+			hasLabel: true,
+			label: label
+		)
+	}
+}
+
+#Preview {
+	KeyboardShortcuts.Recorder("record_shortcut", name: .init("xcodePreview"))
+		.environment(\.locale, .init(identifier: "en"))
+}
+
+#Preview {
+	KeyboardShortcuts.Recorder("record_shortcut", name: .init("xcodePreview"))
+		.environment(\.locale, .init(identifier: "zh-Hans"))
+}
+
+#Preview {
+	KeyboardShortcuts.Recorder("record_shortcut", name: .init("xcodePreview"))
+		.environment(\.locale, .init(identifier: "ru"))
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/RecorderCocoa.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/RecorderCocoa.swift
@@ -1,0 +1,384 @@
+#if os(macOS)
+import AppKit
+import Carbon.HIToolbox
+
+extension KeyboardShortcuts {
+	/**
+	A `NSView` that lets the user record a keyboard shortcut.
+
+	You would usually put this in your settings window.
+
+	It automatically prevents choosing a keyboard shortcut that is already taken by the system or by the app's main menu by showing a user-friendly alert to the user.
+
+	It takes care of storing the keyboard shortcut in `UserDefaults` for you.
+
+	```swift
+	import AppKit
+	import KeyboardShortcuts
+
+	final class SettingsViewController: NSViewController {
+		override func loadView() {
+			view = NSView()
+
+			let recorder = KeyboardShortcuts.RecorderCocoa(for: .toggleUnicornMode)
+			view.addSubview(recorder)
+		}
+	}
+	```
+	*/
+	public final class RecorderCocoa: NSSearchField, NSSearchFieldDelegate {
+		private let minimumWidth = 130.0
+		private let onChange: ((_ shortcut: Shortcut?) -> Void)?
+		private var canBecomeKey = false
+		private var eventMonitor: LocalEventMonitor?
+		private var shortcutsNameChangeObserver: NSObjectProtocol?
+		private var windowDidResignKeyObserver: NSObjectProtocol?
+		private var windowDidBecomeKeyObserver: NSObjectProtocol?
+
+		/**
+		The shortcut name for the recorder.
+
+		Can be dynamically changed at any time.
+		*/
+		public var shortcutName: Name {
+			didSet {
+				guard shortcutName != oldValue else {
+					return
+				}
+
+				setStringValue(name: shortcutName)
+
+				// This doesn't seem to be needed anymore, but I cannot test on older OS versions, so keeping it just in case.
+				if #unavailable(macOS 12) {
+					DispatchQueue.main.async { [self] in
+						// Prevents the placeholder from being cut off.
+						blur()
+					}
+				}
+			}
+		}
+
+		/// :nodoc:
+		override public var canBecomeKeyView: Bool { canBecomeKey }
+
+		/// :nodoc:
+		override public var intrinsicContentSize: CGSize {
+			var size = super.intrinsicContentSize
+			size.width = minimumWidth
+			return size
+		}
+
+		private var cancelButton: NSButtonCell?
+
+		private var showsCancelButton: Bool {
+			get { (cell as? NSSearchFieldCell)?.cancelButtonCell != nil }
+			set {
+				(cell as? NSSearchFieldCell)?.cancelButtonCell = newValue ? cancelButton : nil
+			}
+		}
+
+		/**
+		- Parameter name: Strongly-typed keyboard shortcut name.
+		- Parameter onChange: Callback which will be called when the keyboard shortcut is changed/removed by the user. This can be useful when you need more control. For example, when migrating from a different keyboard shortcut solution and you need to store the keyboard shortcut somewhere yourself instead of relying on the built-in storage. However, it's strongly recommended to just rely on the built-in storage when possible.
+		*/
+		public required init(
+			for name: Name,
+			onChange: ((_ shortcut: Shortcut?) -> Void)? = nil
+		) {
+			self.shortcutName = name
+			self.onChange = onChange
+
+			// Use a default frame that matches our intrinsic size to prevent zero-size issues
+			// when added without constraints (issue #209)
+			super.init(frame: NSRect(x: 0, y: 0, width: minimumWidth, height: 24))
+			self.delegate = self
+			self.placeholderString = "record_shortcut".localized
+			self.alignment = .center
+			(cell as? NSSearchFieldCell)?.searchButtonCell = nil
+
+			self.wantsLayer = true
+			setContentHuggingPriority(.defaultHigh, for: .vertical)
+			setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+			// Hide the cancel button when not showing the shortcut so the placeholder text is properly centered. Must be last.
+			self.cancelButton = (cell as? NSSearchFieldCell)?.cancelButtonCell
+
+			setStringValue(name: name)
+
+			setUpEvents()
+		}
+
+		@available(*, unavailable)
+		public required init?(coder: NSCoder) {
+			fatalError("init(coder:) has not been implemented")
+		}
+
+		private func setStringValue(name: KeyboardShortcuts.Name) {
+			stringValue = getShortcut(for: shortcutName).map { "\($0)" } ?? ""
+
+			// If `stringValue` is empty, hide the cancel button to let the placeholder center.
+			showsCancelButton = !stringValue.isEmpty
+		}
+
+		private func setUpEvents() {
+			shortcutsNameChangeObserver = NotificationCenter.default.addObserver(forName: .shortcutByNameDidChange, object: nil, queue: nil) { [weak self] notification in
+				guard
+					let self,
+					let nameInNotification = notification.userInfo?["name"] as? KeyboardShortcuts.Name,
+					nameInNotification == shortcutName
+				else {
+					return
+				}
+
+				setStringValue(name: nameInNotification)
+			}
+		}
+
+		private func endRecording() {
+			eventMonitor = nil
+			placeholderString = "record_shortcut".localized
+			showsCancelButton = !stringValue.isEmpty
+			restoreCaret()
+			KeyboardShortcuts.isPaused = false
+			NotificationCenter.default.post(name: .recorderActiveStatusDidChange, object: nil, userInfo: ["isActive": false])
+		}
+
+		private func preventBecomingKey() {
+			canBecomeKey = false
+
+			// Prevent the control from receiving the initial focus.
+			DispatchQueue.main.async { [self] in
+				canBecomeKey = true
+			}
+		}
+
+		/// :nodoc:
+		public func controlTextDidChange(_ object: Notification) {
+			if stringValue.isEmpty {
+				saveShortcut(nil)
+			}
+
+			showsCancelButton = !stringValue.isEmpty
+
+			if stringValue.isEmpty {
+				// Hack to ensure that the placeholder centers after the above `showsCancelButton` setter.
+				focus()
+			}
+		}
+
+		/// :nodoc:
+		public func controlTextDidEndEditing(_ object: Notification) {
+			// AppKit posts this spuriously while editing is still active. `becomeFirstResponder`
+			// sets `showsCancelButton`, which mutates the cell's `cancelButtonCell` with the field
+			// editor installed; that ends and restarts editing, and the resulting notification can
+			// land *after* the key monitor is armed — tearing it down microseconds later. The
+			// recorder then looks focused but captures nothing, and keystrokes fall through to the
+			// search field as plain text.
+			//
+			// Deciding synchronously is not reliable in either direction: on the spurious
+			// notification the field editor is still installed, but on a genuine one AppKit has
+			// not necessarily moved first responder yet. Re-check on the next turn, once things
+			// have settled — by then a spurious end has already restarted editing, while a real
+			// one has left `currentEditor()` nil.
+			// Upstream: https://github.com/sindresorhus/KeyboardShortcuts/issues/241 (defect 2).
+			Task { @MainActor [weak self] in
+				guard let self else {
+					return
+				}
+
+				if let editor = currentEditor(), window?.firstResponder === editor {
+					return
+				}
+
+				endRecording()
+			}
+		}
+
+		/// :nodoc:
+		override public func viewDidMoveToWindow() {
+			guard let window else {
+				windowDidResignKeyObserver = nil
+				windowDidBecomeKeyObserver = nil
+				endRecording()
+				return
+			}
+
+			// Ensures the recorder stops when the window is hidden.
+			// This is especially important for Settings windows, which as of macOS 13.5, only hides instead of closes when you click the close button.
+			windowDidResignKeyObserver = NotificationCenter.default.addObserver(forName: NSWindow.didResignKeyNotification, object: window, queue: nil) { [weak self] _ in
+				guard
+					let self,
+					let window = self.window
+				else {
+					return
+				}
+
+				endRecording()
+				window.makeFirstResponder(nil)
+			}
+
+			// Ensures the recorder does not receive initial focus when a hidden window becomes unhidden.
+			windowDidBecomeKeyObserver = NotificationCenter.default.addObserver(forName: NSWindow.didBecomeKeyNotification, object: window, queue: nil) { [weak self] _ in
+				self?.preventBecomingKey()
+			}
+
+			preventBecomingKey()
+		}
+
+		/// :nodoc:
+		override public func becomeFirstResponder() -> Bool {
+			// Ensure we have a valid window before attempting to become first responder
+			// This prevents issues in SwiftUI contexts where the view hierarchy might not be fully established
+			guard window != nil else {
+				return false
+			}
+
+			let shouldBecomeFirstResponder = super.becomeFirstResponder()
+
+			guard shouldBecomeFirstResponder else {
+				return shouldBecomeFirstResponder
+			}
+
+			placeholderString = "press_shortcut".localized
+			showsCancelButton = !stringValue.isEmpty
+			hideCaret()
+			KeyboardShortcuts.isPaused = true // The position here matters.
+			NotificationCenter.default.post(name: .recorderActiveStatusDidChange, object: nil, userInfo: ["isActive": true])
+
+			eventMonitor = LocalEventMonitor(events: [.keyDown, .leftMouseUp, .rightMouseUp]) { [weak self] event in
+				guard let self else {
+					return nil
+				}
+
+				let clickPoint = convert(event.locationInWindow, from: nil)
+				let clickMargin = 3.0
+
+				if event.type == .leftMouseUp || event.type == .rightMouseUp {
+					guard bounds.insetBy(dx: -clickMargin, dy: -clickMargin).contains(clickPoint) else {
+						blur()
+						return event
+					}
+
+					// A click *inside* the field must be passed through, not swallowed. It used to
+					// fall through to the `isKeyEvent` guard below and get consumed, which killed
+					// the clear button: `NSSearchFieldCell` completes `_searchFieldCancel:` on
+					// mouseUp, so the X could be pressed but never fired, and the field could only
+					// be cleared with the Delete key.
+					// Upstream: https://github.com/sindresorhus/KeyboardShortcuts/issues/241 (defect 3).
+					return event
+				}
+
+				guard event.isKeyEvent else {
+					return nil
+				}
+
+				if
+					event.modifiers.isEmpty,
+					event.specialKey == .tab
+				{
+					blur()
+
+					// We intentionally bubble up the event so it can focus the next responder.
+					return event
+				}
+
+				if
+					event.modifiers.isEmpty,
+					event.keyCode == kVK_Escape // TODO: Make this strongly typed.
+				{
+					blur()
+					return nil
+				}
+
+				if
+					event.modifiers.isEmpty,
+					event.specialKey == .delete
+						|| event.specialKey == .deleteForward
+						|| event.specialKey == .backspace
+				{
+					clear()
+					return nil
+				}
+
+				// The “shift” key is not allowed without other modifiers or a function key, since it doesn't actually work.
+				guard
+					!event.modifiers.subtracting([.shift, .function]).isEmpty
+						|| event.specialKey?.isFunctionKey == true,
+					let shortcut = Shortcut(event: event)
+				else {
+					NSSound.beep()
+					return nil
+				}
+
+				if let menuItem = shortcut.takenByMainMenu {
+					// TODO: Find a better way to make it possible to dismiss the alert by pressing "Enter". How can we make the input automatically temporarily lose focus while the alert is open?
+					blur()
+
+					NSAlert.showModal(
+						for: window,
+						title: String.localizedStringWithFormat("keyboard_shortcut_used_by_menu_item".localized, menuItem.title)
+					)
+
+					focus()
+
+					return nil
+				}
+
+				// See: https://developer.apple.com/forums/thread/763878?answerId=804374022#804374022
+				if shortcut.isDisallowed {
+					blur()
+
+					NSAlert.showModal(
+						for: window,
+						title: "keyboard_shortcut_disallowed".localized
+					)
+
+					focus()
+					return nil
+				}
+
+				if shortcut.isTakenBySystem {
+					blur()
+
+					let modalResponse = NSAlert.showModal(
+						for: window,
+						title: "keyboard_shortcut_used_by_system".localized,
+						// TODO: Add button to offer to open the relevant system settings pane for the user.
+						message: "keyboard_shortcuts_can_be_changed".localized,
+						buttonTitles: [
+							"ok".localized,
+							"force_use_shortcut".localized
+						]
+					)
+
+					focus()
+
+					// If the user has selected "Use Anyway" in the dialog (the second option), we'll continue setting the keyboard shorcut even though it's reserved by the system.
+					guard modalResponse == .alertSecondButtonReturn else {
+						return nil
+					}
+				}
+
+				stringValue = "\(shortcut)"
+				showsCancelButton = true
+
+				saveShortcut(shortcut)
+				blur()
+
+				return nil
+			}.start()
+
+			return shouldBecomeFirstResponder
+		}
+
+		private func saveShortcut(_ shortcut: Shortcut?) {
+			setShortcut(shortcut, for: shortcutName)
+			onChange?(shortcut)
+		}
+	}
+}
+
+extension Notification.Name {
+	static let recorderActiveStatusDidChange = Self("KeyboardShortcuts_recorderActiveStatusDidChange")
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Shortcut.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Shortcut.swift
@@ -1,0 +1,781 @@
+#if os(macOS)
+import AppKit
+import Carbon.HIToolbox
+import SwiftUI
+
+extension KeyboardShortcuts {
+	/**
+	A keyboard shortcut.
+	*/
+	public struct Shortcut: Hashable, Codable, Sendable {
+		/**
+		Carbon modifiers are not always stored as the same number.
+
+		For example, the system has `⌃F2` stored with the modifiers number `135168`, but if you press the keyboard shortcut, you get `4096`.
+		*/
+		private static func normalizeModifiers(_ carbonModifiers: Int) -> Int {
+			NSEvent.ModifierFlags(carbon: carbonModifiers).carbon
+		}
+
+		/**
+		The keyboard key of the shortcut.
+		*/
+		public var key: Key? { Key(rawValue: carbonKeyCode) }
+
+		/**
+		The modifier keys of the shortcut.
+		*/
+		public var modifiers: NSEvent.ModifierFlags { NSEvent.ModifierFlags(carbon: carbonModifiers) }
+
+		/**
+		Low-level representation of the key.
+
+		You most likely don't need this.
+		*/
+		public let carbonKeyCode: Int
+
+		/**
+		Low-level representation of the modifier keys.
+
+		You most likely don't need this.
+		*/
+		public let carbonModifiers: Int
+
+		/**
+		Initialize from a strongly-typed key and modifiers.
+		*/
+		public init(_ key: Key, modifiers: NSEvent.ModifierFlags = []) {
+			self.init(
+				carbonKeyCode: key.rawValue,
+				carbonModifiers: modifiers.carbon
+			)
+		}
+
+		/**
+		Initialize from a key event.
+		*/
+		public init?(event: NSEvent) {
+			guard event.isKeyEvent else {
+				return nil
+			}
+
+			self.init(
+				carbonKeyCode: Int(event.keyCode),
+				// Note: We could potentially support users specifying shortcuts with the Fn key, but I haven't found a reliable way to differentate when to display the Fn key and not. For example, with Fn+F1 we only want to display F1, but with Fn+V, we want to display both. I cannot just specialize it for F keys as it applies to other keys too, like Fn+arrowup.
+				carbonModifiers: event.modifierFlags.subtracting(.function).carbon
+			)
+		}
+
+		/**
+		Initialize from a keyboard shortcut stored by `Recorder` or `RecorderCocoa`.
+		*/
+		public init?(name: Name) {
+			guard let shortcut = getShortcut(for: name) else {
+				return nil
+			}
+
+			self = shortcut
+		}
+
+		/**
+		Initialize from a key code number and modifier code.
+
+		You most likely don't need this.
+		*/
+		public init(carbonKeyCode: Int, carbonModifiers: Int = 0) {
+			self.carbonKeyCode = carbonKeyCode
+			self.carbonModifiers = Self.normalizeModifiers(carbonModifiers)
+		}
+	}
+}
+
+enum Constants {
+	static let isSandboxed = ProcessInfo.processInfo.environment.hasKey("APP_SANDBOX_CONTAINER_ID")
+}
+
+extension KeyboardShortcuts.Shortcut {
+	/**
+	System-defined keyboard shortcuts.
+	*/
+	static var system: [Self] {
+		CarbonKeyboardShortcuts.system
+	}
+
+	/**
+	Check whether the keyboard shortcut is disallowed.
+	*/
+	var isDisallowed: Bool {
+		let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+
+		guard
+			osVersion.majorVersion == 15,
+			osVersion.minorVersion == 0 || osVersion.minorVersion == 1,
+			Constants.isSandboxed
+		else {
+			return false
+		}
+
+		if !modifiers.contains(.option) {
+			return false // Allowed if Option is not involved
+		}
+
+		// If Option is present, ensure there's at least one modifier other than Option and Shift
+		let otherModifiers: NSEvent.ModifierFlags = [.command, .control, .function, .capsLock]
+		return modifiers.isDisjoint(with: otherModifiers)
+	}
+
+	/**
+	Check whether the keyboard shortcut is already taken by the system.
+	*/
+	var isTakenBySystem: Bool {
+		guard self != Self(.f12, modifiers: []) else {
+			return false
+		}
+
+		return Self.system.contains(self)
+	}
+}
+
+extension KeyboardShortcuts.Shortcut {
+	/**
+	Recursively finds a menu item in the given menu that has a matching key equivalent and modifier.
+	*/
+	@MainActor
+	func menuItemWithMatchingShortcut(in menu: NSMenu) -> NSMenuItem? {
+		for item in menu.items {
+			var keyEquivalent = item.keyEquivalent
+			var keyEquivalentModifierMask = item.keyEquivalentModifierMask
+
+			if
+				modifiers.contains(.shift),
+				keyEquivalent.lowercased() != keyEquivalent
+			{
+				keyEquivalent = keyEquivalent.lowercased()
+				keyEquivalentModifierMask.insert(.shift)
+			}
+
+			if
+				nsMenuItemKeyEquivalent == keyEquivalent, // Note `nil != ""`
+				modifiers == keyEquivalentModifierMask
+			{
+				return item
+			}
+
+			if
+				let submenu = item.submenu,
+				let menuItem = menuItemWithMatchingShortcut(in: submenu)
+			{
+				return menuItem
+			}
+		}
+
+		return nil
+	}
+
+	/**
+	Returns a menu item in the app's main menu that has a matching key equivalent and modifier.
+	*/
+	@MainActor
+	var takenByMainMenu: NSMenuItem? {
+		guard let mainMenu = NSApp.mainMenu else {
+			return nil
+		}
+
+		return menuItemWithMatchingShortcut(in: mainMenu)
+	}
+}
+
+/*
+An enumeration of special keys requiring specific handling when used with `RecorderCocoa`, AppKit’s `NSMenuItem`, and SwiftUI’s `.keyboardShortcut(_:modifiers:)`.  
+
+Using an enumeration ensures all cases are exhaustively addressed in all three contexts, providing compile-time safety and reducing the risk of unhandled keys.
+*/
+private enum SpecialKey {
+	case `return`
+	case delete
+	case deleteForward
+	case end
+	case escape
+	case help
+	case home
+	case space
+	case tab
+	case pageUp
+	case pageDown
+	case upArrow
+	case rightArrow
+	case downArrow
+	case leftArrow
+	case f1
+	case f2
+	case f3
+	case f4
+	case f5
+	case f6
+	case f7
+	case f8
+	case f9
+	case f10
+	case f11
+	case f12
+	case f13
+	case f14
+	case f15
+	case f16
+	case f17
+	case f18
+	case f19
+	case f20
+	case keypad0
+	case keypad1
+	case keypad2
+	case keypad3
+	case keypad4
+	case keypad5
+	case keypad6
+	case keypad7
+	case keypad8
+	case keypad9
+	case keypadClear
+	case keypadDecimal
+	case keypadDivide
+	case keypadEnter
+	case keypadEquals
+	case keypadMinus
+	case keypadMultiply
+	case keypadPlus
+}
+
+private let keyToSpecialKeyMapping: [KeyboardShortcuts.Key: SpecialKey] = [
+	.return: .return,
+	.delete: .delete,
+	.deleteForward: .deleteForward,
+	.end: .end,
+	.escape: .escape,
+	.help: .help,
+	.home: .home,
+	.space: .space,
+	.tab: .tab,
+	.pageUp: .pageUp,
+	.pageDown: .pageDown,
+	.upArrow: .upArrow,
+	.rightArrow: .rightArrow,
+	.downArrow: .downArrow,
+	.leftArrow: .leftArrow,
+	.f1: .f1,
+	.f2: .f2,
+	.f3: .f3,
+	.f4: .f4,
+	.f5: .f5,
+	.f6: .f6,
+	.f7: .f7,
+	.f8: .f8,
+	.f9: .f9,
+	.f10: .f10,
+	.f11: .f11,
+	.f12: .f12,
+	.f13: .f13,
+	.f14: .f14,
+	.f15: .f15,
+	.f16: .f16,
+	.f17: .f17,
+	.f18: .f18,
+	.f19: .f19,
+	.f20: .f20,
+	.keypad0: .keypad0,
+	.keypad1: .keypad1,
+	.keypad2: .keypad2,
+	.keypad3: .keypad3,
+	.keypad4: .keypad4,
+	.keypad5: .keypad5,
+	.keypad6: .keypad6,
+	.keypad7: .keypad7,
+	.keypad8: .keypad8,
+	.keypad9: .keypad9,
+	.keypadClear: .keypadClear,
+	.keypadDecimal: .keypadDecimal,
+	.keypadDivide: .keypadDivide,
+	.keypadEnter: .keypadEnter,
+	.keypadEquals: .keypadEquals,
+	.keypadMinus: .keypadMinus,
+	.keypadMultiply: .keypadMultiply,
+	.keypadPlus: .keypadPlus
+]
+
+extension SpecialKey {
+	fileprivate var presentableDescription: String {
+		switch self {
+		case .return:
+			"↩"
+		case .delete:
+			"⌫"
+		case .deleteForward:
+			"⌦"
+		case .end:
+			"↘"
+		case .escape:
+			"⎋"
+		case .help:
+			"?⃝"
+		case .home:
+			"↖"
+		case .space:
+			"space_key".localized.capitalized // This matches what macOS uses.
+		case .tab:
+			"⇥"
+		case .pageUp:
+			"⇞"
+		case .pageDown:
+			"⇟"
+		case .upArrow:
+			"↑"
+		case .rightArrow:
+			"→"
+		case .downArrow:
+			"↓"
+		case .leftArrow:
+			"←"
+		case .f1:
+			"F1"
+		case .f2:
+			"F2"
+		case .f3:
+			"F3"
+		case .f4:
+			"F4"
+		case .f5:
+			"F5"
+		case .f6:
+			"F6"
+		case .f7:
+			"F7"
+		case .f8:
+			"F8"
+		case .f9:
+			"F9"
+		case .f10:
+			"F10"
+		case .f11:
+			"F11"
+		case .f12:
+			"F12"
+		case .f13:
+			"F13"
+		case .f14:
+			"F14"
+		case .f15:
+			"F15"
+		case .f16:
+			"F16"
+		case .f17:
+			"F17"
+		case .f18:
+			"F18"
+		case .f19:
+			"F19"
+		case .f20:
+			"F20"
+
+		// Representations for numeric keypad keys with   ⃣  Unicode U+20e3 'COMBINING ENCLOSING KEYCAP'
+		case .keypad0:
+			"0\u{20e3}"
+		case .keypad1:
+			"1\u{20e3}"
+		case .keypad2:
+			"2\u{20e3}"
+		case .keypad3:
+			"3\u{20e3}"
+		case .keypad4:
+			"4\u{20e3}"
+		case .keypad5:
+			"5\u{20e3}"
+		case .keypad6:
+			"6\u{20e3}"
+		case .keypad7:
+			"7\u{20e3}"
+		case .keypad8:
+			"8\u{20e3}"
+		case .keypad9:
+			"9\u{20e3}"
+		// There's "⌧“ 'X In A Rectangle Box' (U+2327), "☒" 'Ballot Box with X' (U+2612), "×" 'Multiplication Sign' (U+00d7), "⨯" 'Vector or Cross Product' (U+2a2f), or a plain small x. All combined symbols appear bigger.
+		case .keypadClear:
+			"☒\u{20e3}" // The combined symbol appears bigger than the other combined 'keycaps'
+		// TODO: Respect locale decimal separator ("." or ",")
+		case .keypadDecimal:
+			".\u{20e3}"
+		case .keypadDivide:
+			"/\u{20e3}"
+		// "⏎" 'Return Symbol' (U+23CE) but "↩" 'Leftwards Arrow with Hook' (U+00d7) seems to be more common on macOS.
+		case .keypadEnter:
+			"↩\u{20e3}" // The combined symbol appears bigger than the other combined 'keycaps'
+		case .keypadEquals:
+			"=\u{20e3}"
+		case .keypadMinus:
+			"-\u{20e3}"
+		case .keypadMultiply:
+			"*\u{20e3}"
+		case .keypadPlus:
+			"+\u{20e3}"
+		}
+	}
+
+	@available(macOS 11.0, *)
+	fileprivate var swiftUIKeyEquivalent: SwiftUI.KeyEquivalent? {
+		switch self {
+		case .return:
+			.return
+		case .delete:
+			.delete
+		case .deleteForward:
+			.deleteForward
+		case .end:
+			.end
+		case .escape:
+			.escape
+		case .help:
+			KeyEquivalent(unicodeScalarValue: NSHelpFunctionKey)
+		case .home:
+			.home
+		case .space:
+			.space
+		case .tab:
+			.tab
+		case .pageUp:
+			.pageUp
+		case .pageDown:
+			.pageDown
+		case .upArrow:
+			.upArrow
+		case .rightArrow:
+			.rightArrow
+		case .downArrow:
+			.downArrow
+		case .leftArrow:
+			.leftArrow
+		case .f1:
+			KeyEquivalent(unicodeScalarValue: NSF1FunctionKey)
+		case .f2:
+			KeyEquivalent(unicodeScalarValue: NSF2FunctionKey)
+		case .f3:
+			KeyEquivalent(unicodeScalarValue: NSF3FunctionKey)
+		case .f4:
+			KeyEquivalent(unicodeScalarValue: NSF4FunctionKey)
+		case .f5:
+			KeyEquivalent(unicodeScalarValue: NSF5FunctionKey)
+		case .f6:
+			KeyEquivalent(unicodeScalarValue: NSF6FunctionKey)
+		case .f7:
+			KeyEquivalent(unicodeScalarValue: NSF7FunctionKey)
+		case .f8:
+			KeyEquivalent(unicodeScalarValue: NSF8FunctionKey)
+		case .f9:
+			KeyEquivalent(unicodeScalarValue: NSF9FunctionKey)
+		case .f10:
+			KeyEquivalent(unicodeScalarValue: NSF10FunctionKey)
+		case .f11:
+			KeyEquivalent(unicodeScalarValue: NSF11FunctionKey)
+		case .f12:
+			KeyEquivalent(unicodeScalarValue: NSF12FunctionKey)
+		case .f13:
+			KeyEquivalent(unicodeScalarValue: NSF13FunctionKey)
+		case .f14:
+			KeyEquivalent(unicodeScalarValue: NSF14FunctionKey)
+		case .f15:
+			KeyEquivalent(unicodeScalarValue: NSF15FunctionKey)
+		case .f16:
+			KeyEquivalent(unicodeScalarValue: NSF16FunctionKey)
+		case .f17:
+			KeyEquivalent(unicodeScalarValue: NSF17FunctionKey)
+		case .f18:
+			KeyEquivalent(unicodeScalarValue: NSF18FunctionKey)
+		case .f19:
+			KeyEquivalent(unicodeScalarValue: NSF19FunctionKey)
+		case .f20:
+			KeyEquivalent(unicodeScalarValue: NSF20FunctionKey)
+		// Neither the " ⃣" enclosed characters (e.g. "7⃣") nor regular
+		// characters with the `.numpad` modifier produce `SwiftUI` buttons that
+		// will capture the only the number pad's keys (last checked: MacOS 14).
+		// Return `nil` to prevent definition of incorrect shortcuts.
+		case .keypad0:
+			nil
+		case .keypad1:
+			nil
+		case .keypad2:
+			nil
+		case .keypad3:
+			nil
+		case .keypad4:
+			nil
+		case .keypad5:
+			nil
+		case .keypad6:
+			nil
+		case .keypad7:
+			nil
+		case .keypad8:
+			nil
+		case .keypad9:
+			nil
+		case .keypadClear:
+			nil
+		case .keypadDecimal:
+			nil
+		case .keypadDivide:
+			nil
+		case .keypadEnter:
+			nil
+		case .keypadEquals:
+			nil
+		case .keypadMinus:
+			nil
+		case .keypadMultiply:
+			nil
+		case .keypadPlus:
+			nil
+		}
+	}
+
+	fileprivate var appKitMenuItemKeyEquivalent: Character? {
+		switch self {
+		case .return:
+			"↩"
+		case .delete:
+			"⌫"
+		case .deleteForward:
+			"⌦"
+		case .end:
+			"↘"
+		case .escape:
+			"⎋"
+		case .help:
+			"?⃝"
+		case .home:
+			"↖"
+		case .space:
+			"\u{0020}"
+		case .tab:
+			"⇥"
+		case .pageUp:
+			"⇞"
+		case .pageDown:
+			"⇟"
+		case .upArrow:
+			"↑"
+		case .rightArrow:
+			"→"
+		case .downArrow:
+			"↓"
+		case .leftArrow:
+			"←"
+		case .f1:
+			Character(unicodeScalarValue: NSF1FunctionKey)
+		case .f2:
+			Character(unicodeScalarValue: NSF2FunctionKey)
+		case .f3:
+			Character(unicodeScalarValue: NSF3FunctionKey)
+		case .f4:
+			Character(unicodeScalarValue: NSF4FunctionKey)
+		case .f5:
+			Character(unicodeScalarValue: NSF5FunctionKey)
+		case .f6:
+			Character(unicodeScalarValue: NSF6FunctionKey)
+		case .f7:
+			Character(unicodeScalarValue: NSF7FunctionKey)
+		case .f8:
+			Character(unicodeScalarValue: NSF8FunctionKey)
+		case .f9:
+			Character(unicodeScalarValue: NSF9FunctionKey)
+		case .f10:
+			Character(unicodeScalarValue: NSF10FunctionKey)
+		case .f11:
+			Character(unicodeScalarValue: NSF11FunctionKey)
+		case .f12:
+			Character(unicodeScalarValue: NSF12FunctionKey)
+		case .f13:
+			Character(unicodeScalarValue: NSF13FunctionKey)
+		case .f14:
+			Character(unicodeScalarValue: NSF14FunctionKey)
+		case .f15:
+			Character(unicodeScalarValue: NSF15FunctionKey)
+		case .f16:
+			Character(unicodeScalarValue: NSF16FunctionKey)
+		case .f17:
+			Character(unicodeScalarValue: NSF17FunctionKey)
+		case .f18:
+			Character(unicodeScalarValue: NSF18FunctionKey)
+		case .f19:
+			Character(unicodeScalarValue: NSF19FunctionKey)
+		case .f20:
+			Character(unicodeScalarValue: NSF20FunctionKey)
+		// Neither the " ⃣" enclosed characters (e.g. "7⃣") nor regular
+		// characters with the `.numericPad` modifier produce a `MenuItem` that
+		// will capture the only the number pad's keys (last checked: MacOS 14).
+		// Return `nil` to prevent definition of incorrect shortcuts.
+		case .keypad0:
+			nil
+		case .keypad1:
+			nil
+		case .keypad2:
+			nil
+		case .keypad3:
+			nil
+		case .keypad4:
+			nil
+		case .keypad5:
+			nil
+		case .keypad6:
+			nil
+		case .keypad7:
+			nil
+		case .keypad8:
+			nil
+		case .keypad9:
+			nil
+		case .keypadClear:
+			nil
+		case .keypadDecimal:
+			nil
+		case .keypadDivide:
+			nil
+		case .keypadEnter:
+			nil
+		case .keypadEquals:
+			nil
+		case .keypadMinus:
+			nil
+		case .keypadMultiply:
+			nil
+		case .keypadPlus:
+			nil
+		}
+	}
+}
+
+extension KeyboardShortcuts.Shortcut {
+	@MainActor // `TISGetInputSourceProperty` crashes if called on a non-main thread.
+	fileprivate func keyToCharacter() -> Character? {
+		guard
+			let source = TISCopyCurrentASCIICapableKeyboardLayoutInputSource()?.takeRetainedValue(),
+			let layoutDataPointer = TISGetInputSourceProperty(source, kTISPropertyUnicodeKeyLayoutData)
+		else {
+			return nil
+		}
+
+		guard key.flatMap({ keyToSpecialKeyMapping[$0] }) == nil else {
+			assertionFailure("Special keys should get special treatment and should not be translated using keyToCharacter()")
+			return nil
+		}
+
+		let layoutData = unsafeBitCast(layoutDataPointer, to: CFData.self)
+		let keyLayout = unsafeBitCast(CFDataGetBytePtr(layoutData), to: UnsafePointer<CoreServices.UCKeyboardLayout>.self)
+		var deadKeyState: UInt32 = 0
+		let maxLength = 4
+		var length = 0
+		var characters = [UniChar](repeating: 0, count: maxLength)
+
+		let error = CoreServices.UCKeyTranslate(
+			keyLayout,
+			UInt16(carbonKeyCode),
+			UInt16(CoreServices.kUCKeyActionDisplay),
+			0, // No modifiers
+			UInt32(LMGetKbdType()),
+			OptionBits(CoreServices.kUCKeyTranslateNoDeadKeysBit),
+			&deadKeyState,
+			maxLength,
+			&length,
+			&characters
+		)
+
+		guard error == noErr else {
+			return nil
+		}
+
+		let string = String(utf16CodeUnits: characters, count: length)
+		if string.count == 1 {
+			return string.first
+		}
+
+		return nil
+	}
+
+	/**
+	Key equivalent string in `NSMenuItem` format.
+
+	This can be used to show the keyboard shortcut in a `NSMenuItem` by assigning it to `NSMenuItem#keyEquivalent`.
+
+	- Note: Don't forget to also pass ``Shortcut/modifiers`` to `NSMenuItem#keyEquivalentModifierMask`.
+	*/
+	@MainActor
+	public var nsMenuItemKeyEquivalent: String? {
+		if
+			let key,
+			let specialKey = keyToSpecialKeyMapping[key]
+		{
+			if let keyEquivalent = specialKey.appKitMenuItemKeyEquivalent {
+				return String(keyEquivalent)
+			}
+		} else if let character = keyToCharacter() {
+			return String(character)
+		}
+
+		return nil
+	}
+}
+
+extension KeyboardShortcuts.Shortcut: CustomStringConvertible {
+	/**
+	The string representation of the keyboard shortcut.
+
+	```swift
+	print(KeyboardShortcuts.Shortcut(.a, modifiers: [.command]))
+	//=> "⌘A"
+	```
+	*/
+
+	@MainActor
+	var presentableDescription: String {
+		if
+			let key,
+			let specialKey = keyToSpecialKeyMapping[key]
+		{
+			return modifiers.ks_symbolicRepresentation + specialKey.presentableDescription
+		}
+
+		return modifiers.ks_symbolicRepresentation + String(keyToCharacter() ?? "�").capitalized
+	}
+
+	@MainActor
+	public var description: String {
+		// TODO: `description` needs to be `nonisolated`
+		presentableDescription
+	}
+}
+
+extension KeyboardShortcuts.Shortcut {
+	@available(macOS 11, *)
+	@MainActor
+	var toSwiftUI: KeyboardShortcut? {
+		if
+			let key,
+			let specialKey = keyToSpecialKeyMapping[key]
+		{
+			if let keyEquivalent = specialKey.swiftUIKeyEquivalent {
+				if #available(macOS 12.0, *) {
+					// We do `localization: .custom)` since the KeyboardShortcuts shortcuts are not localized.
+					return KeyboardShortcut(keyEquivalent, modifiers: modifiers.toEventModifiers, localization: .custom)
+				} else {
+					return KeyboardShortcut(keyEquivalent, modifiers: modifiers.toEventModifiers)
+				}
+			}
+		} else if let character = keyToCharacter() {
+			if #available(macOS 12.0, *) {
+				return KeyboardShortcut(KeyEquivalent(character), modifiers: modifiers.toEventModifiers, localization: .custom)
+			} else {
+				return KeyboardShortcut(KeyEquivalent(character), modifiers: modifiers.toEventModifiers)
+			}
+		}
+
+		return nil
+	}
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/Utilities.swift
@@ -1,0 +1,588 @@
+import SwiftUI
+
+#if os(macOS)
+import Carbon.HIToolbox
+
+
+extension String {
+	/**
+	Makes the string localizable.
+	*/
+	var localized: String {
+		NSLocalizedString(self, bundle: .module, comment: self)
+	}
+}
+
+
+extension Data {
+	var toString: String? { String(data: self, encoding: .utf8) }
+}
+
+
+extension NSEvent {
+	var isKeyEvent: Bool { type == .keyDown || type == .keyUp }
+}
+
+
+extension NSTextField {
+	func hideCaret() {
+		(currentEditor() as? NSTextView)?.insertionPointColor = .clear
+	}
+
+	func restoreCaret() {
+		(currentEditor() as? NSTextView)?.insertionPointColor = .labelColor
+	}
+}
+
+
+extension NSView {
+	func focus() {
+		window?.makeFirstResponder(self)
+	}
+
+	func blur() {
+		window?.makeFirstResponder(nil)
+	}
+}
+
+
+/**
+Listen to local events.
+
+- Important: Don't forget to call `.start()`.
+
+```swift
+eventMonitor = LocalEventMonitor(events: [.leftMouseDown, .rightMouseDown]) { event in
+	// Do something
+
+	return event
+}
+.start()
+```
+*/
+final class LocalEventMonitor {
+	private let events: NSEvent.EventTypeMask
+	private let callback: (NSEvent) -> NSEvent?
+	// Must be a STRONG reference. `NSEvent.addLocalMonitorForEvents` hands back an autoreleased
+	// token that the caller is required to own until it passes it to `removeMonitor`. Held
+	// weakly, nothing retains it, so it dies when the autorelease pool drains at the end of the
+	// current event-loop turn — taking the monitor with it. The recorder then looks focused but
+	// captures nothing, and keystrokes fall through to the search field as plain text.
+	// Upstream: https://github.com/sindresorhus/KeyboardShortcuts/issues/241 (defect 1).
+	private var monitor: AnyObject?
+
+	init(events: NSEvent.EventTypeMask, callback: @escaping (NSEvent) -> NSEvent?) {
+		self.events = events
+		self.callback = callback
+	}
+
+	deinit {
+		stop()
+	}
+
+	@discardableResult
+	func start() -> Self {
+		monitor = NSEvent.addLocalMonitorForEvents(matching: events, handler: callback) as AnyObject
+		return self
+	}
+
+	func stop() {
+		guard let monitor else {
+			return
+		}
+
+		NSEvent.removeMonitor(monitor)
+		// Clear the token so `stop()` is idempotent — with the strong reference above,
+		// `deinit` would otherwise pass the same token to `removeMonitor` a second time.
+		self.monitor = nil
+	}
+}
+
+
+final class RunLoopLocalEventMonitor {
+	private let runLoopMode: RunLoop.Mode
+	private let callback: (NSEvent) -> NSEvent?
+	private let observer: CFRunLoopObserver
+
+	init(
+		events: NSEvent.EventTypeMask,
+		runLoopMode: RunLoop.Mode,
+		callback: @escaping (NSEvent) -> NSEvent?
+	) {
+		self.runLoopMode = runLoopMode
+		self.callback = callback
+
+		self.observer = CFRunLoopObserverCreateWithHandler(nil, CFRunLoopActivity.beforeSources.rawValue, true, 0) { _, _ in
+			// Pull all events from the queue and handle the ones matching the given types.
+			// Non-matching events are left untouched, maintaining their order in the queue.
+
+			var eventsToHandle = [NSEvent]()
+
+			// Retrieve all events from the event queue to preserve their order (instead of using the `matching` parameter).
+			while let eventToHandle = NSApp.nextEvent(matching: .any, until: nil, inMode: .default, dequeue: true) {
+				eventsToHandle.append(eventToHandle)
+			}
+
+			// Iterate over the gathered events, instead of doing it directly in the `while` loop, to avoid potential infinite loops caused by re-retrieving undiscarded events.
+			for eventToHandle in eventsToHandle {
+				var handledEvent: NSEvent?
+
+				if !events.contains(NSEvent.EventTypeMask(rawValue: 1 << eventToHandle.type.rawValue)) {
+					handledEvent = eventToHandle
+				} else if let callbackEvent = callback(eventToHandle) {
+					handledEvent = callbackEvent
+				}
+
+				guard let handledEvent else {
+					continue
+				}
+
+				NSApp.postEvent(handledEvent, atStart: false)
+			}
+		}
+	}
+
+	deinit {
+		stop()
+	}
+
+	@discardableResult
+	func start() -> Self {
+		CFRunLoopAddObserver(RunLoop.current.getCFRunLoop(), observer, CFRunLoopMode(runLoopMode.rawValue as CFString))
+		return self
+	}
+
+	func stop() {
+		CFRunLoopRemoveObserver(RunLoop.current.getCFRunLoop(), observer, CFRunLoopMode(runLoopMode.rawValue as CFString))
+	}
+}
+
+
+extension NSEvent {
+	private static func normalizedModifiers(from flags: ModifierFlags) -> ModifierFlags {
+		flags
+			.intersection(.deviceIndependentFlagsMask)
+			// We remove `capsLock` as it shouldn't affect the modifiers.
+			// We remove `numericPad` as arrow keys trigger it, use `event.specialKeys` instead.
+			.subtracting([.capsLock, .numericPad])
+	}
+
+	static var modifiers: ModifierFlags {
+		normalizedModifiers(from: modifierFlags)
+	}
+
+	/**
+	Real modifiers.
+
+	- Note: Prefer this over `.modifierFlags`.
+
+	```swift
+	// Check if Command is one of possible more modifiers keys
+	event.modifiers.contains(.command)
+
+	// Check if Command is the only modifier key
+	event.modifiers == .command
+
+	// Check if Command and Shift are the only modifiers
+	event.modifiers == [.command, .shift]
+	```
+	*/
+	var modifiers: ModifierFlags {
+		Self.normalizedModifiers(from: modifierFlags)
+	}
+}
+
+
+extension NSSearchField {
+	/**
+	Clear the search field.
+	*/
+	func clear() {
+		(cell as? NSSearchFieldCell)?.cancelButtonCell?.performClick(self)
+	}
+}
+
+
+extension NSAlert {
+	/**
+	Show an alert as a window-modal sheet, or as an app-modal (window-independent) alert if the window is `nil` or not given.
+	*/
+	@discardableResult
+	static func showModal(
+		for window: NSWindow? = nil,
+		title: String,
+		message: String? = nil,
+		style: Style = .warning,
+		icon: NSImage? = nil,
+		buttonTitles: [String] = []
+	) -> NSApplication.ModalResponse {
+		NSAlert(
+			title: title,
+			message: message,
+			style: style,
+			icon: icon,
+			buttonTitles: buttonTitles
+		).runModal(for: window)
+	}
+
+	convenience init(
+		title: String,
+		message: String? = nil,
+		style: Style = .warning,
+		icon: NSImage? = nil,
+		buttonTitles: [String] = []
+	) {
+		self.init()
+		self.messageText = title
+		self.alertStyle = style
+		self.icon = icon
+
+		for buttonTitle in buttonTitles {
+			addButton(withTitle: buttonTitle)
+		}
+
+		if let message {
+			self.informativeText = message
+		}
+	}
+
+	/**
+	Runs the alert as a window-modal sheet, or as an app-modal (window-independent) alert if the window is `nil` or not given.
+	*/
+	@discardableResult
+	func runModal(for window: NSWindow? = nil) -> NSApplication.ModalResponse {
+		guard let window else {
+			return runModal()
+		}
+
+		beginSheetModal(for: window) { returnCode in
+			NSApp.stopModal(withCode: returnCode)
+		}
+
+		return NSApp.runModal(for: window)
+	}
+}
+
+
+enum UnicodeSymbols {
+	/**
+	Represents the Function (Fn) key on the keybord.
+	*/
+	static let functionKey = "🌐\u{FE0E}"
+}
+
+
+extension NSEvent.ModifierFlags {
+	// Not documented anywhere, but reverse-engineered by me.
+	private static let functionKey = 1 << 17 // 131072 (0x20000)
+
+	var carbon: Int {
+		var modifierFlags = 0
+
+		if contains(.control) {
+			modifierFlags |= controlKey
+		}
+
+		if contains(.option) {
+			modifierFlags |= optionKey
+		}
+
+		if contains(.shift) {
+			modifierFlags |= shiftKey
+		}
+
+		if contains(.command) {
+			modifierFlags |= cmdKey
+		}
+
+		if contains(.function) {
+			modifierFlags |= Self.functionKey
+		}
+
+		return modifierFlags
+	}
+
+	init(carbon: Int) {
+		self.init()
+
+		if carbon & controlKey == controlKey {
+			insert(.control)
+		}
+
+		if carbon & optionKey == optionKey {
+			insert(.option)
+		}
+
+		if carbon & shiftKey == shiftKey {
+			insert(.shift)
+		}
+
+		if carbon & cmdKey == cmdKey {
+			insert(.command)
+		}
+
+		if carbon & Self.functionKey == Self.functionKey {
+			insert(.function)
+		}
+	}
+}
+
+extension SwiftUI.EventModifiers {
+	// `.function` is deprecated, so we use the raw value.
+	fileprivate static let function_nonDeprecated = Self(rawValue: 64)
+}
+
+extension NSEvent.ModifierFlags {
+	var toEventModifiers: SwiftUI.EventModifiers {
+		var modifiers = SwiftUI.EventModifiers()
+
+		if contains(.capsLock) {
+			modifiers.insert(.capsLock)
+		}
+
+		if contains(.command) {
+			modifiers.insert(.command)
+		}
+
+		if contains(.control) {
+			modifiers.insert(.control)
+		}
+
+		if contains(.numericPad) {
+			modifiers.insert(.numericPad)
+		}
+
+		if contains(.option) {
+			modifiers.insert(.option)
+		}
+
+		if contains(.shift) {
+			modifiers.insert(.shift)
+		}
+
+		if contains(.function) {
+			modifiers.insert(.function_nonDeprecated)
+		}
+
+		return modifiers
+	}
+}
+
+extension NSEvent.ModifierFlags {
+	/**
+	The string representation of the modifier flags.
+
+	```swift
+	print(NSEvent.ModifierFlags([.command, .shift]).presentableDescription)
+	//=> "⇧⌘"
+	```
+	*/
+	@available(*, deprecated, renamed: "ks_symbolicRepresentation")
+	var presentableDescription: String {
+		ks_symbolicRepresentation
+	}
+}
+
+
+extension NSEvent.ModifierFlags {
+	/**
+	The symbolic representation of the modifier flags.
+
+	```swift
+	let modifiers = NSEvent.ModifierFlags([.command, .shift])
+	print(modifiers.ks_symbolicRepresentation)
+	//=> "⇧⌘"
+	```
+	*/
+	public var ks_symbolicRepresentation: String {
+		var description = ""
+
+		if contains(.control) {
+			description += "⌃"
+		}
+
+		if contains(.option) {
+			description += "⌥"
+		}
+
+		if contains(.shift) {
+			description += "⇧"
+		}
+
+		if contains(.command) {
+			description += "⌘"
+		}
+
+		if contains(.function) {
+			description += UnicodeSymbols.functionKey
+		}
+
+		return description
+	}
+}
+
+
+extension NSEvent.SpecialKey {
+	static let functionKeys: Set<Self> = [
+		.f1,
+		.f2,
+		.f3,
+		.f4,
+		.f5,
+		.f6,
+		.f7,
+		.f8,
+		.f9,
+		.f10,
+		.f11,
+		.f12,
+		.f13,
+		.f14,
+		.f15,
+		.f16,
+		.f17,
+		.f18,
+		.f19,
+		.f20,
+		.f21,
+		.f22,
+		.f23,
+		.f24,
+		.f25,
+		.f26,
+		.f27,
+		.f28,
+		.f29,
+		.f30,
+		.f31,
+		.f32,
+		.f33,
+		.f34,
+		.f35
+	]
+
+	var isFunctionKey: Bool { Self.functionKeys.contains(self) }
+}
+
+
+enum AssociationPolicy {
+	case assign
+	case retainNonatomic
+	case copyNonatomic
+	case retain
+	case copy
+
+	var rawValue: objc_AssociationPolicy {
+		switch self {
+		case .assign:
+			.OBJC_ASSOCIATION_ASSIGN
+		case .retainNonatomic:
+			.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+		case .copyNonatomic:
+			.OBJC_ASSOCIATION_COPY_NONATOMIC
+		case .retain:
+			.OBJC_ASSOCIATION_RETAIN
+		case .copy:
+			.OBJC_ASSOCIATION_COPY
+		}
+	}
+}
+
+final class ObjectAssociation<T> {
+	private let policy: AssociationPolicy
+
+	init(policy: AssociationPolicy = .retainNonatomic) {
+		self.policy = policy
+	}
+
+	subscript(index: AnyObject) -> T? {
+		get {
+			// Force-cast is fine here as we want it to fail loudly if we don't use the correct type.
+			// swiftlint:disable:next force_cast
+			objc_getAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque()) as! T?
+		}
+		set {
+			objc_setAssociatedObject(index, Unmanaged.passUnretained(self).toOpaque(), newValue, policy.rawValue)
+		}
+	}
+}
+
+
+extension HorizontalAlignment {
+	private enum ControlAlignment: AlignmentID {
+		static func defaultValue(in context: ViewDimensions) -> CGFloat { // swiftlint:disable:this no_cgfloat
+			context[HorizontalAlignment.center]
+		}
+	}
+
+	fileprivate static let controlAlignment = Self(ControlAlignment.self)
+}
+
+extension View {
+	func formLabel(@ViewBuilder _ label: () -> some View) -> some View {
+		HStack(alignment: .firstTextBaseline) {
+			label()
+			labelsHidden()
+				.alignmentGuide(.controlAlignment) { $0[.leading] }
+		}
+		.alignmentGuide(.leading) { $0[.controlAlignment] }
+	}
+}
+
+
+extension Dictionary {
+	func hasKey(_ key: Key) -> Bool {
+		index(forKey: key) != nil
+	}
+}
+#endif
+
+
+@available(iOS 14.0, *)
+@available(macOS 11.0, *)
+extension KeyEquivalent {
+	init?(unicodeScalarValue value: Int) {
+		guard let character = Character(unicodeScalarValue: value) else {
+			return nil
+		}
+
+		self = KeyEquivalent(character)
+	}
+}
+
+
+extension Sequence where Element: Hashable {
+	/**
+	Convert a `Sequence` with `Hashable` elements to a `Set`.
+	*/
+	func toSet() -> Set<Element> { Set(self) }
+}
+
+
+extension Set {
+	/**
+	Convert a `Set` to an `Array`.
+	*/
+	func toArray() -> [Element] { Array(self) }
+}
+
+
+extension StringProtocol {
+	func replacingPrefix(_ prefix: String, with replacement: String) -> String {
+		guard hasPrefix(prefix) else {
+			return String(self)
+		}
+
+		return replacement + dropFirst(prefix.count)
+	}
+}
+
+extension Character {
+	init?(unicodeScalarValue value: Int) {
+		guard let content = UnicodeScalar(value) else {
+			return nil
+		}
+
+		self = Character(content)
+	}
+}

--- a/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/ViewModifiers.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Sources/KeyboardShortcuts/ViewModifiers.swift
@@ -1,0 +1,121 @@
+#if os(macOS)
+import SwiftUI
+
+@available(macOS 12, *)
+extension View {
+	/**
+	Renamed to `onGlobalKeyboardShortcut`.
+	*/
+	@available(*, deprecated, renamed: "onGlobalKeyboardShortcut")
+	public func onKeyboardShortcut(
+		_ shortcut: KeyboardShortcuts.Name,
+		perform: @escaping (KeyboardShortcuts.EventType) -> Void
+	) -> some View {
+		task {
+			for await eventType in KeyboardShortcuts.events(for: shortcut) {
+				perform(eventType)
+			}
+		}
+	}
+
+	/**
+	Renamed to `onGlobalKeyboardShortcut`.
+	*/
+	@available(*, deprecated, renamed: "onGlobalKeyboardShortcut")
+	public func onKeyboardShortcut(
+		_ shortcut: KeyboardShortcuts.Name,
+		type: KeyboardShortcuts.EventType,
+		perform: @escaping () -> Void
+	) -> some View {
+		task {
+			for await _ in KeyboardShortcuts.events(type, for: shortcut) {
+				perform()
+			}
+		}
+	}
+}
+
+@available(macOS 12, *)
+extension View {
+	/**
+	Register a listener for keyboard shortcut events with the given name.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	The listener will stop automatically when the view disappears.
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
+	public func onGlobalKeyboardShortcut(
+		_ shortcut: KeyboardShortcuts.Name,
+		perform: @escaping (KeyboardShortcuts.EventType) -> Void
+	) -> some View {
+		task {
+			for await eventType in KeyboardShortcuts.events(for: shortcut) {
+				perform(eventType)
+			}
+		}
+	}
+
+	/**
+	Register a listener for keyboard shortcut events with the given name and type.
+
+	You can safely call this even if the user has not yet set a keyboard shortcut. It will just be inactive until they do.
+
+	The listener will stop automatically when the view disappears.
+
+	- Note: This method is not affected by `.removeAllHandlers()`.
+	*/
+	public func onGlobalKeyboardShortcut(
+		_ shortcut: KeyboardShortcuts.Name,
+		type: KeyboardShortcuts.EventType,
+		perform: @escaping () -> Void
+	) -> some View {
+		task {
+			for await _ in KeyboardShortcuts.events(type, for: shortcut) {
+				perform()
+			}
+		}
+	}
+}
+
+@available(macOS 12.3, *)
+extension View {
+	/**
+	Associates a global keyboard shortcut with a control.
+
+	This is mostly useful to have the keyboard shortcut show for a `Button` in a `Menu` or `MenuBarExtra`.
+
+	It does not trigger the control's action.
+
+	- Important: Do not use it in a `CommandGroup` as the shortcut recorder will think the shortcut is already taken. It does remove the shortcut while the recorder is active, but because of a bug in macOS 15, the state is not reflected correctly in the underlying menu item.
+	*/
+	public func globalKeyboardShortcut(_ name: KeyboardShortcuts.Name) -> some View {
+		modifier(GlobalKeyboardShortcutViewModifier(name: name))
+	}
+}
+
+@available(macOS 12.3, *)
+private struct GlobalKeyboardShortcutViewModifier: ViewModifier {
+	@State private var isRecorderActive = false
+	@State private var triggerRefresh = false
+
+	let name: KeyboardShortcuts.Name
+
+	func body(content: Content) -> some View {
+		content
+			.keyboardShortcut(isRecorderActive ? nil : name.shortcut?.toSwiftUI)
+			.id(triggerRefresh)
+			.onReceive(NotificationCenter.default.publisher(for: .shortcutByNameDidChange)) {
+				guard $0.userInfo?["name"] as? KeyboardShortcuts.Name == name else {
+					return
+				}
+
+				triggerRefresh.toggle()
+			}
+			.onReceive(NotificationCenter.default.publisher(for: .recorderActiveStatusDidChange)) {
+				isRecorderActive = $0.userInfo?["isActive"] as? Bool ?? false
+			}
+	}
+}
+#endif

--- a/app/macos/Vendor/KeyboardShortcuts/Tests/KeyboardShortcutsTests/KeyboardShortcutsTests.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Tests/KeyboardShortcutsTests/KeyboardShortcutsTests.swift
@@ -1,0 +1,319 @@
+import Testing
+import Foundation
+import AppKit
+import KeyboardShortcuts
+
+@Suite("KeyboardShortcuts Tests", .serialized)
+struct KeyboardShortcutsTests {
+	init() {
+		UserDefaults.standard.removeAllKeyboardShortcuts()
+	}
+
+	@Test("Set shortcut and reset")
+	func testSetShortcutAndReset() throws {
+		let defaultShortcut = KeyboardShortcuts.Shortcut(.c)
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a)
+		let shortcut2 = KeyboardShortcuts.Shortcut(.b)
+
+		let shortcutName1 = KeyboardShortcuts.Name("testSetShortcutAndReset1")
+		let shortcutName2 = KeyboardShortcuts.Name("testSetShortcutAndReset2", default: defaultShortcut)
+
+		KeyboardShortcuts.setShortcut(shortcut1, for: shortcutName1)
+		KeyboardShortcuts.setShortcut(shortcut2, for: shortcutName2)
+
+		#expect(KeyboardShortcuts.getShortcut(for: shortcutName1) == shortcut1)
+		#expect(KeyboardShortcuts.getShortcut(for: shortcutName2) == shortcut2)
+
+		KeyboardShortcuts.reset(shortcutName1, shortcutName2)
+
+		#expect(KeyboardShortcuts.getShortcut(for: shortcutName1) == nil)
+		#expect(KeyboardShortcuts.getShortcut(for: shortcutName2) == defaultShortcut)
+	}
+
+	@Test("Shortcut creation")
+	func testShortcutCreation() throws {
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a)
+		let shortcut2 = KeyboardShortcuts.Shortcut(.a, modifiers: [.command])
+		let shortcut3 = KeyboardShortcuts.Shortcut(.a, modifiers: [.command, .shift])
+
+		#expect(shortcut1.key == .a)
+		#expect(shortcut1.modifiers == [])
+
+		#expect(shortcut2.key == .a)
+		#expect(shortcut2.modifiers == [.command])
+
+		#expect(shortcut3.key == .a)
+		#expect(shortcut3.modifiers == [.command, .shift])
+	}
+
+	@Test("Shortcut equality")
+	func testShortcutEquality() throws {
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a, modifiers: [.command])
+		let shortcut2 = KeyboardShortcuts.Shortcut(.a, modifiers: [.command])
+		let shortcut3 = KeyboardShortcuts.Shortcut(.b, modifiers: [.command])
+		let shortcut4 = KeyboardShortcuts.Shortcut(.a, modifiers: [.option])
+
+		#expect(shortcut1 == shortcut2)
+		#expect(shortcut1 != shortcut3)
+		#expect(shortcut1 != shortcut4)
+
+		// Test hashability
+		let set = Set([shortcut1, shortcut2, shortcut3, shortcut4])
+		#expect(set.count == 3) // shortcut1 and shortcut2 are equal
+	}
+
+	@Test("Name equality")
+	func testNameEquality() throws {
+		let name1 = KeyboardShortcuts.Name("test")
+		let name2 = KeyboardShortcuts.Name("test")
+		let name3 = KeyboardShortcuts.Name("different")
+
+		#expect(name1 == name2)
+		#expect(name1 != name3)
+	}
+
+	@Test("Name with default")
+	func testNameWithDefault() throws {
+		let defaultShortcut = KeyboardShortcuts.Shortcut(.space)
+		let name = KeyboardShortcuts.Name("testDefault", default: defaultShortcut)
+
+		// Should return default when no value is set
+		#expect(KeyboardShortcuts.getShortcut(for: name) == defaultShortcut)
+
+		// Setting a value should override the default
+		let customShortcut = KeyboardShortcuts.Shortcut(.tab)
+		KeyboardShortcuts.setShortcut(customShortcut, for: name)
+		#expect(KeyboardShortcuts.getShortcut(for: name) == customShortcut)
+
+		// Resetting should restore the default
+		KeyboardShortcuts.reset(name)
+		#expect(KeyboardShortcuts.getShortcut(for: name) == defaultShortcut)
+	}
+
+	@Test("Shortcut persistence")
+	func testShortcutPersistence() throws {
+		let name = KeyboardShortcuts.Name("persistenceTest")
+		let shortcut = KeyboardShortcuts.Shortcut(.f1, modifiers: [.command, .option])
+
+		KeyboardShortcuts.setShortcut(shortcut, for: name)
+		#expect(KeyboardShortcuts.getShortcut(for: name) == shortcut)
+
+		// Simulate app restart by creating new name with same identifier
+		let sameName = KeyboardShortcuts.Name("persistenceTest")
+		#expect(KeyboardShortcuts.getShortcut(for: sameName) == shortcut)
+	}
+
+	@Test("Multiple shortcuts")
+	func testMultipleShortcuts() throws {
+		let name1 = KeyboardShortcuts.Name("multi1")
+		let name2 = KeyboardShortcuts.Name("multi2")
+		let name3 = KeyboardShortcuts.Name("multi3")
+
+		let shortcut1 = KeyboardShortcuts.Shortcut(.a, modifiers: [.command])
+		let shortcut2 = KeyboardShortcuts.Shortcut(.b, modifiers: [.option])
+		let shortcut3 = KeyboardShortcuts.Shortcut(.c, modifiers: [.shift])
+
+		KeyboardShortcuts.setShortcut(shortcut1, for: name1)
+		KeyboardShortcuts.setShortcut(shortcut2, for: name2)
+		KeyboardShortcuts.setShortcut(shortcut3, for: name3)
+
+		#expect(KeyboardShortcuts.getShortcut(for: name1) == shortcut1)
+		#expect(KeyboardShortcuts.getShortcut(for: name2) == shortcut2)
+		#expect(KeyboardShortcuts.getShortcut(for: name3) == shortcut3)
+	}
+
+	@Test("Removing shortcuts")
+	func testRemovingShortcuts() throws {
+		let name = KeyboardShortcuts.Name("removeTest")
+		let shortcut = KeyboardShortcuts.Shortcut(.delete, modifiers: [.command])
+
+		KeyboardShortcuts.setShortcut(shortcut, for: name)
+		#expect(KeyboardShortcuts.getShortcut(for: name) == shortcut)
+
+		KeyboardShortcuts.setShortcut(nil, for: name)
+		#expect(KeyboardShortcuts.getShortcut(for: name) == nil)
+	}
+
+	@Test("Empty modifiers")
+	func testEmptyModifiers() throws {
+		let shortcut = KeyboardShortcuts.Shortcut(.a, modifiers: [])
+		#expect(shortcut.modifiers.isEmpty)
+		#expect(shortcut.modifiers.ks_symbolicRepresentation == "")
+	}
+
+	@Test("Function keys")
+	func testFunctionKeys() throws {
+		let f1 = KeyboardShortcuts.Shortcut(.f1)
+		let f12 = KeyboardShortcuts.Shortcut(.f12)
+		let f20 = KeyboardShortcuts.Shortcut(.f20)
+
+		#expect(f1.key == .f1)
+		#expect(f12.key == .f12)
+		#expect(f20.key == .f20)
+	}
+
+	@Test("Special keys")
+	func testSpecialKeys() throws {
+		let space = KeyboardShortcuts.Shortcut(.space)
+		let tab = KeyboardShortcuts.Shortcut(.tab)
+		let escape = KeyboardShortcuts.Shortcut(.escape)
+		let delete = KeyboardShortcuts.Shortcut(.delete)
+		let returnKey = KeyboardShortcuts.Shortcut(.return)
+
+		#expect(space.key == .space)
+		#expect(tab.key == .tab)
+		#expect(escape.key == .escape)
+		#expect(delete.key == .delete)
+		#expect(returnKey.key == .return)
+	}
+
+	@Test("Keypad keys")
+	func testKeypadKeys() throws {
+		let keypad0 = KeyboardShortcuts.Shortcut(.keypad0)
+		let keypad9 = KeyboardShortcuts.Shortcut(.keypad9)
+		let keypadPlus = KeyboardShortcuts.Shortcut(.keypadPlus)
+		let keypadEnter = KeyboardShortcuts.Shortcut(.keypadEnter)
+
+		#expect(keypad0.key == .keypad0)
+		#expect(keypad9.key == .keypad9)
+		#expect(keypadPlus.key == .keypadPlus)
+		#expect(keypadEnter.key == .keypadEnter)
+	}
+
+	@Test("Arrow keys")
+	func testArrowKeys() throws {
+		let up = KeyboardShortcuts.Shortcut(.upArrow, modifiers: [.command])
+		let down = KeyboardShortcuts.Shortcut(.downArrow, modifiers: [.command])
+		let left = KeyboardShortcuts.Shortcut(.leftArrow, modifiers: [.command])
+		let right = KeyboardShortcuts.Shortcut(.rightArrow, modifiers: [.command])
+
+		#expect(up.key == .upArrow)
+		#expect(down.key == .downArrow)
+		#expect(left.key == .leftArrow)
+		#expect(right.key == .rightArrow)
+		#expect(up.modifiers == [.command])
+	}
+
+	@Test("Name identity")
+	func testNameIdentity() throws {
+		let name1 = KeyboardShortcuts.Name("sameName")
+		let name2 = KeyboardShortcuts.Name("sameName")
+		#expect(name1 == name2)
+		#expect(name1.hashValue == name2.hashValue)
+	}
+
+	@Test("Default values")
+	func testDefaultValues() throws {
+		let defaultShortcut = KeyboardShortcuts.Shortcut(.d, modifiers: [.command])
+		let nameWithDefault = KeyboardShortcuts.Name("withDefault", default: defaultShortcut)
+		let nameWithoutDefault = KeyboardShortcuts.Name("withoutDefault")
+
+		#expect(KeyboardShortcuts.getShortcut(for: nameWithDefault) == defaultShortcut)
+		#expect(KeyboardShortcuts.getShortcut(for: nameWithoutDefault) == nil)
+	}
+
+	@Test("Overriding defaults")
+	func testOverridingDefaults() throws {
+		let defaultShortcut = KeyboardShortcuts.Shortcut(.x, modifiers: [.control])
+		let name = KeyboardShortcuts.Name("override", default: defaultShortcut)
+
+		let newShortcut = KeyboardShortcuts.Shortcut(.y, modifiers: [.option])
+		KeyboardShortcuts.setShortcut(newShortcut, for: name)
+
+		#expect(KeyboardShortcuts.getShortcut(for: name) == newShortcut)
+
+		// Reset should restore default
+		KeyboardShortcuts.reset(name)
+		#expect(KeyboardShortcuts.getShortcut(for: name) == defaultShortcut)
+	}
+
+	@Test("Batch reset")
+	func testBatchReset() throws {
+		let name1 = KeyboardShortcuts.Name("batch1", default: .init(.a))
+		let name2 = KeyboardShortcuts.Name("batch2", default: .init(.b))
+		let name3 = KeyboardShortcuts.Name("batch3")
+
+		KeyboardShortcuts.setShortcut(.init(.x), for: name1)
+		KeyboardShortcuts.setShortcut(.init(.y), for: name2)
+		KeyboardShortcuts.setShortcut(.init(.z), for: name3)
+
+		KeyboardShortcuts.reset(name1, name2, name3)
+
+		#expect(KeyboardShortcuts.getShortcut(for: name1) == .init(.a))
+		#expect(KeyboardShortcuts.getShortcut(for: name2) == .init(.b))
+		#expect(KeyboardShortcuts.getShortcut(for: name3) == nil)
+	}
+}
+
+// MARK: - Modifier Symbol Tests
+
+@Suite("Modifier Symbol Tests", .serialized)
+struct ModifierSymbolTests {
+	@Test("Individual modifier symbols")
+	func testIndividualModifierSymbols() {
+		#expect(NSEvent.ModifierFlags.control.ks_symbolicRepresentation == "⌃")
+		#expect(NSEvent.ModifierFlags.option.ks_symbolicRepresentation == "⌥")
+		#expect(NSEvent.ModifierFlags.shift.ks_symbolicRepresentation == "⇧")
+		#expect(NSEvent.ModifierFlags.command.ks_symbolicRepresentation == "⌘")
+		#expect(NSEvent.ModifierFlags([]).ks_symbolicRepresentation == "")
+	}
+
+	@Test("Combined modifier symbols")
+	func testCombinedModifierSymbols() {
+		// macOS standard order: Control, Option, Shift, Command
+		// Two modifiers
+		#expect(NSEvent.ModifierFlags([.control, .option]).ks_symbolicRepresentation == "⌃⌥")
+		#expect(NSEvent.ModifierFlags([.command, .shift]).ks_symbolicRepresentation == "⇧⌘")
+		#expect(NSEvent.ModifierFlags([.option, .command]).ks_symbolicRepresentation == "⌥⌘")
+
+		// Three modifiers
+		#expect(NSEvent.ModifierFlags([.control, .option, .shift]).ks_symbolicRepresentation == "⌃⌥⇧")
+		#expect(NSEvent.ModifierFlags([.control, .shift, .command]).ks_symbolicRepresentation == "⌃⇧⌘")
+
+		// All four main modifiers
+		#expect(NSEvent.ModifierFlags([.control, .option, .shift, .command]).ks_symbolicRepresentation == "⌃⌥⇧⌘")
+	}
+
+	@Test("Modifier symbols via shortcut")
+	func testModifierSymbolsViaShortcut() {
+		let shortcut = KeyboardShortcuts.Shortcut(.a, modifiers: [.command, .shift])
+		#expect(shortcut.modifiers.ks_symbolicRepresentation == "⇧⌘")
+
+		let complexShortcut = KeyboardShortcuts.Shortcut(.space, modifiers: [.control, .option, .command])
+		#expect(complexShortcut.modifiers.ks_symbolicRepresentation == "⌃⌥⌘")
+	}
+
+	@Test("Modifier order independence")
+	func testModifierOrderIndependence() {
+		// No matter the input order, output should be consistent
+		#expect(NSEvent.ModifierFlags([.command, .shift, .option, .control]).ks_symbolicRepresentation == "⌃⌥⇧⌘")
+		#expect(NSEvent.ModifierFlags([.shift, .control, .command, .option]).ks_symbolicRepresentation == "⌃⌥⇧⌘")
+		#expect(NSEvent.ModifierFlags([.option, .command, .control, .shift]).ks_symbolicRepresentation == "⌃⌥⇧⌘")
+	}
+
+	@Test("Special modifiers and edge cases")
+	func testSpecialModifiersAndEdgeCases() {
+		// Function key modifier
+		#expect(NSEvent.ModifierFlags.function.ks_symbolicRepresentation == "🌐︎")
+		#expect(NSEvent.ModifierFlags([.function, .command]).ks_symbolicRepresentation == "⌘🌐︎")
+
+		// All modifiers combined
+		let allModifiers: NSEvent.ModifierFlags = [.control, .option, .shift, .command, .function]
+		#expect(allModifiers.ks_symbolicRepresentation == "⌃⌥⇧⌘🌐︎")
+
+		// Empty modifiers
+		#expect(NSEvent.ModifierFlags().ks_symbolicRepresentation == "")
+	}
+}
+
+// MARK: - UserDefaults Extension for Testing
+
+extension UserDefaults {
+	func removeAllKeyboardShortcuts() {
+		dictionaryRepresentation().keys.forEach { key in
+			if key.hasPrefix("KeyboardShortcuts_") {
+				removeObject(forKey: key)
+			}
+		}
+	}
+}

--- a/app/macos/Vendor/KeyboardShortcuts/Tests/KeyboardShortcutsTests/RecorderLayoutTests.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Tests/KeyboardShortcutsTests/RecorderLayoutTests.swift
@@ -1,0 +1,26 @@
+import Testing
+import Foundation
+import AppKit
+import KeyboardShortcuts
+
+@Suite("RecorderCocoa Layout Tests")
+struct RecorderCocoaLayoutTests {
+	@Test("RecorderCocoa has default size")
+	func testRecorderDefaultSize() throws {
+		let recorder = KeyboardShortcuts.RecorderCocoa(for: .init("test"))
+
+		#expect(recorder.frame.width >= 130)
+		#expect(recorder.frame.height > 0)
+	}
+
+	@Test("RecorderCocoa works with addSubview")
+	@MainActor
+	func testRecorderAddSubview() throws {
+		let recorder = KeyboardShortcuts.RecorderCocoa(for: .init("test"))
+		let containerView = NSView(frame: NSRect(x: 0, y: 0, width: 400, height: 100))
+
+		containerView.addSubview(recorder)
+
+		#expect(recorder.frame.size != .zero)
+	}
+}

--- a/app/macos/Vendor/KeyboardShortcuts/Tests/KeyboardShortcutsTests/Utilities.swift
+++ b/app/macos/Vendor/KeyboardShortcuts/Tests/KeyboardShortcutsTests/Utilities.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension UserDefaults {
+	/**
+	Remove all entries.
+
+	- Note: This only removes user-defined entries. System-defined entries will remain.
+	*/
+	public func removeAll() {
+		for key in dictionaryRepresentation().keys {
+			removeObject(forKey: key)
+		}
+	}
+}

--- a/app/macos/Vendor/KeyboardShortcuts/license
+++ b/app/macos/Vendor/KeyboardShortcuts/license
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/app/macos/hyperwhisper.xcodeproj/project.pbxproj
+++ b/app/macos/hyperwhisper.xcodeproj/project.pbxproj
@@ -337,7 +337,7 @@
 			mainGroup = 7142EF062E50808900DA9A2D;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
-				716D3DE02E52B8910018DCF5 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+				716D3DE02E52B8910018DCF5 /* XCLocalSwiftPackageReference "Vendor/KeyboardShortcuts" */,
 				719EC7CF2E53428100880D18 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				712082922E5409BB00212D08 /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 				7118D5CA2E5E8E39000F525A /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
@@ -856,6 +856,13 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCLocalSwiftPackageReference section */
+		716D3DE02E52B8910018DCF5 /* XCLocalSwiftPackageReference "Vendor/KeyboardShortcuts" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Vendor/KeyboardShortcuts;
+		};
+/* End XCLocalSwiftPackageReference section */
+
 /* Begin XCRemoteSwiftPackageReference section */
 		7118D5CA2E5E8E39000F525A /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -871,14 +878,6 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.9.19;
-			};
-		};
-		716D3DE02E52B8910018DCF5 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.3.0;
 			};
 		};
 		718C2CFD2EDDE83A00A255D5 /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {
@@ -934,7 +933,7 @@
 /* Begin XCSwiftPackageProductDependency section */
 		716D3DE12E52B8910018DCF5 /* KeyboardShortcuts */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 716D3DE02E52B8910018DCF5 /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;
+			package = 716D3DE02E52B8910018DCF5 /* XCLocalSwiftPackageReference "Vendor/KeyboardShortcuts" */;
 			productName = KeyboardShortcuts;
 		};
 		71805ACF2EDDE90D00E7A29A /* LaunchAtLogin */ = {


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), **Settings → Keyboard Shortcuts is unusable**: clicking **Record Shortcut** focuses the field, but pressing a key combination does not record anything — keystrokes type characters into the search field instead, and no error or message is shown. The clear (x) button also does nothing. Once a user clears a shortcut (the value is stored as `0` in `UserDefaults`), they are permanently locked out of rebinding it.

This is not an app bug. It is three independent, compounding defects in `sindresorhus/KeyboardShortcuts`, present in every released version (verified upstream on 0.7.1 through 3.0.1), diagnosed in [sindresorhus/KeyboardShortcuts#241](https://github.com/sindresorhus/KeyboardShortcuts/issues/241):

1. **`LocalEventMonitor` holds its monitor token weakly.** `NSEvent.addLocalMonitorForEvents` returns an autoreleased token the caller must own. Held in a `weak var`, it deallocates when the autorelease pool drains at the end of the event-loop turn — the recorder looks focused but its key monitor is already dead. Older macOS releases evidently kept the token alive internally, which is why this only surfaced on macOS 26.
2. **`showsCancelButton` ends the recording session it just started.** `becomeFirstResponder` mutates the cell's `cancelButtonCell` while the field editor is installed; AppKit ends and restarts editing, and the resulting `controlTextDidEndEditing` calls `endRecording()` — tearing down the key monitor microseconds after it was armed (fails when the field already holds a shortcut).
3. **The recorder's monitor swallows `mouseUp` inside the field**, so the clear button highlights but never fires (`NSSearchFieldCell` completes `_searchFieldCancel:` on mouseUp).

Upstream has the fixes available (issue author's fork) but has not merged or released them yet, and PRs on that repo are restricted to collaborators.

## Fix

Vendor `KeyboardShortcuts` at **2.4.0** (the exact version the project already resolves via `upToNextMajor from: 2.3.0` — so zero API change) into `app/macos/Vendor/KeyboardShortcuts/`, with the three fixes backported from the issue author's fork ([c3f86c6](https://github.com/ppardi/KeyboardShortcuts/commit/c3f86c6), [3f517c0](https://github.com/ppardi/KeyboardShortcuts/commit/3f517c0), [d4bd30d](https://github.com/ppardi/KeyboardShortcuts/commit/d4bd30d), which target 3.0.1), and switch the Xcode project from the remote package reference to the local one.

- Every patched line carries a comment linking upstream issue #241, and `README-VENDORED.md` documents provenance, the exact delta vs stock 2.4.0, and how to drop the vendor dir once upstream ships a fixed release.
- One hardening addition beyond the fork's commits: `LocalEventMonitor.stop()` now nils its token after `removeMonitor`, so the `deinit → stop()` path cannot remove the same token twice now that the reference is strong.
- `THIRD_PARTY_LICENSES.md` updated to note the vendored copy (MIT license file included in the vendor dir).

Vendoring was chosen over pointing the SPM reference at a third-party fork so the repo stays self-contained and the supply chain stays under your control; the change is trivially revertible when upstream fixes land.

## Verification

- `swift build` on the vendored package: compiles clean.
- `swift test` on the vendored package: all 24 tests pass.
- `xcodebuild -resolvePackageDependencies`: resolves `KeyboardShortcuts @ local`.
- Full `xcodebuild` Debug build of the app: BUILD SUCCEEDED (macOS 26.5, after building `libhyperwhisper_core.a` per `app/macos/AGENTS.md`; built with `CODE_SIGNING_ALLOWED=NO` since this machine has no signing team for the project).
- Manual check on macOS 26.5: with the shipped release build, Record Shortcut captures nothing (bug reproduced); the storage layer itself is fine (writing `KeyboardShortcuts_*` defaults directly restores working hotkeys), confirming only the recorder UI path is broken — exactly what the vendored patches fix.

## Workaround for affected users (until a release ships)

Quit HyperWhisper, then restore the default bindings and relaunch:

```sh
defaults write com.hyperwhisper.hyperwhisper "KeyboardShortcuts_toggleRecordingWithTranscription" -string '{"carbonModifiers":2048,"carbonKeyCode":49}'   # ⌥Space
defaults write com.hyperwhisper.hyperwhisper "KeyboardShortcuts_pushToTalk" -string '{"carbonModifiers":2048,"carbonKeyCode":41}'                        # ⌥;
open -a HyperWhisper
```

(Or click **Reset shortcuts** in Settings → Keyboard Shortcuts, which restores defaults without the recorder.)
