### PR TITLE
Add the journal check's test suite, and a way to record old violations

### DIFF
--- a/.github/scripts/test_validate_drizzle_journal.sh
+++ b/.github/scripts/test_validate_drizzle_journal.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+# Tests for validate_drizzle_journal.py.
+#
+# Each case builds a throwaway git repository with a small journal, so the
+# tests never touch this repository's real migrations. Run it after any edit
+# to the check:
+#
+#   bash .github/scripts/test_validate_drizzle_journal.sh
+#
+# CI runs it too, so a change that breaks a rule fails the pull request that
+# makes it rather than the pull request that trips over it later.
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+SCRIPT=${1:-$HERE/validate_drizzle_journal.py}
+ROOT=$(mktemp -d)
+PASS=0
+FAIL=0
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+journal() { # reads "idx tag when" triples on stdin, writes journal + .sql files
+  printf '{"version":"7","dialect":"postgresql","entries":[' \
+    > drizzle/meta/_journal.json
+  local first=1 idx tag when
+  while read -r idx tag when; do
+    [ -z "${idx:-}" ] && continue
+    [ $first -eq 0 ] && printf ',' >> drizzle/meta/_journal.json
+    first=0
+    printf '{"idx":%s,"version":"7","when":%s,"tag":"%s","breakpoints":true}' \
+      "$idx" "$when" "$tag" >> drizzle/meta/_journal.json
+    echo "-- $tag" > "drizzle/$tag.sql"
+  done
+  printf ']}\n' >> drizzle/meta/_journal.json
+}
+
+fresh() { # repo whose main branch already has three applied migrations
+  rm -rf "$ROOT/repo"
+  mkdir -p "$ROOT/repo/drizzle/meta" "$ROOT/repo/.github"
+  cd "$ROOT/repo" || exit 1
+  git init -q -b main .
+  git config user.email test@example.com
+  git config user.name test
+  journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2000
+2 0002_charlie 3000
+EOF
+  git add -A && git commit -qm base
+  git checkout -qb feature
+}
+
+want() { # want <name> <expected exit> [substring the output must contain]
+  local name="$1" expected="$2" needle="${3:-}" out got
+  out=$(BASE_REF=main python3 "$SCRIPT" 2>&1)
+  got=$?
+  if [ "$got" != "$expected" ]; then
+    echo "FAIL $name: exit $got, expected $expected"
+    echo "$out" | sed 's/^/       /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [ -n "$needle" ] && ! echo "$out" | grep -q "$needle"; then
+    echo "FAIL $name: output did not mention '$needle'"
+    echo "$out" | sed 's/^/       /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "ok   $name"
+  PASS=$((PASS + 1))
+}
+
+# ── the journal on its own, and against its base branch ──────────────────────
+
+fresh
+want "untouched branch" 0
+
+fresh
+journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2000
+2 0002_charlie 3000
+3 0003_delta 4000
+EOF
+git add -A && git commit -qm append
+want "correct append" 0
+
+fresh
+journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2000
+2 0002_charlie 3000
+3 0003_delta 2500
+EOF
+git add -A && git commit -qm past
+want "new entry stamped in the past" 1 "not past the newest entry"
+
+fresh
+journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2500
+2 0002_charlie 3000
+EOF
+git add -A && git commit -qm restamp
+want "re-stamped an applied entry" 1 'changed `when`'
+
+fresh
+journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2000
+EOF
+git add -A && git commit -qm remove
+want "removed an applied entry" 1 "was removed"
+
+fresh
+echo "-- tampered" >> drizzle/0001_bravo.sql
+git add -A && git commit -qm edit
+want "edited an applied .sql" 1 "was edited"
+
+fresh
+git mv drizzle/0001_bravo.sql drizzle/0001_renamed.sql
+journal <<'EOF'
+0 0000_alpha 1000
+1 0001_renamed 2000
+2 0002_charlie 3000
+EOF
+git add -A && git commit -qm rename
+want "renamed an applied migration" 1 'changed `tag`'
+
+fresh
+echo "-- stray" > drizzle/0009_orphan.sql
+git add -A && git commit -qm orphan
+want "orphan NNNN_ file" 1 "no journal entry lists them"
+
+fresh
+echo "-- hand run" > drizzle/custom_triggers.sql
+git add -A && git commit -qm helper
+want "hand-run helper added" 0
+
+fresh
+echo "-- hand run" > drizzle/custom_triggers.sql
+git add -A && git commit -qm helper
+echo "-- changed" >> drizzle/custom_triggers.sql
+git add -A && git commit -qm "edit helper"
+want "hand-run helper edited" 0
+
+# One entry stamped in the future sits above several later ones at once. A
+# neighbour-only comparison would report the first victim and hide the rest.
+fresh
+journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2000
+2 0002_charlie 3000
+3 0003_delta 9000
+4 0004_echo 4000
+5 0005_foxtrot 5000
+EOF
+git add -A && git commit -qm future
+out=$(BASE_REF=main python3 "$SCRIPT" 2>&1)
+count=$(echo "$out" | grep -c "does not come after")
+if [ "$count" = "2" ]; then
+  echo "ok   a future stamp hides both later entries"
+  PASS=$((PASS + 1))
+else
+  echo "FAIL a future stamp hides both later entries: reported $count, wanted 2"
+  echo "$out" | sed 's/^/       /'
+  FAIL=$((FAIL + 1))
+fi
+
+# ── the baseline file, for violations already merged and reconciled ──────────
+
+with_history() { # main already carries an out-of-order pair at idx 3
+  rm -rf "$ROOT/repo"
+  mkdir -p "$ROOT/repo/drizzle/meta" "$ROOT/repo/.github"
+  cd "$ROOT/repo" || exit 1
+  git init -q -b main .
+  git config user.email test@example.com
+  git config user.name test
+  journal <<'EOF'
+0 0000_alpha 1000
+1 0001_bravo 2000
+2 0002_charlie 9000
+3 0003_delta 3000
+EOF
+  git add -A && git commit -qm base
+  git checkout -qb feature
+}
+
+baseline() { # write the baseline file from stdin and commit it
+  cat > .github/drizzle-journal-baseline.json
+  git add -A && git commit -qm baseline
+}
+
+with_history
+want "pre-existing violation fails without a baseline" 1 "does not come after"
+
+with_history
+baseline <<'EOF'
+{
+  "allow_out_of_order": [
+    {
+      "idx": 3,
+      "tag": "0003_delta",
+      "when": 3000,
+      "why": "Verified applied in production, 4 of 4 rows recorded."
+    }
+  ]
+}
+EOF
+want "baseline accepts the recorded violation" 0 "accepted by"
+
+with_history
+baseline <<'EOF'
+{"allow_out_of_order":[{"idx":3,"tag":"0003_delta","when":3000,"why":"checked"}]}
+EOF
+python3 - <<'EOF'
+import json
+path = "drizzle/meta/_journal.json"
+data = json.load(open(path))
+data["entries"][3]["when"] = 3500
+json.dump(data, open(path, "w"))
+EOF
+git add -A && git commit -qm restamp
+want "baseline does not cover a re-stamped entry" 1 'changed `when`'
+
+with_history
+baseline <<'EOF'
+{"allow_out_of_order":[{"idx":3,"tag":"0003_WRONG","when":3000,"why":"checked"}]}
+EOF
+want "baseline with the wrong tag does not match" 1 "does not come after"
+
+with_history
+baseline <<'EOF'
+{"allow_out_of_order":[{"idx":3,"tag":"0003_delta","when":3000}]}
+EOF
+want "baseline entry with no reason is rejected" 1 'needs `idx`'
+
+# ── result ───────────────────────────────────────────────────────────────────
+
+echo
+echo "passed $PASS, failed $FAIL"
+cd /
+rm -rf "$ROOT"
+[ "$FAIL" = "0" ]

--- a/.github/scripts/validate_drizzle_journal.py
+++ b/.github/scripts/validate_drizzle_journal.py
@@ -38,6 +38,14 @@ import sys
 # the rules below leave it alone.
 GENERATED_SQL = re.compile(r"^\d{4}_")
 
+# A repository whose history already contains an ordering violation cannot fix
+# it: the entry has been applied and recorded, and re-stamping it would only
+# hide the entry from databases that already ran it. Without a way to record
+# such a case, the check stays red forever and can never be a required check,
+# which is the same as not having it. This file records those, one object per
+# entry, and each one must be reconciled against the live database first.
+BASELINE_PATH = ".github/drizzle-journal-baseline.json"
+
 # Wording reused by every history failure. All of them have the same fix.
 APPEND_ONLY_FIX = (
     "Migrations are append-only once they reach main. To undo a migration, add "
@@ -86,6 +94,40 @@ def discover_drizzle_dir():
     return found[0][: -len("/meta/_journal.json")], None
 
 
+def load_baseline():
+    """Read the recorded pre-existing violations. Returns (allowed, errors).
+
+    `allowed` maps (idx, tag, when) to the reason it was accepted. Keying on
+    all three means a later edit to the entry stops matching and fails again,
+    so this can wave through history without weakening the rule.
+    """
+    if not os.path.exists(BASELINE_PATH):
+        return {}, []
+
+    try:
+        with open(BASELINE_PATH, "r") as handle:
+            data = json.load(handle)
+    except json.JSONDecodeError as exc:
+        return {}, [f"{BASELINE_PATH} is not valid JSON: {exc}"]
+
+    listed = data.get("allow_out_of_order", [])
+    if not isinstance(listed, list):
+        return {}, [f"{BASELINE_PATH} needs `allow_out_of_order` to be a list."]
+
+    allowed, errors = {}, []
+    for item in listed:
+        missing = [k for k in ("idx", "tag", "when", "why") if not item.get(k)]
+        if missing:
+            errors.append(
+                f"{BASELINE_PATH} has an entry missing {missing}: {item}. Every "
+                "accepted violation needs `idx`, `tag`, `when` and a `why` "
+                "saying how it was reconciled against the live database."
+            )
+            continue
+        allowed[(item["idx"], item["tag"], item["when"])] = item["why"]
+    return allowed, errors
+
+
 def load_journal(raw, where):
     """Parse journal JSON and return (entries, errors)."""
     try:
@@ -104,9 +146,14 @@ def load_journal(raw, where):
     return entries, []
 
 
-def check_structure(entries):
-    """Rules that hold for the journal on its own, with no history."""
+def check_structure(entries, allowed):
+    """Rules that hold for the journal on its own, with no history.
+
+    Returns (errors, notes). A violation listed in the baseline file becomes a
+    note, so it stays visible without failing the check for ever.
+    """
     errors = []
+    notes = []
 
     # The watermark only ever moves forward, so each entry must beat the
     # highest `when` before it, not merely the one directly above it. One
@@ -116,6 +163,13 @@ def check_structure(entries):
         curr = entries[i]
         highest = max(entries[:i], key=lambda entry: entry["when"])
         if curr["when"] <= highest["when"]:
+            key = (curr["idx"], curr["tag"], curr["when"])
+            if key in allowed:
+                notes.append(
+                    f"idx={curr['idx']} ({curr['tag']}) is out of order and is "
+                    f"accepted by {BASELINE_PATH}: {allowed[key]}"
+                )
+                continue
             errors.append(
                 f"Entry idx={curr['idx']} ({curr['tag']}, when={curr['when']}) "
                 f"does not come after idx={highest['idx']} ({highest['tag']}, "
@@ -137,7 +191,7 @@ def check_structure(entries):
     if duplicates:
         errors.append(f"Duplicate `tag` values in the journal: {duplicates}")
 
-    return errors
+    return errors, notes
 
 
 def check_files_match(entries, drizzle_dir):
@@ -302,11 +356,19 @@ def main():
     with open(path, "r") as handle:
         entries, errors = load_journal(handle.read(), path)
 
+    allowed, baseline_errors = load_baseline()
+    errors += baseline_errors
+
+    notes = []
     if entries is not None:
-        errors += check_structure(entries)
+        structural, notes = check_structure(entries, allowed)
+        errors += structural
         errors += check_files_match(entries, drizzle_dir)
         if args.base:
             errors += check_history(entries, drizzle_dir, args.base)
+
+    for note in notes:
+        print(f"note: {note}")
 
     if errors:
         return report(errors)

--- a/.github/workflows/drizzle-journal.yml
+++ b/.github/workflows/drizzle-journal.yml
@@ -21,6 +21,12 @@ jobs:
           # needs the history, not just the tip commit.
           fetch-depth: 0
 
+      # Runs first, on throwaway repositories, so a change that breaks a rule
+      # fails the pull request that makes it rather than one that trips over it
+      # months later.
+      - name: Test the check itself
+        run: bash .github/scripts/test_validate_drizzle_journal.sh
+
       - name: Validate the Drizzle journal
         env:
           BASE_REF: origin/${{ github.base_ref }}


### PR DESCRIPTION
## Summary

Follow-up to the Drizzle journal check that merged earlier today. Two changes, both found by putting the same check into seven repositories at once. The check file stays byte for byte identical everywhere, so this lands in all of them.

## A repository with an old violation could never go green

If a journal already contains an ordering violation, there is no fix. The entry has been applied and recorded, and re-stamping it would only hide it from the databases that already ran it. The check would fail on every pull request for ever, so it could never be a required check, which is the same as not having it.

`.github/drizzle-journal-baseline.json` now records those entries:

```json
{
  "allow_out_of_order": [
    {
      "idx": 50,
      "tag": "0050_sturdy_joseph",
      "when": 1780051352492,
      "why": "Verified applied in production: 82 of 82 recorded."
    }
  ]
}
```

It cannot be used to wave through new mistakes:

- the record is keyed on `idx`, `tag` **and** `when`, so editing the entry changes the key, the record stops matching, and it fails again;
- a record with no `why` is rejected, so every accepted violation carries a written reason;
- accepted entries are still printed on every run, as `note:` lines, so they stay visible instead of disappearing;
- it only ever covers ordering. Every other rule is untouched.

This repository needs no baseline file. Its journal is clean.

## The check now has tests

`.github/scripts/test_validate_drizzle_journal.sh`, 16 cases, each building a throwaway git repository so the tests never touch real migrations:

| Must pass | Must fail |
|---|---|
| untouched branch | new entry stamped in the past |
| correct append | re-stamped an applied entry |
| hand-run helper added | removed an applied entry |
| hand-run helper edited | edited an applied `.sql` |
| baseline accepts a recorded violation | renamed an applied migration |
| | orphan `NNNN_*.sql` |
| | a future stamp hiding two later entries |
| | pre-existing violation with no baseline |
| | baseline against a re-stamped entry |
| | baseline with the wrong tag |
| | baseline entry with no reason |

CI runs them **before** the check itself, so a change that breaks a rule fails the pull request that makes it rather than one that trips over it months later.

## Verification

- [x] 16 of 16 cases pass.
- [x] The check still passes on this repository's own journal.
- [x] With no baseline file present, behaviour is exactly what merged earlier. The file is optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
