### PR TITLE
fix(web): let the latency page show a number from three attempts

### DIFF
--- a/nextjs/lib/latency/types.ts
+++ b/nextjs/lib/latency/types.ts
@@ -46,21 +46,34 @@ export const WINDOW_DAYS = 30;
 
 /**
  * A cell below this many attempts shows "not enough data" instead of a number.
- * A p95 drawn from a handful of samples is noise wearing a percentile's clothes.
+ *
+ * Deliberately low. The honest statistical bar is far higher — a p95 from three
+ * calls is that cell's slowest call wearing a percentile's clothes — but a page
+ * of nothing but dashes tells a visitor less than a rough number does, and the
+ * table already carries the caveat in two places: the footnote states the bar,
+ * and every populated cell puts its own attempt count in the hover title, so a
+ * three-attempt cell never passes itself off as a settled figure. Three is the
+ * floor at which a median has a middle value that is not simply one of the two
+ * extremes.
+ *
+ * Raise this as the dataset fills in. p99 is exempt and always has been; see
+ * MIN_SAMPLES_FOR_P99 for the arithmetic that makes it a different question.
  */
-export const MIN_SAMPLES_PER_CELL = 20;
+export const MIN_SAMPLES_PER_CELL = 3;
 
 /**
  * p99 needs its own, far higher bar.
  *
  * `percentile_cont(0.99)` interpolates at index `0.99 × (n - 1)`, so at the p50
- * threshold of 20 attempts it lands at 18.81 — between the two slowest calls the
- * cell has ever made. Nineteen 300 ms calls and one 15-second timeout would
- * print ≈12,200 ms as though it were a stable figure, and one more slow call the
- * next day would move it by seconds. At 500 attempts the reported value has five
- * observations above it, so a single outlier shifts it by tens of milliseconds
- * rather than seconds. A cell that cannot clear this shows a dash under p99 and
- * still shows its p50 and p95.
+ * threshold of 3 attempts it lands at 1.98 — 98% of the way from the cell's
+ * second-slowest call to its slowest. Two 300 ms calls and one 15-second timeout
+ * would print ≈14,700 ms as though it were a stable figure, and one more slow
+ * call the next day would move it by seconds. The same holds at 20 attempts
+ * (index 18.81) and at any cell size a young dataset reaches: p99 does not
+ * become meaningful by lowering the bar, only by collecting more calls. At 500
+ * attempts the reported value has five observations above it, so a single
+ * outlier shifts it by tens of milliseconds rather than seconds. A cell that
+ * cannot clear this shows a dash under p99 and still shows its p50 and p95.
  */
 export const MIN_SAMPLES_FOR_P99 = 500;
 


### PR DESCRIPTION
## The problem

`/en/latency` renders every one of its 66 cells as a dash. Not a bug in the query, the ingest, or the page — a threshold set for a mature dataset applied to a dataset one day old.

`MIN_SAMPLES_PER_CELL` is 20. Checked against production:

| | |
|---|---|
| Rows in `stt_latency_samples` | 131 |
| First row | 2026-08-13 01:00 UTC |
| Largest cell **anywhere** | 17 (ElevenLabs / Frankfurt / medium) |
| Largest cell in the **default** view (`short`) | 7 (Deepgram / Ashburn) |

Nothing clears 20, so nothing prints.

The pipeline itself is healthy — 44 populated provider × region × bucket cells, all 11 providers, 7 Fly regions, hourly coarsening working. Volume is thin because `clientOffersLatencyOptOut` only counts macOS ≥ 2.43.0 and Windows ≥ 1.10.0, and macOS 2.43.0 published at 03:09 UTC the same day. That resolves itself as Sparkle rolls users forward.

## The change

One constant: `MIN_SAMPLES_PER_CELL` 20 → 3, plus the comment rewritten to say plainly that this sits below the honest statistical bar and should be raised as the window fills.

Nothing else needs touching — the footnote already prints `at least {minSamples} attempts` from the same constant, and every populated cell already carries its own attempt count in its hover title. A three-attempt cell cannot present itself as settled.

This lights up 15 cells in the default view, including all 11 providers in Ashburn:

```
Groq 330 · Grok 384 · Mistral 406 · ElevenLabs 476 · Deepgram 529
Azure MAI 589 · Google Chirp 888 · OpenAI 1491 · Soniox 2372
Gemini 2961 · AssemblyAI 3709        (ms, median, iad, <10s clips)
```

plus Azure MAI in Tokyo (1262), Deepgram in Sydney (1628) and Chicago (509), ElevenLabs in Frankfurt (852).

## What is deliberately left alone

`MIN_SAMPLES_FOR_P99` stays at 500, so the p99 tab remains entirely dashed. Lowering it would not make p99 meaningful — `percentile_cont(0.99)` over three samples interpolates at index `0.99 × 2 = 1.98`, i.e. 98% of the way from the cell's second-slowest call to its slowest, so one timeout becomes the whole number. The page already explains this in the footnote when p99 is selected. The comment now works the arithmetic at both 3 and 20 to make clear the bar is not the thing standing in the way.

## Testing

`node --test --experimental-strip-types tests/latency-report-validation.test.ts` — 24/24 pass, including `p99 needs far more attempts than the other metrics`, which pins the relationship between the two thresholds and still holds (`samplesAboveP99(3) = 0.02 < 1`, `samplesAboveP99(500) = 4.99 ≥ 4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1AXTD9aFjrPrSr3wzx6Ca