### PR TITLE
fix(macos): unwrap the optional cloudProvider on backup restore (unbreaks main)

### DIFF
--- a/app/macos/hyperwhisper/CoreData/PersistenceController.swift
+++ b/app/macos/hyperwhisper/CoreData/PersistenceController.swift
@@ -2430,7 +2430,7 @@ class PersistenceController: ObservableObject {
                 cloudTranscriptionModel: backupMode.cloudTranscriptionModel.map {
                     CloudTranscriptionModels.resolveModelAlias(
                         $0,
-                        provider: CloudProvider(rawValue: backupMode.cloudProvider)
+                        provider: backupMode.cloudProvider.flatMap { CloudProvider(rawValue: $0) }
                     )
                 },
                 postProcessingMode: backupMode.postProcessingMode,


### PR DESCRIPTION
## What

`main` has not compiled on macOS since #150 landed on 2026-08-07. One line:

```
app/macos/hyperwhisper/CoreData/PersistenceController.swift:2433:70:
error: value of optional type 'String?' must be unwrapped to a value of type 'String'
```

`BackupMode.cloudProvider` is `String?` (`Models/BackupModels.swift:483`), but the backup-restore path passed it straight into `CloudProvider(rawValue:)`, which takes a non-optional `String`.

## The fix

```diff
-  provider: CloudProvider(rawValue: backupMode.cloudProvider)
+  provider: backupMode.cloudProvider.flatMap { CloudProvider(rawValue: $0) }
```

`resolveModelAlias` already takes `CloudProvider?` and handles `nil` in its own `case nil` arm (`Models/CloudTranscriptionModels.swift:690`). So flat-mapping the optional is the whole fix. A backup with no stored provider resolves its model ID unqualified, which is what the pre-#150 code did.

This matches how Windows does the same job in `Services/UniversalBackupMapper.cs:455`: the raw (not normalized) provider goes through a null-safe lookup.

## Verification

Local `xcodebuild`, Debug, arm64:

- `build` → **BUILD SUCCEEDED**
- `build-for-testing` → **TEST BUILD SUCCEEDED**

Clean `origin/main` without this patch fails both, with exactly the error above.

## Note on CI

macOS CI caught this on the #150 PR itself — that run was red before merge, and every macOS CI run since has been red. Worth a look at why a red required check did not block the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NAdt2PeuMStcC4pCGaHaWJ