### PR TITLE
fix(apps): three follow-ups from the pre-release audit

### DIFF
--- a/app/macos/hyperwhisper/Views/Modes/Components/ModePostProcessingSettings.swift
+++ b/app/macos/hyperwhisper/Views/Modes/Components/ModePostProcessingSettings.swift
@@ -295,6 +295,18 @@ struct LanguageProcessingSettingsView: View {
 
         guard !options.contains(where: { $0.id == current }) else { return }
 
+        // DEPRECATION MAP RESOLUTION:
+        // Consult the documented retirement map (PostProcessingModels.resolvedModelId)
+        // before falling back to list order. This is the same map the transcription
+        // path uses (AIPostProcessor.swift), so a stored retired id lands on its
+        // intended replacement here too, instead of on whatever option happens to be
+        // first in the picker.
+        let resolved = PostProcessingModels.resolvedModelId(current, provider: currentProvider)
+        if resolved != current, options.contains(where: { $0.id == resolved }) {
+            languageModel = resolved
+            return
+        }
+
         // CASE-INSENSITIVE RESOLUTION:
         // Handles stored ids that differ only in casing from the current catalog (e.g.
         // legacy Gemma 4 12B uppercase → current lowercase). Rewrites the stored id to

--- a/app/macos/hyperwhisperTests/PostProcessingModelResolutionTests.swift
+++ b/app/macos/hyperwhisperTests/PostProcessingModelResolutionTests.swift
@@ -1,0 +1,47 @@
+//
+//  PostProcessingModelResolutionTests.swift
+//  hyperwhisperTests
+//
+
+import Foundation
+import Testing
+@testable import HyperWhisper
+
+/// Covers the data the mode editor's `ensureValidLanguageModelSelection()` relies on
+/// (`ModePostProcessingSettings.swift`) when a stored `languageModel` id is one of the
+/// 5 ids retired by #217 (commit 367443a). The editor now resolves a stored id through
+/// `PostProcessingModels.resolvedModelId()` before falling back to `options.first`, so
+/// this asserts each retired id resolves to its documented replacement, and that the
+/// replacement is actually present in that provider's picker options — the same guard
+/// `ensureValidLanguageModelSelection()` checks before accepting the resolved id.
+struct PostProcessingModelResolutionTests {
+    @Test func retiredIdsResolveToDocumentedReplacementPresentInPickerOptions() {
+        let retiredIds: [(id: String, provider: PostProcessingProvider, replacement: String)] = [
+            ("moonshotai/kimi-k2-instruct", .groq, "openai/gpt-oss-120b"),
+            ("open-mistral-nemo", .mistral, "mistral-small-latest"),
+            ("claude-sonnet-4-0", .anthropic, "claude-sonnet-4-5"),
+            ("meta-llama/llama-4-maverick-17b-128e-instruct", .groq, "openai/gpt-oss-120b"),
+            ("zai-glm-4.7", .cerebras, "gpt-oss-120b"),
+        ]
+
+        for entry in retiredIds {
+            let resolved = PostProcessingModels.resolvedModelId(entry.id, provider: entry.provider)
+            #expect(resolved == entry.replacement, "\(entry.id) should resolve to \(entry.replacement)")
+
+            let options = PostProcessingModels.models(for: entry.provider)
+            #expect(
+                options.contains(where: { $0.id == resolved }),
+                "resolved replacement \(resolved) must be a selectable option for \(entry.provider), otherwise the editor falls back to options.first instead of the intended model"
+            )
+        }
+    }
+
+    @Test func unknownIdIsLeftUnresolvedSoCallersFallBackToOptionsFirst() {
+        // A truly unmapped id must come back unchanged — this is what tells
+        // `ensureValidLanguageModelSelection()` to fall through to its
+        // `options.first` last resort instead of accepting a bogus "replacement".
+        let unknownId = "totally-unknown-model-id-\(UUID().uuidString)"
+        let resolved = PostProcessingModels.resolvedModelId(unknownId, provider: .groq)
+        #expect(resolved == unknownId)
+    }
+}

--- a/app/windows/HyperWhisper.SmokeTests/Program.cs
+++ b/app/windows/HyperWhisper.SmokeTests/Program.cs
@@ -1546,6 +1546,93 @@ internal static class Program
                 }
             });
 
+            // HYPERWHISPER-SP / HYPERWHISPER-FM parity: LicenseNetworkService.LicenseVerdictReason
+            // decides whether a non-200 license-validate reply is an ordinary verdict (log only) or
+            // a genuine backend incident (capture to Sentry). The backend answers 400 with the SAME
+            // {"valid":false,"error":"..."} shape for a lapsed license, a nonexistent key, AND a real
+            // infrastructure fault, so the shape alone cannot decide this - only the server's own
+            // `reason` field can. Mirrors macOS LicenseNetworkVerdictReportingTests.swift exactly.
+            Run("LicenseVerdictReason recognizes reason=not_entitled at 400 as an ordinary verdict", () =>
+            {
+                var body = System.Text.Encoding.UTF8.GetBytes(
+                    """{"valid":false,"error":"License is revoked","reason":"not_entitled"}""");
+                var reason = LicenseNetworkService.LicenseVerdictReason(400, body);
+                Assert(reason == LicenseNetworkService.NotEntitledReason,
+                    $"expected '{LicenseNetworkService.NotEntitledReason}', got '{reason ?? "<null>"}'");
+            });
+
+            Run("LicenseVerdictReason: reason alone (no other fields) is enough at 400", () =>
+            {
+                var body = System.Text.Encoding.UTF8.GetBytes("""{"reason":"not_entitled"}""");
+                var reason = LicenseNetworkService.LicenseVerdictReason(400, body);
+                Assert(reason == LicenseNetworkService.NotEntitledReason, $"got '{reason ?? "<null>"}'");
+            });
+
+            Run("LicenseVerdictReason: lookup_failed and bad_request are NOT an ordinary verdict", () =>
+            {
+                var lookupFailed = System.Text.Encoding.UTF8.GetBytes(
+                    """{"valid":false,"error":"Failed to validate with Polar","reason":"lookup_failed"}""");
+                var badRequest = System.Text.Encoding.UTF8.GetBytes(
+                    """{"valid":false,"error":"License key is required","reason":"bad_request"}""");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, lookupFailed) == "lookup_failed",
+                    "expected 'lookup_failed' returned verbatim");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, badRequest) == "bad_request",
+                    "expected 'bad_request' returned verbatim");
+            });
+
+            Run("LicenseVerdictReason: an unrecognised reason is returned verbatim but is not a verdict", () =>
+            {
+                var body = System.Text.Encoding.UTF8.GetBytes(
+                    """{"valid":false,"error":"...","reason":"quota_exceeded"}""");
+                var reason = LicenseNetworkService.LicenseVerdictReason(400, body);
+                Assert(reason == "quota_exceeded", $"got '{reason ?? "<null>"}'");
+                Assert(reason != LicenseNetworkService.NotEntitledReason,
+                    "an unrecognised reason must never equal the not-entitled constant");
+            });
+
+            Run("LicenseVerdictReason: a body with no reason field is not a verdict (must still be captured)", () =>
+            {
+                var noReason = System.Text.Encoding.UTF8.GetBytes(
+                    """{"valid":false,"error":"License is revoked"}""");
+                var validTrue = System.Text.Encoding.UTF8.GetBytes("""{"valid":true}""");
+                var emptyObject = System.Text.Encoding.UTF8.GetBytes("{}");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, noReason) == null,
+                    "expected null for a 400 body with no reason field");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, validTrue) == null,
+                    "expected null for valid:true with no reason field");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, emptyObject) == null,
+                    "expected null for an empty JSON object");
+            });
+
+            Run("LicenseVerdictReason: an empty body or an HTML captive-portal page is not a verdict", () =>
+            {
+                var html = System.Text.Encoding.UTF8.GetBytes(
+                    "<!DOCTYPE html><html><body><h1>Sign in to continue</h1></body></html>");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, System.Array.Empty<byte>()) == null,
+                    "expected null for an empty body");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, html) == null,
+                    "expected null for an undecodable HTML body");
+            });
+
+            Run("LicenseVerdictReason: non-object JSON and a non-string reason are not a verdict", () =>
+            {
+                var array = System.Text.Encoding.UTF8.GetBytes("[]");
+                var nonStringReason = System.Text.Encoding.UTF8.GetBytes("""{"valid":false,"reason":7}""");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, array) == null, "expected null for a JSON array");
+                Assert(LicenseNetworkService.LicenseVerdictReason(400, nonStringReason) == null,
+                    "expected null for a non-string reason value");
+            });
+
+            Run("LicenseVerdictReason: only status 400 is eligible - same body at 500 is not a verdict", () =>
+            {
+                var verdictBody = System.Text.Encoding.UTF8.GetBytes(
+                    """{"valid":false,"error":"License is revoked","reason":"not_entitled"}""");
+                Assert(LicenseNetworkService.LicenseVerdictReason(500, verdictBody) == null,
+                    "expected null - a 5xx never reaches this predicate as a terminal result, and even if it did, only 400 is the documented verdict status");
+                Assert(LicenseNetworkService.LicenseVerdictReason(401, verdictBody) == null, "expected null at 401");
+                Assert(LicenseNetworkService.LicenseVerdictReason(200, verdictBody) == null, "expected null at 200");
+            });
+
             Console.WriteLine(_failures == 0
                 ? "All smoke tests passed."
                 : $"{_failures} smoke test(s) FAILED.");

--- a/app/windows/HyperWhisper/Services/LicenseNetworkService.cs
+++ b/app/windows/HyperWhisper/Services/LicenseNetworkService.cs
@@ -21,9 +21,19 @@
 // - 24-hour validation cache; 7-day offline grace period.
 // - license.customerId / cachedStatus / lastValidation in kvstore.json.
 // - Raw license key in Windows Credential Manager (unchanged 1:1).
+//
+// ERROR REPORTING (HYPERWHISPER-SP / HYPERWHISPER-FM parity with macOS):
+// - A non-200 that is a genuine backend incident (unexpected status, an
+//   unrecognised/absent verdict reason, or an undecodable body) is captured to
+//   Sentry. An ordinary "this license isn't entitled" reply (400 + a `reason`
+//   of "not_entitled" - lapsed, revoked, or a mistyped/non-existent key) is
+//   only logged - see LicenseVerdictReason.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using HyperWhisper.Models;
@@ -159,6 +169,45 @@ public sealed class LicenseNetworkService : IDisposable
                 // TODO-verify (Windows/CI): Rust shared-core swap.
                 var httpOutcome = HyperwhisperCoreMethods.LicenseHttpErrorOutcome(
                     (ushort)code, responseBytes);
+
+                // The server's own classification of this rejection, or nil if it
+                // stated none. Decoded once and used for BOTH the verdict decision
+                // and the Sentry tag below, so the two can never disagree about
+                // what the server said. Mirrors macOS LicenseNetworkService.swift
+                // (HYPERWHISPER-SP / HYPERWHISPER-FM).
+                var verdictReason = LicenseVerdictReason(code, responseBytes);
+
+                if (verdictReason == NotEntitledReason)
+                {
+                    // An ordinary "this license isn't entitled" reply (lapsed,
+                    // revoked, or a mistyped/non-existent key) — log it, never
+                    // report it. Never log the license key itself.
+                    LoggingService.Warn(
+                        $"LicenseNetworkService: Validation rejected by server - status={code}, reason={verdictReason}, message={httpOutcome.errorMessage ?? "no message"}");
+                }
+                else
+                {
+                    // Everything else is an unexpected non-200: a different
+                    // status, an unrecognised/absent reason, or an undecodable
+                    // body. That is a genuine backend incident, not an ordinary
+                    // verdict — report it. `license_reason` as a TAG (not just an
+                    // extra) so lookup_failed / bad_request / unstated stay
+                    // separable in triage.
+                    SentryService.CaptureDiagnosticEvent(
+                        "License validation server error",
+                        extras: new Dictionary<string, object>
+                        {
+                            ["endpoint"] = request.url,
+                            ["status"] = code,
+                            ["license_reason"] = verdictReason ?? UnstatedReason
+                        },
+                        tags: new Dictionary<string, string>
+                        {
+                            ["component"] = "license",
+                            ["license_reason"] = verdictReason ?? UnstatedReason
+                        });
+                }
+
                 HyperwhisperCoreMethods.LicensePersistValidationVerdict(
                     store, httpOutcome.status, trimmedKey, RustLicenseCore.Now());
                 return RustLicenseCore.ToResult(httpOutcome);
@@ -220,6 +269,83 @@ public sealed class LicenseNetworkService : IDisposable
         }
         return RustLicenseCore.ToResult(
             HyperwhisperCoreMethods.LicenseOfflineFallbackOutcome(store, RustLicenseCore.Now()));
+    }
+
+    // =========================================================================
+    // VERDICT CLASSIFICATION (HYPERWHISPER-SP / HYPERWHISPER-FM parity)
+    // =========================================================================
+
+    /// <summary>
+    /// The one `reason` value that means "ordinary verdict - log it, don't
+    /// report it". Named rather than spelled out at each use so the predicate,
+    /// the call site's branch, and its log line cannot drift apart.
+    /// internal (not private): test seam for HyperWhisper.SmokeTests via
+    /// InternalsVisibleTo (see HyperWhisper.csproj) - no other accessibility
+    /// change is intended.
+    /// </summary>
+    internal const string NotEntitledReason = "not_entitled";
+
+    /// <summary>
+    /// Stand-in used in Sentry tags/extras when the server stated no usable
+    /// reason, so "the backend didn't classify this" is searchable instead of
+    /// being an absent tag.
+    /// </summary>
+    private const string UnstatedReason = "unstated";
+
+    /// <summary>
+    /// The one field of the backend's invalid-license reply this classifier reads.
+    /// Everything else in that body (valid/error/status) is the core's job -
+    /// this is decoded independently, native-side, purely to read `reason`.
+    /// </summary>
+    private sealed class LicenseVerdictBody
+    {
+        [JsonPropertyName("reason")]
+        public string? Reason { get; set; }
+    }
+
+    /// <summary>
+    /// The backend's machine-readable classification of a non-200 invalid-license
+    /// reply - "not_entitled", "lookup_failed", "bad_request", or whatever else
+    /// it may add later - returned verbatim. Null when the status is not 400,
+    /// the body does not decode, or it states no non-empty reason.
+    ///
+    /// Mirrors macOS <c>LicenseNetworkService.licenseVerdictReason(statusCode:body:)</c>
+    /// exactly: the response SHAPE cannot decide this, because the backend
+    /// answers 400 with the same <c>{"valid":false,"error":"..."}</c> for an
+    /// ordinary lapsed license, for a key that doesn't exist, AND for genuine
+    /// infrastructure faults - only the server knows which branch it took, so
+    /// it says so via `reason`. See <c>nextjs/src/lib/license-validation-probe.ts</c>
+    /// (`LicenseInvalidReason`) for the backend side.
+    ///
+    /// Callers treat exactly one value - <see cref="NotEntitledReason"/> - as an
+    /// ordinary verdict to log rather than capture. A different status, an HTML
+    /// captive-portal page, an empty body, a missing/blank reason, or an
+    /// unrecognised reason all fall through to "report it" - nil-means-report is
+    /// the safe default, and it is accurate: one backend serves every client, so
+    /// `reason` is present on every invalid reply from the moment it deploys.
+    /// </summary>
+    // internal (not private): test seam for HyperWhisper.SmokeTests via
+    // InternalsVisibleTo (see HyperWhisper.csproj) - no other accessibility
+    // change is intended.
+    internal static string? LicenseVerdictReason(int statusCode, byte[] body)
+    {
+        if (statusCode != 400)
+        {
+            return null;
+        }
+
+        LicenseVerdictBody? decoded;
+        try
+        {
+            decoded = JsonSerializer.Deserialize<LicenseVerdictBody>(body);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        var reason = decoded?.Reason;
+        return string.IsNullOrEmpty(reason) ? null : reason;
     }
 
     /// <summary>

--- a/app/windows/HyperWhisper/Services/ModelLibraryManager.cs
+++ b/app/windows/HyperWhisper/Services/ModelLibraryManager.cs
@@ -533,7 +533,6 @@ public sealed class ModelLibraryManager
         ["gemini-3.1-flash-lite-preview"]                 = (4, 3),
         ["openai/gpt-oss-120b"]                           = (4, 4),
         ["openai/gpt-oss-20b"]                            = (4, 4),
-        ["meta-llama/llama-4-maverick-17b-128e-instruct"] = (2, 3),
         ["qwen/qwen3.6-27b"]                              = (4, 3),
         ["grok-4.3"]                                      = (2, 5),
         ["grok-4.5"]                                      = (2, 5),


### PR DESCRIPTION
Three independent follow-ups found while auditing what ships in macOS 2.44.0 and Windows 1.11.0. None of them blocked the release; all three are cheap to fix now and awkward to fix later.

### 1. macOS — repair a retired model id through the redirect map, not list order

`ensureValidLanguageModelSelection()` dropped a stored id that is no longer in the picker onto `options.first`. For the five ids retired in #217 that happened to be the documented replacement, but only because of list ordering — the editor never consulted the map the transcription path already uses (`AIPostProcessor.swift:282`).

This is the release that retires five ids, so it is the release where that luck gets tested.

`resolvedModelId()` is asked first, and its answer is taken only when the replacement is really among the provider's options. The case-insensitive block and the `options.first` last resort are unchanged, so an unknown id still cannot leave the picker blank.

### 2. Windows — report a genuine licence-validation fault to Sentry

The Windows licence path called Sentry nowhere. A verdict, a malformed reply and a real backend fault all ended as one local warning line, so an outage that blocked licence checks produced no signal at all — the mirror image of the macOS bug in #205, which over-reported instead.

Mirrors the rule macOS shipped: the response *shape* cannot decide this, because the backend answers 400 with the same `{"valid":false,"error":"..."}` body for an ordinary lapsed licence and for an infrastructure fault. Only the server's own `reason` field separates them, so exactly one value — `not_entitled` — is logged rather than captured.

The 429/5xx branch returns to the cached/offline fallback before any of this runs. Telemetry cannot change whether a user stays licensed. The licence key is never logged or sent.

### 3. Windows — drop a rating for a model that left the picker

`meta-llama/llama-4-maverick-17b-128e-instruct` was retired but kept its `PostProcessingRatings` entry. `TryGetValue` with a `(3,3)` default made it unreachable. No runtime change.

## Verification

- macOS builds; the new `PostProcessingModelResolutionTests` pass.
- Windows app and smoke-test project both build clean. The 8 new predicate tests need the Windows Desktop runtime, so CI runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKTbXPFNgPPc4C7C1zFfV1