### PR TITLE
Drop the ACS member credit bundle from $10 back to $5

### DIFF
--- a/nextjs/src/lib/db-layer.ts
+++ b/nextjs/src/lib/db-layer.ts
@@ -206,15 +206,18 @@ export async function getGrantedEmails(): Promise<string[]> {
     .filter((email) => email.length > 0);
 }
 
-// Credits granted with each internal-bundle Account Key mint. $10 at the
+// Credits granted with each internal-bundle Account Key mint. $5 at the
 // 1000-credits-per-dollar rate. This is the ACS member perk; only brand-new
 // emails receive it (an email that already has a granted key gets no top-up).
-const INTERNAL_BUNDLE_CREDITS = 10000;
+// The perk ran at $5, was bumped to $10 on 2026-07-02, and came back to $5 on
+// 2026-08-13. ACS shows each member what they truly got, keyed off their claim
+// date, so keep its `creditDollarsForClaim` eras in step with any change here.
+const INTERNAL_BUNDLE_CREDITS = 5000;
 
 /**
  * Mint a fresh internal-bundle license for an email: generate a collision-free
  * key, ensure the user exists, insert the license as "granted", and grant the
- * standard 10,000-credit ($10) internal bundle.
+ * standard 5,000-credit ($5) internal bundle.
  *
  * This is the single source of truth for the internal mint flow. Its only
  * caller is the grant-license endpoint (driven by the ACS claim flow), which


### PR DESCRIPTION
`INTERNAL_BUNDLE_CREDITS` goes from `10000` to `5000`, at the 1000-credits-per-dollar rate.

This is the grant behind the Agentic Coding School perk ("claim your HyperWhisper Cloud credits"). ACS never sends an amount. It POSTs the member's email to `/api/internal/grant-license`, and this constant is the only place the size is decided, so this one line is the whole change.

Only brand-new emails are affected. An email that already holds a granted key gets no top-up, so nobody's existing balance moves.

## Paired change

ACS: https://github.com/ray-amjad/agentic-coding-school/pull/812 (copy, plus a third `$5` era in `creditDollarsForClaim` so members keep seeing what they truly received).

That PR closes its `$10` era at 2026-08-13T01:50Z, which is already in the past, so the two deploys can land in either order. Until this one ships, a new claimer receives $10 and is shown $5: an under-report rather than an over-promise.

## Checks

`tsc --noEmit` reports the same 3 pre-existing errors as `main` (in `CustomersClient.tsx` and `TRPCProvider.tsx`), none in `db-layer.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N35qAVpZV4e6BGmT7okSxL