### PR TITLE
fix(macos): stop the History badge strip shoving the window content off-screen

### DIFF
--- a/app/macos/hyperwhisper/Views/Components/FlowLayout.swift
+++ b/app/macos/hyperwhisper/Views/Components/FlowLayout.swift
@@ -61,14 +61,21 @@ struct FlowLayout: Layout {
 
     /// Measures every subview at its natural width and groups the subviews into
     /// lines that fit `maxWidth`. A subview wider than `maxWidth` gets a line of
-    /// its own and is measured against `maxWidth`, so it wraps internally rather
-    /// than overflow the container.
+    /// its own, capped to `maxWidth`, so its label truncates rather than overflow
+    /// the container.
+    ///
+    /// Measure with `.unspecified`, never against `maxWidth`. SwiftUI probes a
+    /// pane's minimum size by proposing a near-zero width, and a badge measured
+    /// at ~32pt wraps inside its own pill into a column hundreds of points tall.
+    /// That height becomes the History detail pane's minimum height, escapes to
+    /// the fixed 1000x600 window frame, and the oversized content is centred —
+    /// which clips the top and bottom off every column in the window.
     private func layoutLines(maxWidth: CGFloat, subviews: Subviews) -> [Line] {
         var lines: [Line] = []
         var current = Line()
 
         for index in subviews.indices {
-            var size = subviews[index].sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
+            var size = subviews[index].sizeThatFits(.unspecified)
             size.width = min(size.width, maxWidth)
 
             let needsNewLine = !current.items.isEmpty && current.width + spacing + size.width > maxWidth


### PR DESCRIPTION
## The bug

Selecting a transcript in History moved the whole window content up. The sidebar, the search bar and the detail header were all clipped off the top.

## The cause

`FlowLayout` measured every badge against the container width:

```swift
var size = subviews[index].sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
```

SwiftUI sizes a pane's minimum by proposing a near-zero width. At ~32pt each badge wrapped inside its own pill, so the strip reported 811pt tall. That became the detail pane's minimum height and travelled up the tree:

```
detail pane 961 -> HSplitView 1014 -> NavigationStack 1014 -> NavigationSplitView 1082
```

The window root is a fixed `.frame(width: 1000, height: 600)` (`hyperwhisperApp.swift:292`). A fixed frame centres a child that is too big, so the top and bottom got cut off every column. This is why the sidebar, the list and the detail all shifted together.

## The fix

Measure each badge at its natural width and keep the existing width cap:

```swift
var size = subviews[index].sizeThatFits(.unspecified)
size.width = min(size.width, maxWidth)
```

This matches what the file header already describes: each badge keeps its natural one-line width, and the strip grows to a second line. `FlowLayout` has one call site (the History detail header), so the blast radius is that strip.

## Verification

Geometry probes in the running app, on a selected transcript:

| Probe | Before | After |
|---|---|---|
| detail pane measurement | 961pt | 318pt |
| detail pane, steady state | 962pt and rising | 576pt |
| window root | 1082pt and rising | 600pt |

Before the fix the height kept growing on every layout pass (1082 -> 1130 -> 1153). After the fix nothing above the pane changes size at all. Badges still wrap onto a second line, and a clean Debug build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9Wmia8vDPGvm2PtFkrhtr