### PR TITLE
Add Control+Option+Command push-to-talk preset

### DIFF
--- a/app/macos/hyperwhisper/Localizations/Base.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/Base.lproj/Localizable.strings
@@ -504,6 +504,7 @@
 "settings.shortcuts.pushToTalk.mode.control" = "Control Key";
 "settings.shortcuts.pushToTalk.mode.fnControl" = "FN + Control";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.shortcuts.pushToTalk.mode.custom" = "Custom Shortcut";
 
 "settings.shortcuts.pushToTalk.doublePress.title" = "Double press to lock recording";

--- a/app/macos/hyperwhisper/Localizations/ar.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ar.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "أغلق HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "لاحقاً";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "إبقاء الميكروفون دافئاً بين التسجيلات";
 "settings.sound.keepWarmMicrophone.info" = "يقلل تأخير بدء تشغيل زر الضغط للتحدث من خلال إبقاء جلسة الميكروفون مفتوحة بينما يكون HyperWhisper في وضع الخمول. سيعرض macOS مؤشر الميكروفون البرتقالي باستمرار، وقد تبقى سماعات Bluetooth في وضع المكالمات منخفضة الجودة أثناء تفعيل هذا الخيار.";
 "settings.models.local.inUse" = "هذا النموذج المحلي يُستخدم حالياً للمعالجة اللاحقة بواسطة:

--- a/app/macos/hyperwhisper/Localizations/bg.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/bg.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Затвори HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "По-късно";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Поддържай микрофона активен между записите";
 "settings.sound.keepWarmMicrophone.info" = "Намалява забавянето при стартиране на push-to-talk, като поддържа микрофонната сесия отворена, докато HyperWhisper е в неактивен режим. macOS ще показва непрекъснато оранжевия индикатор на микрофона, а Bluetooth слушалките може да останат в режим на разговор с по-ниско качество, докато е активирано.";
 "settings.models.local.inUse" = "Този локален модел в момента се използва за последваща обработка от:

--- a/app/macos/hyperwhisper/Localizations/ca.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ca.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Tanca HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Més tard";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Mantén el micròfon actiu entre gravacions";
 "settings.sound.keepWarmMicrophone.info" = "Redueix el retard d'inici de push-to-talk mantenint la sessió del micròfon oberta mentre HyperWhisper està inactiu. macOS mostrarà contínuament l'indicador taronja del micròfon, i els auriculars Bluetooth poden romandre en mode de trucada de menor qualitat mentre estigui activat.";
 "settings.models.local.inUse" = "Aquest model local s'utilitza actualment per al postprocessament per:

--- a/app/macos/hyperwhisper/Localizations/cs.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/cs.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Zavřít HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Později";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Udržovat mikrofon aktivní mezi nahrávkami";
 "settings.sound.keepWarmMicrophone.info" = "Snižuje prodlevu spuštění push-to-talk tím, že udržuje relaci mikrofonu otevřenou, když je HyperWhisper nečinný. macOS bude nepřetržitě zobrazovat oranžový indikátor mikrofonu a Bluetooth sluchátka mohou zůstat v režimu hovoru nižší kvality, dokud je tato funkce aktivní.";
 "settings.models.local.inUse" = "Tento lokální model je aktuálně používán pro post-processing v:

--- a/app/macos/hyperwhisper/Localizations/da.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/da.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Luk HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Senere";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Hold mikrofon varm mellem optagelser";
 "settings.sound.keepWarmMicrophone.info" = "Reducerer push-to-talk opstartsforsinkelse ved at holde mikrofonssessionen åben, mens HyperWhisper er inaktiv. macOS viser den orange mikrofonindikator kontinuerligt, og Bluetooth-headset kan forblive i lavere kvalitets opkaldstilstand, mens dette er aktiveret.";
 "settings.models.local.inUse" = "Denne lokale model bruges i øjeblikket til efterbehandling af:

--- a/app/macos/hyperwhisper/Localizations/de.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/de.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisper beenden";
 "vocabulary.icloudSync.restart.later" = "Später";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Mikrofon zwischen Aufnahmen warm halten";
 "settings.sound.keepWarmMicrophone.info" = "Reduziert die Push-to-Talk-Startverzögerung, indem die Mikrofonsitzung offen gehalten wird, während HyperWhisper im Leerlauf ist. macOS zeigt den orangen Mikrofonindikator dauerhaft an, und Bluetooth-Headsets bleiben möglicherweise im Anrufmodus mit geringerer Qualität, solange dies aktiviert ist.";
 "settings.models.local.inUse" = "Dieses lokale Modell wird derzeit für die Nachbearbeitung verwendet von:

--- a/app/macos/hyperwhisper/Localizations/el.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/el.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Κλείσιμο HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Αργότερα";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Διατήρηση μικροφώνου ενεργού μεταξύ εγγραφών";
 "settings.sound.keepWarmMicrophone.info" = "Μειώνει την καθυστέρηση εκκίνησης push-to-talk διατηρώντας τη συνεδρία μικροφώνου ανοιχτή ενώ το HyperWhisper είναι σε αδράνεια. Το macOS θα εμφανίζει συνεχώς την πορτοκαλί ένδειξη μικροφώνου, και τα ακουστικά Bluetooth ενδέχεται να παραμένουν σε λειτουργία κλήσης χαμηλότερης ποιότητας ενώ αυτό είναι ενεργοποιημένο.";
 "settings.models.local.inUse" = "Αυτό το τοπικό μοντέλο χρησιμοποιείται αυτή τη στιγμή για μετεπεξεργασία από:

--- a/app/macos/hyperwhisper/Localizations/es.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/es.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Cerrar HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Más tarde";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Mantener el micrófono activo entre grabaciones";
 "settings.sound.keepWarmMicrophone.info" = "Reduce el retraso de inicio de push-to-talk manteniendo la sesión del micrófono abierta mientras HyperWhisper está inactivo. macOS mostrará continuamente el indicador naranja del micrófono, y los auriculares Bluetooth pueden permanecer en modo de llamada de menor calidad mientras esté activado.";
 "settings.models.local.inUse" = "Este modelo local se está utilizando actualmente para el posprocesamiento por:

--- a/app/macos/hyperwhisper/Localizations/et.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/et.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Sulge HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Hiljem";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Hoia mikrofon soojana salvestuste vahel";
 "settings.sound.keepWarmMicrophone.info" = "Vähendab push-to-talk käivitusviivitust, hoides mikrofoni seansi avatuna, kui HyperWhisper on jõude. macOS kuvab pidevalt oranži mikrofonimärguannet ja Bluetooth-kõrvaklapid võivad selle lubamise ajal jääda madalama kvaliteediga kõnerežiimi.";
 "settings.models.local.inUse" = "Seda kohalikku mudelit kasutatakse praegu järeltöötlemiseks:

--- a/app/macos/hyperwhisper/Localizations/fi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/fi.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Sulje HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Myöhemmin";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Pidä mikrofoni lämpimänä tallennusten välillä";
 "settings.sound.keepWarmMicrophone.info" = "Vähentää push-to-talk-käynnistysviivettä pitämällä mikrofonisession auki, kun HyperWhisper on käyttämättömänä. macOS näyttää oranssin mikrofoninilmaisimen jatkuvasti, ja Bluetooth-kuulokkeet voivat pysyä heikomman laadun puhelutilassa tämän ollessa käytössä.";
 "settings.models.local.inUse" = "Tätä paikallista mallia käytetään tällä hetkellä jälkikäsittelyyn:

--- a/app/macos/hyperwhisper/Localizations/fr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/fr.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Quitter HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Plus tard";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Maintenir le microphone actif entre les enregistrements";
 "settings.sound.keepWarmMicrophone.info" = "Réduit le délai de démarrage du push-to-talk en maintenant la session microphone ouverte pendant que HyperWhisper est inactif. macOS affichera en permanence l'indicateur orange du microphone, et les casques Bluetooth peuvent rester en mode appel de moindre qualité tant que cette option est activée.";
 "settings.models.local.inUse" = "Ce modèle local est actuellement utilisé pour le post-traitement par :

--- a/app/macos/hyperwhisper/Localizations/he.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/he.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "סגור את HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "מאוחר יותר";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "שמור את המיקרופון פעיל בין הקלטות";
 "settings.sound.keepWarmMicrophone.info" = "מפחית את עיכוב ההפעלה של push-to-talk על ידי שמירת ההפעלה של המיקרופון פתוחה בזמן ש-HyperWhisper בסרק. macOS יציג את מחוון המיקרופון הכתום ברציפות, ואוזניות Bluetooth עשויות להישאר במצב שיחה באיכות נמוכה יותר בזמן שאפשרות זו מופעלת.";
 "settings.models.local.inUse" = "מודל מקומי זה נמצא כעת בשימוש לעיבוד מאוחר על ידי:

--- a/app/macos/hyperwhisper/Localizations/hi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hi.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisper बंद करें";
 "vocabulary.icloudSync.restart.later" = "बाद में";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "रिकॉर्डिंग के बीच माइक्रोफ़ोन को सक्रिय रखें";
 "settings.sound.keepWarmMicrophone.info" = "HyperWhisper के निष्क्रिय रहने के दौरान माइक्रोफ़ोन सत्र को खुला रखकर पुश-टू-टॉक स्टार्टअप देरी को कम करता है। macOS लगातार नारंगी माइक्रोफ़ोन संकेतक दिखाएगा, और Bluetooth हेडसेट इसके सक्षम होने पर कम-गुणवत्ता वाले कॉल मोड में रह सकते हैं।";
 "settings.models.local.inUse" = "यह स्थानीय मॉडल वर्तमान में पोस्ट-प्रोसेसिंग के लिए उपयोग किया जा रहा है:

--- a/app/macos/hyperwhisper/Localizations/hr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hr.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Zatvori HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Kasnije";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Zadrži mikrofon aktivan između snimanja";
 "settings.sound.keepWarmMicrophone.info" = "Smanjuje kašnjenje pokretanja push-to-talk zadržavanjem mikrofon sesije otvorenom dok je HyperWhisper u mirovanju. macOS će kontinuirano prikazivati narančasti indikator mikrofona, a Bluetooth slušalice mogu ostati u načinu poziva niže kvalitete dok je ovo omogućeno.";
 "settings.models.local.inUse" = "Ovaj lokalni model se trenutno koristi za naknadnu obradu od strane:

--- a/app/macos/hyperwhisper/Localizations/hu.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/hu.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisper bezárása";
 "vocabulary.icloudSync.restart.later" = "Később";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Mikrofon melegen tartása felvételek között";
 "settings.sound.keepWarmMicrophone.info" = "Csökkenti a push-to-talk indítási késleltetést azzal, hogy nyitva tartja a mikrofon munkamenetet, amíg a HyperWhisper tétlen. A macOS folyamatosan megjeleníti a narancsszínű mikrofon jelzőt, és a Bluetooth fejhallgatók alacsonyabb minőségű hívás módban maradhatnak, amíg ez engedélyezve van.";
 "settings.models.local.inUse" = "Ezt a helyi modellt jelenleg a következők használják utófeldolgozásra:

--- a/app/macos/hyperwhisper/Localizations/id.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/id.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Tutup HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Nanti";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Jaga mikrofon tetap hangat di antara rekaman";
 "settings.sound.keepWarmMicrophone.info" = "Mengurangi penundaan startup push-to-talk dengan menjaga sesi mikrofon tetap terbuka saat HyperWhisper tidak aktif. macOS akan terus menampilkan indikator mikrofon oranye, dan headset Bluetooth mungkin tetap dalam mode panggilan kualitas lebih rendah saat ini diaktifkan.";
 "settings.models.local.inUse" = "Model lokal ini saat ini digunakan untuk pasca-pemrosesan oleh:

--- a/app/macos/hyperwhisper/Localizations/is.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/is.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Loka HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Seinna";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Haltu hljóðnema heitum á milli upptaka";
 "settings.sound.keepWarmMicrophone.info" = "Dregur úr push-to-talk ræsingartafinu með því að halda hljóðnemasetunni opinni meðan HyperWhisper er aðgerðarlaus. macOS mun sýna appelsínugula hljóðnemavísa stöðugt, og Bluetooth heyrnartól gætu verið í lægri gæða símtalsham á meðan þetta er virkt.";
 "settings.models.local.inUse" = "Þetta staðbundna líkan er notað í aukavinnslu af:

--- a/app/macos/hyperwhisper/Localizations/it.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/it.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Chiudi HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Più tardi";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Mantieni il microfono attivo tra le registrazioni";
 "settings.sound.keepWarmMicrophone.info" = "Riduce il ritardo di avvio del push-to-talk mantenendo la sessione del microfono aperta mentre HyperWhisper è inattivo. macOS mostrerà continuamente l'indicatore arancione del microfono, e i cuffie Bluetooth potrebbero rimanere in modalità chiamata di qualità inferiore mentre questa opzione è attiva.";
 "settings.models.local.inUse" = "Questo modello locale è attualmente utilizzato per la post-elaborazione da:

--- a/app/macos/hyperwhisper/Localizations/ja.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ja.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisperを終了";
 "vocabulary.icloudSync.restart.later" = "後で";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "録音の合間もマイクをウォームアップ状態に保つ";
 "settings.sound.keepWarmMicrophone.info" = "HyperWhisperがアイドル中もマイクセッションを開いたままにすることで、プッシュトゥトークの起動遅延を軽減します。macOSはオレンジ色のマイクインジケーターを常時表示し、この機能が有効な間はBluetoothヘッドセットが低品質の通話モードのままになる場合があります。";
 "settings.models.local.inUse" = "このローカルモデルは現在、以下でポスト処理に使用されています：

--- a/app/macos/hyperwhisper/Localizations/ko.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ko.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisper 종료";
 "vocabulary.icloudSync.restart.later" = "나중에";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "녹음 사이에 마이크를 워밍업 상태로 유지";
 "settings.sound.keepWarmMicrophone.info" = "HyperWhisper가 유휴 상태일 때 마이크 세션을 열어 두어 푸시 투 토크 시작 지연을 줄입니다. macOS는 주황색 마이크 표시기를 지속적으로 표시하며, 이 기능이 활성화된 동안 Bluetooth 헤드셋이 낮은 품질의 통화 모드를 유지할 수 있습니다.";
 "settings.models.local.inUse" = "이 로컬 모델은 현재 다음에서 후처리에 사용 중입니다:

--- a/app/macos/hyperwhisper/Localizations/lt.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/lt.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Uždaryti HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Vėliau";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Laikyk mikrofoną aktyvų tarp įrašų";
 "settings.sound.keepWarmMicrophone.info" = "Sumažina push-to-talk paleidimo delsą, laikant mikrofono sesiją atvirą, kol HyperWhisper yra neaktyvus. macOS nuolat rodys oranžinį mikrofono indikatorių, o Bluetooth ausinės gali likti žemesnės kokybės skambučio režime, kol tai įjungta.";
 "settings.models.local.inUse" = "Šis vietinis modelis šiuo metu naudojamas post-apdorojimui:

--- a/app/macos/hyperwhisper/Localizations/lv.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/lv.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Aizvērt HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Vēlāk";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Uzturēt mikrofonu siltu starp ierakstiem";
 "settings.sound.keepWarmMicrophone.info" = "Samazina push-to-talk palaišanas aizkavēšanos, uzturot mikrofona sesiju atvērtu, kamēr HyperWhisper ir dīkstāvē. macOS pastāvīgi rādīs oranžo mikrofona indikatoru, un Bluetooth austiņas var palikt zemākas kvalitātes zvana režīmā, kamēr tas ir iespējots.";
 "settings.models.local.inUse" = "Šis lokālais modelis pašlaik tiek izmantots pēcapstrādei:

--- a/app/macos/hyperwhisper/Localizations/ms.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ms.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Tutup HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Kemudian";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Pastikan mikrofon tetap hangat antara rakaman";
 "settings.sound.keepWarmMicrophone.info" = "Mengurangkan kelewatan permulaan push-to-talk dengan mengekalkan sesi mikrofon terbuka semasa HyperWhisper melahu. macOS akan memaparkan penunjuk mikrofon oren secara berterusan, dan headset Bluetooth mungkin kekal dalam mod panggilan kualiti lebih rendah semasa ini diaktifkan.";
 "settings.models.local.inUse" = "Model tempatan ini sedang digunakan untuk pasca-pemprosesan oleh:

--- a/app/macos/hyperwhisper/Localizations/nb.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/nb.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Avslutt HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Senere";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Hold mikrofon varm mellom opptak";
 "settings.sound.keepWarmMicrophone.info" = "Reduserer push-to-talk oppstartsforsinkelse ved å holde mikrofonøkten åpen mens HyperWhisper er inaktiv. macOS vil vise den oransje mikrofonindikatoren kontinuerlig, og Bluetooth-hodetelefoner kan forbli i lavere kvalitets samtalemodus mens dette er aktivert.";
 "settings.models.local.inUse" = "Denne lokale modellen brukes for øyeblikket til etterbehandling av:

--- a/app/macos/hyperwhisper/Localizations/nl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/nl.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisper afsluiten";
 "vocabulary.icloudSync.restart.later" = "Later";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Houd microfoon warm tussen opnames";
 "settings.sound.keepWarmMicrophone.info" = "Vermindert de push-to-talk opstartvertraging door de microfoonsessie open te houden terwijl HyperWhisper inactief is. macOS toont de oranje microfoonindicator continu, en Bluetooth-headsets kunnen in de lagere kwaliteit belmodus blijven zolang dit is ingeschakeld.";
 "settings.models.local.inUse" = "Dit lokale model wordt momenteel gebruikt voor nabewerking door:

--- a/app/macos/hyperwhisper/Localizations/pl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/pl.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Zamknij HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Później";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Utrzymuj mikrofon w gotowości między nagraniami";
 "settings.sound.keepWarmMicrophone.info" = "Zmniejsza opóźnienie uruchamiania push-to-talk, utrzymując sesję mikrofonu otwartą, gdy HyperWhisper jest nieaktywny. macOS będzie stale wyświetlał pomarańczowy wskaźnik mikrofonu, a zestawy słuchawkowe Bluetooth mogą pozostawać w trybie połączenia niższej jakości, gdy jest to włączone.";
 "settings.models.local.inUse" = "Ten model lokalny jest aktualnie używany do przetwarzania końcowego przez:

--- a/app/macos/hyperwhisper/Localizations/pt.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/pt.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Fechar HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Mais tarde";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Manter o microfone ativo entre gravações";
 "settings.sound.keepWarmMicrophone.info" = "Reduz o atraso de início do push-to-talk mantendo a sessão do microfone aberta enquanto o HyperWhisper está inativo. O macOS exibirá continuamente o indicador laranja do microfone, e os headsets Bluetooth podem permanecer no modo de chamada de menor qualidade enquanto esta opção estiver ativada.";
 "settings.models.local.inUse" = "Este modelo local está atualmente sendo usado para pós-processamento por:

--- a/app/macos/hyperwhisper/Localizations/ro.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ro.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Închide HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Mai târziu";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Menține microfonul activ între înregistrări";
 "settings.sound.keepWarmMicrophone.info" = "Reduce întârzierea de pornire push-to-talk menținând sesiunea microfonului deschisă în timp ce HyperWhisper este inactiv. macOS va afișa continuu indicatorul portocaliu al microfonului, iar căștile Bluetooth pot rămâne în modul de apel de calitate inferioară cât timp aceasta este activată.";
 "settings.models.local.inUse" = "Acest model local este utilizat în prezent pentru post-procesare de către:

--- a/app/macos/hyperwhisper/Localizations/ru.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/ru.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Закрыть HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Позже";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Держать микрофон активным между записями";
 "settings.sound.keepWarmMicrophone.info" = "Уменьшает задержку запуска push-to-talk, сохраняя сеанс микрофона открытым, пока HyperWhisper простаивает. macOS будет постоянно отображать оранжевый индикатор микрофона, а Bluetooth-гарнитуры могут оставаться в режиме звонка более низкого качества, пока это включено.";
 "settings.models.local.inUse" = "Эта локальная модель в настоящее время используется для пост-обработки:

--- a/app/macos/hyperwhisper/Localizations/sk.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sk.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Zatvoriť HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Neskôr";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Udržiavaj mikrofón aktívny medzi nahrávkami";
 "settings.sound.keepWarmMicrophone.info" = "Znižuje oneskorenie spustenia push-to-talk tým, že udržuje reláciu mikrofónu otvorenú, keď je HyperWhisper nečinný. macOS bude nepretržite zobrazovať oranžový indikátor mikrofónu a Bluetooth slúchadlá môžu zostať v režime hovoru nižšej kvality, pokiaľ je táto funkcia aktívna.";
 "settings.models.local.inUse" = "Tento lokálny model sa v súčasnosti používa na následné spracovanie pre:

--- a/app/macos/hyperwhisper/Localizations/sl.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sl.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Zapri HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Pozneje";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Ohrani mikrofon aktiven med posnetki";
 "settings.sound.keepWarmMicrophone.info" = "Zmanjša zakasnitev zagona push-to-talk z ohranjanjem seje mikrofona odprte, medtem ko je HyperWhisper v mirovanju. macOS bo neprekinjeno prikazoval oranžni indikator mikrofona, Bluetooth slušalke pa bodo morda ostale v načinu klica nižje kakovosti, ko je to omogočeno.";
 "settings.models.local.inUse" = "Ta lokalni model se trenutno uporablja za naknadno obdelavo s strani:

--- a/app/macos/hyperwhisper/Localizations/sr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sr.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Затвори HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Касније";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Одржавај микрофон активним између снимања";
 "settings.sound.keepWarmMicrophone.info" = "Смањује кашњење покретања push-to-talk задржавањем сесије микрофона отвореном док је HyperWhisper у мировању. macOS ће континуирано приказивати наранџасти индикатор микрофона, а Bluetooth слушалице могу остати у режиму позива ниже квалитета док је ово омогућено.";
 "settings.models.local.inUse" = "Овај локални модел се тренутно користи за пост-обраду од стране:

--- a/app/macos/hyperwhisper/Localizations/sv.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/sv.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Stäng HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Senare";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Håll mikrofon varm mellan inspelningar";
 "settings.sound.keepWarmMicrophone.info" = "Minskar push-to-talk-startfördröjningen genom att hålla mikrofonsessionen öppen medan HyperWhisper är inaktiv. macOS visar den orangea mikrofonindikatorn kontinuerligt, och Bluetooth-headset kan stanna kvar i samtalsmodus med lägre kvalitet medan detta är aktiverat.";
 "settings.models.local.inUse" = "Denna lokala modell används för närvarande för efterbehandling av:

--- a/app/macos/hyperwhisper/Localizations/th.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/th.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "ปิด HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "ภายหลัง";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "รักษาไมโครโฟนให้พร้อมใช้งานระหว่างการบันทึก";
 "settings.sound.keepWarmMicrophone.info" = "ลดความล่าช้าในการเริ่มต้น push-to-talk โดยรักษาเซสชันไมโครโฟนให้เปิดอยู่ขณะที่ HyperWhisper อยู่ในโหมดสแตนด์บาย macOS จะแสดงไฟแสดงสถานะไมโครโฟนสีส้มอย่างต่อเนื่อง และชุดหูฟัง Bluetooth อาจอยู่ในโหมดโทรศัพท์คุณภาพต่ำกว่าในขณะที่เปิดใช้งานตัวเลือกนี้";
 "settings.models.local.inUse" = "โมเดลท้องถิ่นนี้กำลังถูกใช้สำหรับการประมวลผลภายหลังโดย:

--- a/app/macos/hyperwhisper/Localizations/tr.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/tr.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "HyperWhisper'ı Kapat";
 "vocabulary.icloudSync.restart.later" = "Daha Sonra";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Kayıtlar arasında mikrofonu sıcak tut";
 "settings.sound.keepWarmMicrophone.info" = "HyperWhisper boştayken mikrofon oturumunu açık tutarak push-to-talk başlatma gecikmesini azaltır. macOS turuncu mikrofon göstergesini sürekli gösterecek ve Bluetooth kulaklıklar bu etkinken daha düşük kaliteli arama modunda kalabilir.";
 "settings.models.local.inUse" = "Bu yerel model şu anda şunlar tarafından son işleme için kullanılıyor:

--- a/app/macos/hyperwhisper/Localizations/uk.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/uk.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Закрити HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Пізніше";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Тримати мікрофон активним між записами";
 "settings.sound.keepWarmMicrophone.info" = "Зменшує затримку запуску push-to-talk, тримаючи сеанс мікрофона відкритим, поки HyperWhisper простоює. macOS постійно відображатиме помаранчевий індикатор мікрофона, а Bluetooth-гарнітури можуть залишатися в режимі дзвінка нижчої якості, поки це ввімкнено.";
 "settings.models.local.inUse" = "Ця локальна модель наразі використовується для постобробки:

--- a/app/macos/hyperwhisper/Localizations/vi.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/vi.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "Đóng HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "Sau";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "Giữ micro ấm giữa các lần ghi âm";
 "settings.sound.keepWarmMicrophone.info" = "Giảm độ trễ khởi động push-to-talk bằng cách giữ phiên micro mở trong khi HyperWhisper ở chế độ chờ. macOS sẽ hiển thị liên tục chỉ báo micro màu cam, và tai nghe Bluetooth có thể ở lại chế độ cuộc gọi chất lượng thấp hơn khi tính năng này được bật.";
 "settings.models.local.inUse" = "Mô hình cục bộ này hiện đang được sử dụng cho hậu xử lý bởi:

--- a/app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/zh-Hans.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "退出 HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "稍后";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "在录音间隙保持麦克风热启动状态";
 "settings.sound.keepWarmMicrophone.info" = "通过在 HyperWhisper 空闲时保持麦克风会话开启，减少一键通启动延迟。macOS 将持续显示橙色麦克风指示灯，启用时蓝牙耳机可能会保持在较低音质的通话模式。";
 "settings.models.local.inUse" = "此本地模型当前正被以下功能用于后处理：

--- a/app/macos/hyperwhisper/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/app/macos/hyperwhisper/Localizations/zh-Hant.lproj/Localizable.strings
@@ -614,6 +614,7 @@
 "vocabulary.icloudSync.restart.quit" = "結束 HyperWhisper";
 "vocabulary.icloudSync.restart.later" = "稍後";
 "settings.shortcuts.pushToTalk.mode.fnOption" = "FN + Left Option";
+"settings.shortcuts.pushToTalk.mode.controlOptionCommand" = "Control + Option + Command";
 "settings.sound.keepWarmMicrophone.title" = "在錄音間隙保持麥克風熱啟動狀態";
 "settings.sound.keepWarmMicrophone.info" = "透過在 HyperWhisper 閒置時保持麥克風工作階段開啟，減少一鍵通啟動延遲。macOS 將持續顯示橙色麥克風指示燈，啟用時藍牙耳機可能會保持在較低音質的通話模式。";
 "settings.models.local.inUse" = "此本機模型目前正被以下功能用於後處理：

--- a/app/macos/hyperwhisper/Managers/AudioRecording/AudioRecordingManager.swift
+++ b/app/macos/hyperwhisper/Managers/AudioRecording/AudioRecordingManager.swift
@@ -443,11 +443,12 @@ class AudioRecordingManager: NSObject, ObservableObject {
         // Combo modes (FN+Control, FN+Option) don't support double-press-to-lock —
         // a quick press-and-release should silently exit, not start recording.
         let isComboMode = pushToTalkMode == .fnControl || pushToTalkMode == .fnOption
+            || pushToTalkMode == .controlOptionCommand
         BareModifierKeyMonitor.shared.doublePressEnabled = isComboMode ? false : settingsManager.pushToTalkDoublePressEnabled
 
         if pushToTalkMode == .disabled {
             AppLogger.audio.debug("📴 Push to Talk is disabled")
-        } else if [.fn, .control, .leftOption, .rightOption, .fnControl, .fnOption].contains(pushToTalkMode) {
+        } else if [.fn, .control, .leftOption, .rightOption, .fnControl, .fnOption, .controlOptionCommand].contains(pushToTalkMode) {
             // BARE MODIFIER MODE (single key or combo)
 
             if AccessibilityHelper.shared.hasAccessibilityPermission() {
@@ -531,6 +532,7 @@ class AudioRecordingManager: NSObject, ObservableObject {
                     switch pushToTalkMode {
                     case .fnControl: BareModifierKeyMonitor.shared.start(combo: [.fn, .control])
                     case .fnOption: BareModifierKeyMonitor.shared.start(combo: [.fn, .leftOption])
+                    case .controlOptionCommand: BareModifierKeyMonitor.shared.start(combo: [.control, .anyOption, .command])
                     case .fn: BareModifierKeyMonitor.shared.start(mode: .fn)
                     case .control: BareModifierKeyMonitor.shared.start(mode: .control)
                     case .leftOption: BareModifierKeyMonitor.shared.start(mode: .leftOption)

--- a/app/macos/hyperwhisper/Managers/SettingsManager.swift
+++ b/app/macos/hyperwhisper/Managers/SettingsManager.swift
@@ -50,6 +50,7 @@ enum PushToTalkMode: String, CaseIterable, Codable {
     case rightOption
     case fnControl
     case fnOption
+    case controlOptionCommand
     case custom
 
     var localizedName: String {
@@ -68,6 +69,8 @@ enum PushToTalkMode: String, CaseIterable, Codable {
             return NSLocalizedString("settings.shortcuts.pushToTalk.mode.fnControl", value: "FN + Control", comment: "")
         case .fnOption:
             return NSLocalizedString("settings.shortcuts.pushToTalk.mode.fnOption", value: "FN + Left Option", comment: "")
+        case .controlOptionCommand:
+            return NSLocalizedString("settings.shortcuts.pushToTalk.mode.controlOptionCommand", value: "Control + Option + Command", comment: "")
         case .custom:
             return NSLocalizedString("settings.shortcuts.pushToTalk.mode.custom", value: "Custom Shortcut", comment: "")
         }

--- a/app/macos/hyperwhisper/Utilities/BareModifierKeyMonitor.swift
+++ b/app/macos/hyperwhisper/Utilities/BareModifierKeyMonitor.swift
@@ -81,6 +81,10 @@ final class BareModifierKeyMonitor {
         case control
         case leftOption
         case rightOption
+        /// Either Option key. Combo members are matched with allSatisfy, which cannot
+        /// express "left OR right", so combos that should accept both sides use this.
+        case anyOption
+        case command
     }
 
     private enum MonitorState {
@@ -1008,6 +1012,11 @@ final class BareModifierKeyMonitor {
             return flags.contains(.maskSecondaryFn)
         case .control:
             return flags.contains(.maskControl)
+        case .command:
+            return flags.contains(.maskCommand)
+        case .anyOption:
+            // .maskAlternate covers both Option keys
+            return flags.contains(.maskAlternate)
         case .leftOption, .rightOption:
             // CGEventFlags doesn't directly distinguish left/right Option
             // We check the raw value for side-specific detection
@@ -1045,7 +1054,9 @@ final class BareModifierKeyMonitor {
                 break
             case .control:
                 interferingFlags.removeAll { $0 == .maskControl }
-            case .leftOption, .rightOption:
+            case .command:
+                interferingFlags.removeAll { $0 == .maskCommand }
+            case .leftOption, .rightOption, .anyOption:
                 interferingFlags.removeAll { $0 == .maskAlternate }
             }
         }

--- a/app/macos/hyperwhisper/Views/MainAppView.swift
+++ b/app/macos/hyperwhisper/Views/MainAppView.swift
@@ -650,6 +650,8 @@ struct MenuBarItems: View {
             return "Hold FN+⌃"
         case .fnOption:
             return "Hold FN+⌥"
+        case .controlOptionCommand:
+            return "Hold ⌃⌥⌘"
         case .custom:
             // For custom PTT shortcut, try to get its description
             if let shortcut = KeyboardShortcuts.getShortcut(for: .pushToTalk) {

--- a/app/macos/hyperwhisper/Views/Settings/ShortcutsSettingsSection.swift
+++ b/app/macos/hyperwhisper/Views/Settings/ShortcutsSettingsSection.swift
@@ -151,7 +151,8 @@ struct ShortcutsSettingsSection: View {
                     // Combo modes (FN+Control, FN+Option) don't support double-press-to-lock
                     if settingsManager.pushToTalkMode != .custom
                         && settingsManager.pushToTalkMode != .fnControl
-                        && settingsManager.pushToTalkMode != .fnOption {
+                        && settingsManager.pushToTalkMode != .fnOption
+                        && settingsManager.pushToTalkMode != .controlOptionCommand {
                         Divider()
 
                         SettingsToggleRow(


### PR DESCRIPTION
## What

Adds a **Control + Option + Command** hold-to-talk preset to the Push to Talk "Recording Mode" picker — hold all three modifiers to record, release to transcribe. No letter key involved.

## Why

Users coming from PC keyboards often want a pure modifier chord as their push-to-talk trigger (all three cluster under the left thumb/fingers). Today the only modifier-only options are the FN/Control/Option presets; a three-modifier chord has two advantages over a single bare modifier:

- It essentially cannot false-trigger: no app shortcut and no typing pattern holds ⌃⌥⌘ alone for 250 ms.
- It works on keyboards with no usable FN key (most external PC keyboards).

This is also a natural fit for the existing architecture: `BareModifierKeyMonitor` already supports simultaneous-modifier combos generically (`start(combo:)`, introduced for FN+Control / FN+Option) — this preset just adds new combo members.

## Changes

- `BareModifierKeyMonitor.ModifierKey`: new `.command` case, plus `.anyOption` (either Option key — combo matching uses `allSatisfy`, which cannot express "left OR right", so combos that should accept both sides need a dedicated case). Flag detection via `.maskCommand` / `.maskAlternate`; both are exempted from interference detection when part of the active combo.
- `PushToTalkMode`: new `controlOptionCommand` case (placed before `custom` so it lists with the other bare-modifier presets in the picker).
- `AudioRecordingManager.setupPushToTalk()`: routes the new mode to `start(combo: [.control, .anyOption, .command])`; included in the combo-mode set so double-press-to-lock is disabled for it (same rationale as FN+Control / FN+Option).
- `ShortcutsSettingsSection`: hides the double-press row for the new combo mode (same as the other combos).
- Localization: `settings.shortcuts.pushToTalk.mode.controlOptionCommand` added to all 40 locale files. Modifier-key names stay untranslated, matching how every locale renders "FN + Control" verbatim.

## Behavior details

- 250 ms activation delay applies as usual, so real shortcuts that use ⌃⌥⌘+key (e.g. window managers) do not trigger recording — pressing any regular key during the window cancels via the existing interference detection.
- Left and right Option both work.
- Requires Accessibility permission, same as every bare-modifier preset.

## Verification

- Full `xcodebuild` Debug build succeeds (macOS 26.5).
- Runtime testing is underway on a locally installed build on macOS 26.5; I will report results in this thread. The mode reuses the exact combo machinery FN+Control already ships (`start(combo:)` + interference detection), with no new state-machine paths.
