### PR TITLE
fix(macos): stop launch-minimized hiding a window the user just opened

### DIFF
--- a/app/macos/hyperwhisper/AppDelegate.swift
+++ b/app/macos/hyperwhisper/AppDelegate.swift
@@ -50,6 +50,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// follows launch completion.
     static private(set) var didFinishLaunching = false
 
+    /// When `applicationDidFinishLaunching` ran, or `nil` if it has not yet.
+    ///
+    /// Lets scene code tell a launch-time window appearance from a
+    /// user-initiated one — see `HyperWhisperApp.handleMainWindowAppear()`.
+    static private(set) var didFinishLaunchingAt: Date?
+
     // MARK: - Initialization
     
     override init() {
@@ -67,6 +73,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - NSApplicationDelegate
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppDelegate.didFinishLaunching = true
+        AppDelegate.didFinishLaunchingAt = Date()
 
         // Initialize Sentry if DSN is configured and error logging is enabled
         let loggingEnabled = UserDefaults.standard.bool(forKey: "enableErrorLogging")

--- a/app/macos/hyperwhisper/hyperwhisperApp.swift
+++ b/app/macos/hyperwhisper/hyperwhisperApp.swift
@@ -802,6 +802,12 @@ struct MenuBarIconView: View {
         }
     }
 
+    /// How long after `applicationDidFinishLaunching` a main-window appearance
+    /// still counts as part of launch. Generous on purpose: the only thing on the
+    /// other side of it is a window the user asked for by hand, which no plausible
+    /// launch takes this long to reach.
+    private static let launchAppearanceGracePeriod: TimeInterval = 10
+
     /// Handles setup that genuinely needs the main window to exist.
     ///
     /// Only onboarding (which presents a sheet in this window) and the
@@ -813,6 +819,23 @@ struct MenuBarIconView: View {
         // the end to avoid restoring the selected mode twice on a normal launch.
         let wasAlreadyBootstrapped = Self.didBootstrapAppServices
         bootstrapAppServices()
+
+        // Is this the window appearance that belongs to app launch?
+        //
+        // Since #182 the main window may be created for the first time long after
+        // launch — the user picks Settings from the menu bar and SwiftUI builds the
+        // WindowGroup right then. `didResolveLaunchMinimizedHide` does not catch
+        // that: a login-item launch never renders the window, so the hide is still
+        // unresolved and would fire on the window the user just asked for. Gate on
+        // elapsed time instead of on "first appearance", which would also cancel
+        // the retry the no-window-yet path below depends on.
+        let isLaunchAppearance: Bool
+        if let launchedAt = AppDelegate.didFinishLaunchingAt {
+            isLaunchAppearance = Date().timeIntervalSince(launchedAt) < Self.launchAppearanceGracePeriod
+        } else {
+            // Launch hasn't even finished — this can only be the launch window.
+            isLaunchAppearance = true
+        }
 
         // Ensure the app is activated so the window comes forward on a normal
         // (non-minimized) launch. Hotkeys no longer depend on this — see
@@ -841,7 +864,7 @@ struct MenuBarIconView: View {
         // LAUNCH MINIMIZED: Hide main window if preference is set
         // This allows the app to run in menu bar only mode by default
         // Users can still access the window via Menu Bar > Settings
-        if launchMinimized && hasCompletedOnboarding && !Self.didResolveLaunchMinimizedHide {
+        if isLaunchAppearance && launchMinimized && hasCompletedOnboarding && !Self.didResolveLaunchMinimizedHide {
             // Delay to ensure window is fully created before hiding
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 // MainWindowStore, not NSApp.windows.first: hotkeys are now live


### PR DESCRIPTION
Follow-up to #182, found by a review pass over that branch.

## The bug

#182 made menu-bar-only operation viable — hotkeys come up without the main window. So a login-item launch can now run for hours with the `WindowGroup` never rendered.

That turns the launch-minimized hide into a trap:

1. The app starts as a login item with `launchMinimized` on. The window is never built.
2. Hours later the user picks **Settings** from the menu bar.
3. SwiftUI builds the `WindowGroup`. `.onAppear` fires for the **first** time.
4. `handleMainWindowAppear()` runs the launch-minimized hide. 0.3s later the window is ordered out and the app deactivates.

The Settings window flashes and vanishes. Every time. The user has no way to reach it.

`didResolveLaunchMinimizedHide` does not catch this. It suppresses a *second* hide, and on a login-item launch no first hide ever ran — the flag is still `false` when that late appearance arrives.

## The fix

Gate the hide on how long ago the app launched. `AppDelegate` records `didFinishLaunchingAt`; an appearance more than 10s later is a window the user asked for, not the launch window.

A "first appearance only" flag was the obvious rule and is wrong: it cancels the no-window-yet retry directly below it, which needs a later appearance to stay eligible.

A normal launch is unchanged — the window appears well inside the grace period and the hide runs as before.

## Testing

`xcodebuild -scheme hyperwhisper -configuration Debug build` → **BUILD SUCCEEDED**.

Not verified by hand: the login-item launch, the hours-later Settings open, and the flash itself. This is read from the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zg7LAKsDnds2dB3nKmTx9