### PR TITLE
feat(web): link the latency page from the navbar

### DIFF
--- a/nextjs/components/navbar.tsx
+++ b/nextjs/components/navbar.tsx
@@ -25,15 +25,25 @@ export const Navbar = () => {
   const t = useTranslations("navbar");
   const locale = useLocale();
 
+  /*
+    The latency page is English-only — it 404s on every other locale — so its
+    href is the absolute /en/latency and it is rendered with a native <a>,
+    never LocaleLink (which would prefix it into /ja/en/latency). Label is
+    hardcoded for the same reason: the page it opens is English either way.
+  */
+  const latencyItem = { label: "Latency", href: "/en/latency", raw: true };
+
   const navItems = [
     { label: t("features"), href: `/${locale}#features` },
     { label: t("cloud"), href: `/${locale}#cloud` },
+    latencyItem,
     { label: t("faq"), href: `/${locale}#faq` },
   ];
 
   const navMenuItems = [
     { label: t("features"), href: `/${locale}#features` },
     { label: t("cloud"), href: `/${locale}#cloud` },
+    latencyItem,
     { label: t("faq"), href: `/${locale}#faq` },
     { label: t("support"), href: "/support" },
   ];
@@ -120,10 +130,10 @@ export const Navbar = () => {
 
       <NavbarMenu className="bg-black/95 backdrop-blur-xl">
         <div className="mx-4 mt-2 flex flex-col gap-2">
-          {/* Use native <a> for anchor links, LocaleLink for page routes */}
+          {/* Use native <a> for anchor links and already-localed hrefs, LocaleLink for page routes */}
           {navMenuItems.map((item, index) => (
             <NavbarMenuItem key={`${item}-${index}`}>
-              {item.href.includes("#") ? (
+              {item.href.includes("#") || "raw" in item ? (
                 <a
                   className="text-gray-300 hover:text-white transition-colors text-lg"
                   href={item.href}


### PR DESCRIPTION
The latency page shipped with no route into it — you had to know the URL. This adds **Latency** to the navbar, in the desktop bar and the mobile menu, between Cloud and FAQ (it is the proof behind the Cloud pitch).

### Why the href is `/en/latency` and not `/latency`

`app/[locale]/latency/page.tsx` calls `notFound()` for every locale but `en`, so a locale-relative link would break for the other forty locales. The absolute path always resolves.

That also means it cannot go through next-intl's `LocaleLink` in the mobile menu, which would rewrite `/en/latency` into `/ja/en/latency` — hence the `raw` flag on the item and the widened native-`<a>` condition.

The label is a literal rather than a `messages/*.json` key, matching the footer's existing `"Open Source"` link: the page it opens is untranslated English either way.

### Verified

Against a local dev server, the link renders as `href="/en/latency"` on `/en`, on `/ja`, and on the latency page itself; `/en/latency` returns 200. `tsc --noEmit` surfaces no new errors (three pre-existing ones in `CustomersClient.tsx` and `lib/trpc/TRPCProvider.tsx` come from dependency drift in the local checkout).

### Noticed, not fixed here

- The footer's Resources column still does not list Latency.
- In production `/ja/latency` serves the not-found body with a **200** status — `force-static` + `notFound()` gets prerendered and edge-cached. This PR's link sidesteps it, but search engines may be indexing forty locale copies of a soft 404. A `generateStaticParams` returning only `en` would fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y1CizDk76ZcJtE5ni1dzJi