### PR TITLE
fix(cloud): stop one spaced vocabulary term 400ing every Mistral request

### DIFF
--- a/hyperwhisper-cloud/references/custom-vocab.md
+++ b/hyperwhisper-cloud/references/custom-vocab.md
@@ -16,4 +16,13 @@ When dealing with Deepgram vocabulary boosting method based on the language para
 - Backend appends ONE repeated query value per term — `keyterm=a&keyterm=b` (and `keywords=a&keywords=b` on Nova-2). NOT a single comma-joined value. `keyterm` does NOT accept a `:boost` suffix (that's the legacy Nova-2 `keywords` syntax); send the bare term.
 - Maximum 100 terms per request (enforced at both client and backend)
 - `keyterm` is used when language is explicitly specified with Nova-3 (monolingual transcription)
+
+## Mistral Voxtral (`context_bias`)
+
+Voxtral takes the same `initial_prompt` string, split into ≤100 `context_bias` items (`providers/mistral.ts`).
+
+- Each item is sent as ONE repeated multipart field — `context_bias=a` `context_bias=b`. A comma-joined value is read as a single literal phrase and boosts nothing (still HTTP 200).
+- **An item may not contain a comma or ANY whitespace.** Voxtral validates under `context_bias_input_method=comma_separated` (its server default) and rejects the WHOLE request with a 400. One spaced term like `Claude Code` fails the transcription outright, and a 400 is not a failover status, so no sibling provider covers it.
+- Multi-word phrases are therefore joined with underscores (`Claude_Code`) — the format Mistral's own docs use (`affordable_health_care`, `American_people`).
+- Items longer than 80 characters are dropped.
 - No vocabulary parameter is used when language is "auto" (Nova-3 doesn't support `keywords`, and `keyterm` is ignored with `detect_language=true`)

--- a/hyperwhisper-cloud/src/providers/mistral.test.ts
+++ b/hyperwhisper-cloud/src/providers/mistral.test.ts
@@ -108,6 +108,25 @@ describe('transcribeWithMistral — context_bias encoding', () => {
     expect(captured.form?.getAll('context_bias')).toEqual(['Drizzle', 'HyperWhisper', 'Voxtral']);
   });
 
+  // Voxtral 400s the whole request when ANY item holds whitespace, so a single
+  // multi-word vocabulary term used to fail the transcription outright.
+  test('joins a multi-word phrase with underscores instead of leaving the space', async () => {
+    const captured = captureRequest(okBody);
+
+    await transcribeWithMistral(audio(), 'audio/wav', undefined, 'Claude Code,Drizzle,Fly.io');
+    expect(captured.form?.getAll('context_bias')).toEqual(['Claude_Code', 'Drizzle', 'Fly.io']);
+  });
+
+  test('leaves no whitespace of any kind inside a phrase', async () => {
+    const captured = captureRequest(okBody);
+
+    await transcribeWithMistral(audio(), 'audio/wav', undefined, '-  New\tYork  City , a b');
+    expect(captured.form?.getAll('context_bias')).toEqual(['New_York_City', 'a_b']);
+    for (const term of captured.form?.getAll('context_bias') ?? []) {
+      expect(String(term)).not.toMatch(/[\s,]/);
+    }
+  });
+
   test('drops phrases longer than 80 characters and keeps the rest', async () => {
     const captured = captureRequest(okBody);
     const tooLong = 'x'.repeat(81);

--- a/hyperwhisper-cloud/src/providers/mistral.ts
+++ b/hyperwhisper-cloud/src/providers/mistral.ts
@@ -22,11 +22,22 @@ const MAX_CONTEXT_BIAS_TERMS = 100;
 /** Voxtral additionally takes raw AAC, which the other adapters don't name. */
 const MISTRAL_AUDIO_EXTENSIONS = [...DEFAULT_AUDIO_EXTENSIONS, 'aac'] as const;
 
-/** Split a comma/newline vocabulary prompt into ≤100 `context_bias` phrases. */
+/**
+ * Split a comma/newline vocabulary prompt into ≤100 `context_bias` phrases.
+ *
+ * Inner whitespace collapses to `_` because Voxtral validates every item under
+ * `context_bias_input_method=comma_separated` (its server-side default) and 400s
+ * the WHOLE request when one item holds a comma or any whitespace — a single
+ * multi-word term like "Claude Code" then kills the transcription, not just that
+ * term, and a 400 is not a failover status so no sibling provider covers it.
+ * Underscores are the documented way to bias a phrase (docs.mistral.ai
+ * audio/speech_to_text → `["affordable_health_care", "American_people"]`), so
+ * joining beats dropping the term.
+ */
 function toContextBias(initialPrompt: string): string[] {
   return initialPrompt
     .split(/[,\n;]+/)
-    .map((t) => t.trim().replace(/^[-*]\s*/, ''))
+    .map((t) => t.trim().replace(/^[-*]\s*/, '').replace(/\s+/g, '_'))
     .filter((t) => t.length > 0 && t.length <= 80)
     .slice(0, MAX_CONTEXT_BIAS_TERMS);
 }


### PR DESCRIPTION
## The bug

A vocabulary term with a space in it — `Claude Code` — makes **every** Mistral transcription fail:

```
Transcription failed: Server error (400): No transcription provider accepted this request:
Mistral rejected input (400): Context bias item 'Claude Code' must not contain commas or whitespace
(context_bias_input_method=comma_separated)
```

## Why

1. The client joins vocabulary terms with commas (`buildInitialTranscriptionPrompt`), so inner spaces survive.
2. `toContextBias()` splits on `,` `\n` `;` and trims the **ends** only, so the item stays `Claude Code`.
3. Voxtral validates each item under `context_bias_input_method=comma_separated` (its server-side default) and rejects the item for holding whitespace.
4. The rejection 400s the **whole request**, not the one term. A 400 is not a failover status here (only 402 fails over), so the chain stops and nothing is transcribed.

Net effect: one multi-word term in the user's vocabulary disabled Mistral entirely.

## The fix

Collapse inner whitespace to `_`. Underscores are how Mistral's own docs bias a phrase — their example passes `["affordable_health_care", "American_people"]` — so the term is still boosted rather than dropped.

```diff
-    .map((t) => t.trim().replace(/^[-*]\s*/, ''))
+    .map((t) => t.trim().replace(/^[-*]\s*/, '').replace(/\s+/g, '_'))
```

`Claude Code` → `Claude_Code`. Single-word terms are untouched.

## Tests

Two cases added to `mistral.test.ts`:
- a multi-word phrase arrives underscore-joined
- no item carries whitespace of any kind (space, tab, repeated spaces), asserted with `/[\s,]/`

`bun test src/providers/mistral.test.ts src/routes/transcribe-multi-provider.test.ts` → 56 pass, 0 fail. `tsc --noEmit` clean.

Also documents the Voxtral rules in `references/custom-vocab.md`, which `hyperwhisper-cloud/CLAUDE.md` points at for vocabulary work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9xaa691ABAKAqP23SUK9h
