### PR TITLE
style(web): drop the latency page header title and add vertical padding

### DIFF
--- a/nextjs/app/[locale]/latency/page.tsx
+++ b/nextjs/app/[locale]/latency/page.tsx
@@ -46,15 +46,9 @@ export default async function LatencyPage({ params }: Props) {
   );
 
   return (
-    <div className="w-full">
+    <div className="w-full py-16 md:py-24">
       <header className="mx-auto max-w-3xl text-center">
-        <p className="text-sm uppercase tracking-[0.3em] text-purple-300">
-          HyperWhisper Cloud
-        </p>
-        <h1 className="mt-4 bg-gradient-to-r from-white to-gray-400 bg-clip-text text-4xl font-bold text-transparent md:text-6xl">
-          {TITLE}
-        </h1>
-        <p className="mx-auto mt-5 text-lg text-gray-400">
+        <p className="mx-auto text-lg text-gray-400">
           Every transcription we run times the provider that answered it. These
           are those timings — {totalSamples.toLocaleString()} provider attempts
           over the last {WINDOW_DAYS} days, grouped by the region that made the


### PR DESCRIPTION
## What

On `/en/latency`:

- Removes the `HyperWhisper Cloud` eyebrow and the `Speech-to-text latency, measured` `<h1>` from the header.
- Keeps the lead paragraph as the first element of the header.
- Adds `py-16 md:py-24` to the page root, so the page has top and bottom padding.

The `TITLE` constant stays. It is still used for the page metadata and the canonical title.

## Test

`npx tsc --noEmit` shows no error for this file. The pre-existing errors in `CustomersClient.tsx` and `TRPCProvider.tsx` are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Khv94wPTEwK2a88nrKbpWJ