### PR TITLE
fix(assemblyai): send canonical audio/wav so the sync fast path stops 415ing

### DIFF
--- a/hyperwhisper-cloud/src/providers/assemblyai.test.ts
+++ b/hyperwhisper-cloud/src/providers/assemblyai.test.ts
@@ -134,6 +134,32 @@ describe('transcribeWithAssemblyAI — sync fast path eligibility', () => {
 });
 
 describe('transcribeWithAssemblyAI — sync fast path behavior', () => {
+  // Regression: sync matches the audio part's Content-Type against a fixed set
+  // and 415s everything else ("unsupported audio Content-Type: 'audio/vnd.wave'").
+  // macOS's UTType.preferredMIMEType returns `audio/vnd.wave` for a .wav file,
+  // so forwarding the caller's spelling meant every macOS sync attempt 415'd and
+  // silently fell through to async. See SYNC_AUDIO_CONTENT_TYPE.
+  test('the audio part is canonical audio/wav even when the caller sent another WAV spelling', async () => {
+    const calls: Call[] = [];
+    let sentType: string | undefined;
+    let sentFilename: string | undefined;
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(input), method: 'POST' });
+      const audioPart = (init?.body as FormData).get('audio') as File;
+      sentType = audioPart.type;
+      sentFilename = audioPart.name;
+      return jsonResponse({ text: 'hello world', audio_duration_ms: 3000 });
+    }) as unknown as typeof fetch;
+
+    const result = await transcribeWithAssemblyAI(SMALL_AUDIO, 'audio/vnd.wave', 'en-US');
+
+    // Still eligible — the loose gate is unchanged, only the wire value is fixed.
+    expect(calls).toEqual([{ url: SYNC_URL, method: 'POST' }]);
+    expect(result.text).toBe('hello world');
+    expect(sentType).toBe('audio/wav');
+    expect(sentFilename).toBe('audio.wav');
+  });
+
   test('a successful sync transcript reports the sync-only model and computed cost', async () => {
     globalThis.fetch = mock(async () => jsonResponse({ text: 'bonjour', audio_duration_ms: 60_000 })) as unknown as typeof fetch;
 

--- a/hyperwhisper-cloud/src/providers/assemblyai.ts
+++ b/hyperwhisper-cloud/src/providers/assemblyai.ts
@@ -39,6 +39,11 @@
 // round-trip up to the sync timeout on the most common input format. Rather
 // than transcode, sync eligibility is gated on a WAV `contentType` — see
 // `isWavContentType` below. Mirrors the Rust core's `build_sync_request`.
+//
+// Container SPELLING is a separate concern from the gate: sync matches the
+// audio part's Content-Type against a fixed set and 415s everything else, so
+// the caller's own WAV spelling is NEVER forwarded — see
+// `SYNC_AUDIO_CONTENT_TYPE` below.
 
 import { computeAssemblyAISyncTranscriptionCost, computeAssemblyAITranscriptionCost } from '../lib/cost-calculator';
 import { MEDICAL_DOMAIN } from '../lib/stt-models';
@@ -78,6 +83,28 @@ const MAX_KEYTERM_WORDS = 6;
 //   precisely, just log a best-effort reason.
 const SYNC_TRANSCRIBE_URL = `${ASSEMBLYAI_SYNC_BASE}/v1/transcribe`;
 const SYNC_DEFAULT_MODEL = 'universal-3-5-pro';
+// The Content-Type put on the `audio` multipart part, ALWAYS — the caller's
+// own `contentType` is deliberately not forwarded. Sync matches this value
+// against a fixed set and rejects anything else with
+// `{"status":415,"title":"Unsupported Media Type","detail":"unsupported audio
+// Content-Type: '<value>'"}` BEFORE decoding a byte, so an unrecognised
+// spelling of WAV fails 100% of the time regardless of the audio itself.
+//
+// Measured against the live API (2026-08-16, one 7s 16 kHz mono WAV, same
+// bytes each time): `audio/wav`, `audio/wave` and `audio/x-wav` -> 200;
+// `audio/vnd.wave` and `application/octet-stream` -> 415. The multipart
+// filename has no effect either way.
+//
+// `audio/vnd.wave` is not hypothetical: it is what macOS's
+// `UTType.preferredMIMEType` returns for a .wav file, so it is the value
+// `AudioMimeTypeResolver` puts on every macOS upload, and it is what the
+// desktop app actually sent here. Until this constant existed, EVERY macOS
+// sync attempt 415'd and fell through to the async upload/create/poll flow —
+// the fast path was dead on arrival for the platform that produces most of
+// the traffic. `isWavContentType` stays a loose substring gate because it
+// answers a different question ("is this a WAV container?"); this is what
+// goes on the wire. Mirrors the Rust core's `sync_flow::SYNC_AUDIO_MIME`.
+const SYNC_AUDIO_CONTENT_TYPE = 'audio/wav';
 const SYNC_MAX_DURATION_SECONDS = 120;
 // Safety margin below the hard cap: `estimateSecondsFromBytes` is a rough
 // 64kbps-encoded guess, not a real duration. An estimate landing in the last
@@ -222,7 +249,6 @@ function throwForStatus(status: number, bodyPreview: string): never {
  */
 async function transcribeWithAssemblyAISync(
   audio: ArrayBuffer,
-  contentType: string,
   language: string | undefined,
   initialPrompt: string | undefined,
   apiKey: string,
@@ -250,7 +276,9 @@ async function transcribeWithAssemblyAISync(
   }
 
   const form = new FormData();
-  form.append('audio', new Blob([audio], { type: contentType || 'application/octet-stream' }), 'audio');
+  // Canonical `audio/wav`, NOT `contentType` — see SYNC_AUDIO_CONTENT_TYPE.
+  // The filename mirrors the Python SDK's `audio.wav`; sync ignores it.
+  form.append('audio', new Blob([audio], { type: SYNC_AUDIO_CONTENT_TYPE }), 'audio.wav');
   if (Object.keys(config).length > 0) {
     // Append as a plain string, NOT a Blob. Per the FormData/multipart spec, a
     // Blob part without an explicit filename serializes as `filename="blob"`,
@@ -395,7 +423,7 @@ export async function transcribeWithAssemblyAI(
     logProviderEvent(provider, 'sync_attempt', {
       estimatedSeconds, thresholdSeconds: SYNC_ELIGIBLE_ESTIMATED_SECONDS,
     }, context);
-    const syncResult = await transcribeWithAssemblyAISync(audio, contentType, language, initialPrompt, apiKey, context);
+    const syncResult = await transcribeWithAssemblyAISync(audio, language, initialPrompt, apiKey, context);
     if (syncResult) {
       return syncResult;
     }

--- a/shared-core-rs/crates/hw-net/src/providers/assemblyai/sync_flow.rs
+++ b/shared-core-rs/crates/hw-net/src/providers/assemblyai/sync_flow.rs
@@ -199,6 +199,27 @@ fn is_wav_mime(mime: &str) -> bool {
     mime.to_lowercase().contains("wav")
 }
 
+/// The Content-Type put on the `audio` multipart part, ALWAYS — the resolved
+/// MIME is what [`is_wav_mime`] gates on, never what goes on the wire.
+///
+/// Sync matches this value against a fixed set and rejects anything else with
+/// `{"status":415,"title":"Unsupported Media Type","detail":"unsupported audio
+/// Content-Type: '<value>'"}` BEFORE decoding a byte, so an unrecognized
+/// spelling of WAV fails 100% of the time regardless of the audio itself.
+///
+/// Measured against the live API (2026-08-16, one 7s 16 kHz mono WAV, same
+/// bytes each time): `audio/wav`, `audio/wave` and `audio/x-wav` -> 200;
+/// `audio/vnd.wave` and `application/octet-stream` -> 415. The multipart
+/// filename has no effect either way.
+///
+/// `audio/vnd.wave` is not hypothetical: it is what macOS's
+/// `UTType.preferredMIMEType` returns for a .wav file, so it is the value
+/// `AudioMimeTypeResolver` puts in `params.audio_mime` on every macOS
+/// recording. Until this constant existed, EVERY macOS sync attempt 415'd and
+/// fell through to the async upload/create/poll flow. Mirrors the cloud TS
+/// mirror's `SYNC_AUDIO_CONTENT_TYPE`.
+const SYNC_AUDIO_MIME: &str = "audio/wav";
+
 /// Build the **sync** transcription request: one multipart POST carrying the
 /// audio file plus an optional `config` JSON part.
 ///
@@ -255,7 +276,8 @@ pub fn build_sync_request(params: &TranscribeParams) -> Result<HttpRequest, Tran
     let mut parts: Vec<Part> = vec![multipart_file(
         "audio",
         params.audio_path.clone(),
-        mime,
+        // Canonical `audio/wav`, NOT the resolved `mime` — see SYNC_AUDIO_MIME.
+        SYNC_AUDIO_MIME.to_string(),
         filename_of(&params.audio_path),
     )];
     if let Some(config_json) = sync_config_json(params) {
@@ -389,6 +411,29 @@ mod tests {
                 other => panic!("expected FileRef first, got {other:?}"),
             },
             other => panic!("expected Multipart body, got {other:?}"),
+        }
+    }
+
+    /// Regression: sync matches the audio part's Content-Type against a fixed
+    /// set and 415s everything else ("unsupported audio Content-Type:
+    /// 'audio/vnd.wave'"). macOS resolves a .wav file to `audio/vnd.wave`, so
+    /// forwarding the resolved MIME meant every macOS sync attempt 415'd and
+    /// silently fell through to async. See `SYNC_AUDIO_MIME`.
+    #[test]
+    fn sync_request_sends_canonical_wav_mime_not_the_resolved_one() {
+        for resolved in ["audio/vnd.wave", "audio/wave", "audio/x-wav", "audio/wav"] {
+            let mut p = sync_params();
+            p.audio_mime = Some(resolved.to_string());
+            let req = build_sync_request(&p).unwrap();
+            match &req.body {
+                Body::Multipart { parts, .. } => match &parts[0] {
+                    Part::FileRef { mime, .. } => {
+                        assert_eq!(mime, SYNC_AUDIO_MIME, "resolved MIME {resolved:?}");
+                    }
+                    other => panic!("expected FileRef first, got {other:?}"),
+                },
+                other => panic!("expected Multipart body, got {other:?}"),
+            }
         }
     }
 


### PR DESCRIPTION
## The bug

The AssemblyAI sync fast path has **never** succeeded from the macOS app. Every attempt returns 415 and falls through to the async `upload → create → poll` flow. So every AssemblyAI transcription pays a wasted sync round-trip *and then* the full async cost.

Caught in production logs (`hyperwhisper-transcribe`, prod):

```
provider.sync_attempt {
provider.sync_fallback {
provider.sync_fallback_to_async {
provider.prepare {                  ← async upload starts
transcribe.stt_done  elapsedMs: 3784
```

## Cause

Sync matches the audio part's `Content-Type` against a fixed set and rejects anything else before decoding a byte:

```json
{"status":415,"title":"Unsupported Media Type",
 "detail":"unsupported audio Content-Type: 'audio/vnd.wave'"}
```

Both mirrors forwarded the **caller's** MIME rather than a canonical one. macOS's `UTType.preferredMIMEType` returns `audio/vnd.wave` for a `.wav` file, so that is what `AudioMimeTypeResolver` puts on every macOS upload — and it is the one WAV spelling sync refuses.

Measured against the live API, one 7 s 16 kHz mono WAV, identical bytes each time:

| Audio part `Content-Type` | Result |
|---|---|
| `audio/wav` | 200 |
| `audio/wave` | 200 |
| `audio/x-wav` | 200 |
| `audio/vnd.wave` ← what macOS sends | **415** |
| `application/octet-stream` | **415** |

The multipart filename has no effect either way. The `config` part is optional.

## The fix

The gate was never wrong. `isWavContentType` / `is_wav_mime` answer *"is this a WAV container?"*, and both correctly accept `audio/vnd.wave` — an m4a still has to skip sync. Only the wire value was wrong. Both keep their loose substring match and now send a fixed `audio/wav`.

- `hyperwhisper-cloud/src/providers/assemblyai.ts` — new `SYNC_AUDIO_CONTENT_TYPE`; drops the now-unused `contentType` parameter from `transcribeWithAssemblyAISync`.
- `shared-core-rs/.../assemblyai/sync_flow.rs` — new `SYNC_AUDIO_MIME` in `build_sync_request`. This covers **both BYOK clients**: macOS (`AssemblyAIProvider.swift`) and Windows (`AssemblyAIService.cs`) build their sync request over FFI, so neither app needs a code change.

## Why it was missed

The module header says it outright:

```
// Contract verified against the AssemblyAI Python SDK source
// (`assemblyai/sync/v1/api.py`, `_base.py`, `types.py`), not a live call:
```

The URL, the `X-AAI-Model` header and every `config` field name check out against the SDK. The content type is the one value `_base.py` computes *itself* (`"audio/pcm" if is_pcm else "audio/wav"`) rather than taking from its caller, so reading the call signature never surfaced it.

Every existing test on both sides also passed an already-canonical `audio/wav`, so nothing covered the value real clients send.

## Tests

A regression test on each side feeds `audio/vnd.wave` and asserts the outgoing part is `audio/wav` (and that the clip is still sync-eligible).

- `bun test` — 661 pass, 0 fail
- `bun --bun tsc --noEmit` — clean
- `cargo test -p hw-net assemblyai` — 48 pass, 0 fail
- `cargo clippy -p hw-net --all-targets` — clean

## End-to-end verification

Called the **real** provider module against the live API with `contentType: 'audio/vnd.wave'`:

```
provider.success { model: "universal-3-5-pro", path: "sync", elapsedMs: 2368, ... }
source: assemblyai   duration: 7.088   text: "Hello, this is a test of the AssemblyAI ..."
```

`path: "sync"`, no async fallback. The 2.4 s is a home-connection upload of a 230 KB WAV; from `nrt` this replaces a measured 3.8–6.2 s of server-side async time.

## Note for review

`cargo fmt --check` reports diffs across the whole workspace, including 4 hunks in `sync_flow.rs`. All of them are in untouched code — a rustfmt version drift that predates this branch. Nothing here was reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wDeqDt7cy3Q9vXw5Q2Dgb
