### PR TITLE
feat(web): name /latency rows the way the app does, and cut them by model

### DIFF
--- a/nextjs/app/[locale]/latency/page.tsx
+++ b/nextjs/app/[locale]/latency/page.tsx
@@ -9,7 +9,7 @@ export const revalidate = 3600;
 
 const TITLE = "Speech-to-text latency, measured";
 const DESCRIPTION =
-  "How fast each speech-to-text provider actually answers HyperWhisper Cloud, by region, over the last 30 days.";
+  `How fast each speech-to-text provider actually answers HyperWhisper Cloud, by region and by model, over the last ${WINDOW_DAYS} days.`;
 
 export async function generateMetadata() {
   return {
@@ -87,15 +87,30 @@ export default async function LatencyPage({ params }: Props) {
           </div>
           <div>
             <dt className="font-medium text-gray-200">
-              A row is a provider, not a model
+              A row is a provider, until you open it
             </dt>
             <dd className="mt-1">
               Most of these providers offer several models, and HyperWhisper
-              lets you pin the one you want. A row covers whichever model of
-              that provider actually ran — its default for most people, plus
-              whatever anyone else picked — so read a row as &ldquo;how fast
-              this provider answers us&rdquo;, not as a benchmark of one named
-              model against another.
+              lets you pin the one you want. A provider row covers whichever
+              model of that provider actually ran — its default for most people,
+              plus whatever anyone else picked — so read it as &ldquo;how fast
+              this provider answers us&rdquo;. <span className="text-gray-200">Break
+              down by model</span> splits each one into its models. Those rows
+              count only the attempts that ran on that model, so they fill in
+              more slowly and a young model may show nothing but dashes for a
+              while.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">
+              The names match the app
+            </dt>
+            <dd className="mt-1">
+              Provider and model names here are the same ones the app&apos;s
+              Provider and Model menus show, read from the same shared catalog.
+              Google covers both Chirp and Gemini in one row, exactly as the app
+              does — the model you pick under it is what decides which of the two
+              runs.
             </dd>
           </div>
           <div>

--- a/nextjs/app/api/internal/latency/route.ts
+++ b/nextjs/app/api/internal/latency/route.ts
@@ -45,8 +45,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  // The page's display map is the one list of provider ids; a provider it can
-  // render is a provider this route stores. See lib/latency/providers.ts.
+  // The page's catalog mirror is the one list of provider ids; a provider it
+  // can render is a provider this route stores. See lib/latency/providers.ts.
   const result = validateBatch(body, KNOWN_PROVIDERS);
   if (!result.ok) {
     return NextResponse.json({ error: result.error }, { status: 400 });
@@ -98,10 +98,10 @@ export async function POST(request: NextRequest) {
         // hour beside it, grouping on those columns reassembles the request and
         // its provider chain, which is the one correlation the row promises not
         // to allow. Nothing reads the column (src/content/latency.ts selects
-        // provider, region, count, percentiles and error rate, and filters on
-        // duration_bucket), so it is stored as null rather than coarsened into
-        // a second spelling of the bucket. The column stays for a future,
-        // deliberate use.
+        // vendor, provider, model, region, count, percentiles and error rate,
+        // and filters on duration_bucket), so it is stored as null rather than
+        // coarsened into a second spelling of the bucket. The column stays for a
+        // future, deliberate use.
         audioSeconds: null,
         // Bucketed here rather than on the page: the boundaries and the labels
         // that describe them live in one place (lib/latency/types.ts), and the

--- a/nextjs/app/api/internal/latency/validation.ts
+++ b/nextjs/app/api/internal/latency/validation.ts
@@ -117,7 +117,7 @@ function isValidRegion(value: unknown): value is string {
  * imports at all: `node --test --experimental-strip-types` loads it directly and
  * resolves neither the `@/` alias nor an extensionless relative `.ts` path. The
  * one list the ingest actually runs on is `KNOWN_PROVIDERS` in
- * lib/latency/providers.ts, derived from the page's display map — route.ts
+ * lib/latency/providers.ts, derived from the page's catalog mirror — route.ts
  * hands it in, and the test loads the same export.
  */
 export function validateSample(

--- a/nextjs/components/latency/LatencyMatrix.tsx
+++ b/nextjs/components/latency/LatencyMatrix.tsx
@@ -1,16 +1,18 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { MapPin, Pin } from "lucide-react";
+import { ChevronDown, ChevronRight, MapPin, Pin } from "lucide-react";
 
 import {
   BUCKET_LABELS,
   DURATION_BUCKETS,
   minSamplesForMetric,
   type DurationBucket,
+  type LatencyCell,
   type LatencyMatrixData,
+  type LatencyModelRow,
+  type LatencyVendorRow,
 } from "@/lib/latency/types";
-import { providerDisplayName } from "@/lib/latency/providers";
 import { regionCity } from "@/lib/latency/fly-regions";
 
 const METRICS = [
@@ -33,19 +35,51 @@ type CellValue = {
   enough: boolean;
 } | null;
 
+/** A drawn row: a vendor, or one of its models while the breakdown is on. */
+type DisplayRow = {
+  key: string;
+  label: string;
+  isModel: boolean;
+  isDefaultModel: boolean;
+  /** The vendor row this belongs to — a model row pins and hovers with its vendor. */
+  vendor: string;
+  cells: Map<string, CellValue>;
+};
+
+function cellMap(cells: LatencyCell[], metric: MetricKey, minSamples: number) {
+  const map = new Map<string, CellValue>();
+  for (const cell of cells) {
+    const value = metric === "errorRate" ? cell.errorRate * 100 : cell[metric];
+    map.set(cell.region, {
+      value,
+      samples: cell.samples,
+      enough: cell.samples >= minSamples,
+    });
+  }
+  return map;
+}
+
 /**
  * The provider × region heatmap.
  *
  * Every cell prints its number, so colour is never the only channel carrying
  * meaning. A cell backed by too few attempts shows a dash and its sample count
  * on hover rather than a number nobody should trust.
+ *
+ * A row is a vendor, named the way the app's Provider dropdown names it. "Break
+ * down by model" opens each vendor into the models underneath it, named the way
+ * the app's Model dropdown names them. It is off by default: a model row counts
+ * only the attempts that ran on that model, so the breakdown is a thinner,
+ * noisier view of the same window, and the question most visitors arrive with is
+ * about providers.
  */
 export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
   const [bucket, setBucket] = useState<DurationBucket>(defaultBucket);
   const [metric, setMetric] = useState<MetricKey>("p50");
+  const [byModel, setByModel] = useState(false);
   const [sortRegion, setSortRegion] = useState<string | null>(null);
-  const [pinnedProvider, setPinnedProvider] = useState<string | null>(null);
-  const [hover, setHover] = useState<{ provider: string; region: string } | null>(null);
+  const [pinnedVendor, setPinnedVendor] = useState<string | null>(null);
+  const [hover, setHover] = useState<{ vendor: string; region: string } | null>(null);
   const [homeRegion, setHomeRegion] = useState<string | null>(null);
   const [homeCity, setHomeCity] = useState<string | null>(null);
   const [pickingRegion, setPickingRegion] = useState(false);
@@ -54,7 +88,7 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
   const regionPickedByUser = useRef(false);
 
   const data = matrices[bucket];
-  const { providers, regions } = data;
+  const { regions } = data;
   const hasData = regions.length > 0;
   // p99 asks much more of a cell than p50 or p95 do, so the bar moves with the
   // metric on screen rather than being one number for the whole page.
@@ -63,20 +97,6 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
   // own array, and the props re-cross the RSC boundary, so keying the effect
   // below on `regions` itself would re-run it on every bucket toggle.
   const regionsKey = regions.join(",");
-
-  const lookup = useMemo(() => {
-    const map = new Map<string, CellValue>();
-    for (const cell of data.cells) {
-      const value =
-        metric === "errorRate" ? cell.errorRate * 100 : cell[metric];
-      map.set(`${cell.provider}|${cell.region}`, {
-        value,
-        samples: cell.samples,
-        enough: cell.samples >= minSamples,
-      });
-    }
-    return map;
-  }, [data, metric, minSamples]);
 
   // Ask which region is nearest this visitor, once the page has painted. The
   // page itself is static, so it cannot know. Only regions that actually have
@@ -116,21 +136,39 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
 
   // Exactly the same rule for the row-order pick, and for exactly the same
   // reason: a sort region that this bucket's axis does not have scores every
-  // provider null, the comparator falls through to localeCompare, and the table
-  // silently re-orders by raw backend id ("azure-mai" between "assemblyai" and
-  // "deepgram") while the Row-order button still claims to be sorted by a city.
-  // Both the comparator and the label read this, never `sortRegion` directly;
-  // `sortRegion` is still remembered so returning to a bucket that has it
-  // restores the order.
+  // vendor null, the comparator falls through to localeCompare, and the table
+  // silently re-orders by name while the Row-order button still claims to be
+  // sorted by a city. Both the comparator and the label read this, never
+  // `sortRegion` directly; `sortRegion` is still remembered so returning to a
+  // bucket that has it restores the order.
   const activeSortRegion = sortRegion && regions.includes(sortRegion) ? sortRegion : null;
 
-  const cellFor = (provider: string, region: string): CellValue =>
-    lookup.get(`${provider}|${region}`) ?? null;
+  /**
+   * Every vendor's cells for the metric on screen, plus its models' cells. Built
+   * once per (bucket, metric) rather than per lookup, and always for both levels
+   * — the breakdown toggle changes which rows are drawn, not what is measured,
+   * so flipping it does not re-aggregate anything.
+   */
+  const vendorRows = useMemo(
+    () =>
+      data.vendors.map((vendor: LatencyVendorRow) => ({
+        vendor: vendor.vendor,
+        label: vendor.label,
+        cells: cellMap(vendor.cells, metric, minSamples),
+        models: vendor.models.map((model: LatencyModelRow) => ({
+          key: `${vendor.vendor}|${model.provider}|${model.model ?? ""}`,
+          label: model.label,
+          isDefault: model.isDefault,
+          cells: cellMap(model.cells, metric, minSamples),
+        })),
+      })),
+    [data, metric, minSamples],
+  );
 
-  /** Median of a provider's usable cells, used for the default row order. */
-  const globalValue = (provider: string): number | null => {
+  /** Median of a row's usable cells, used for the default row order. */
+  const globalValue = (cells: Map<string, CellValue>): number | null => {
     const values = regions
-      .map((region) => cellFor(provider, region))
+      .map((region) => cells.get(region))
       .filter((cell): cell is NonNullable<CellValue> => Boolean(cell?.enough))
       .map((cell) => cell.value)
       .sort((a, b) => a - b);
@@ -138,41 +176,73 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
     return values[Math.floor(values.length / 2)];
   };
 
-  const sortedProviders = useMemo(() => {
-    const scored = providers.map((provider) => {
+  /**
+   * The rows to draw, in order. Vendors sort by the metric on screen; a vendor's
+   * models keep the catalog order the server sent them in — the order the app's
+   * Model dropdown uses — so the breakdown reads as a list of that vendor's
+   * models rather than as a second, competing ranking.
+   */
+  const rows = useMemo(() => {
+    const scored = vendorRows.map((vendor) => {
       const score = activeSortRegion
-        ? (cellFor(provider, activeSortRegion)?.enough
-            ? cellFor(provider, activeSortRegion)!.value
+        ? (vendor.cells.get(activeSortRegion)?.enough
+            ? vendor.cells.get(activeSortRegion)!.value
             : null)
-        : globalValue(provider);
-      return { provider, score };
+        : globalValue(vendor.cells);
+      return { vendor, score };
     });
 
-    // Providers with nothing to show sink to the bottom instead of sorting as 0.
-    // The tie-break runs on the DISPLAYED name, not the backend id: on p99 no
-    // cell clears the 500-attempt bar, so every score is null and this is the
-    // order the whole table gets — "azure-mai" between "assemblyai" and
-    // "deepgram" reads as no order at all next to the names on screen.
+    // Vendors with nothing to show sink to the bottom instead of sorting as 0.
+    // The tie-break runs on the displayed name: on p99 no cell may clear the
+    // 500-attempt bar, and that is the order the whole table gets.
     scored.sort((a, b) => {
       if (a.score === null && b.score === null) {
-        return providerDisplayName(a.provider).localeCompare(providerDisplayName(b.provider));
+        return a.vendor.label.localeCompare(b.vendor.label);
       }
       if (a.score === null) return 1;
       if (b.score === null) return -1;
       return a.score - b.score;
     });
 
-    return scored.map((entry) => entry.provider);
+    const drawn: DisplayRow[] = [];
+    for (const { vendor } of scored) {
+      drawn.push({
+        key: vendor.vendor,
+        label: vendor.label,
+        isModel: false,
+        isDefaultModel: false,
+        vendor: vendor.vendor,
+        cells: vendor.cells,
+      });
+      if (!byModel) continue;
+      for (const model of vendor.models) {
+        drawn.push({
+          key: model.key,
+          label: model.label,
+          isModel: true,
+          isDefaultModel: model.isDefault,
+          vendor: vendor.vendor,
+          cells: model.cells,
+        });
+      }
+    }
+    return drawn;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [providers, regions, activeSortRegion, lookup]);
+  }, [vendorRows, regions, activeSortRegion, byModel]);
 
+  /**
+   * Colour range over the rows actually on screen. Model rows are included only
+   * while the breakdown is open, so opening it cannot leave the vendor rows
+   * recoloured by numbers the visitor cannot see.
+   */
   const scale = useMemo(() => {
-    const values = Array.from(lookup.values())
+    const values = rows
+      .flatMap((row) => Array.from(row.cells.values()))
       .filter((cell): cell is NonNullable<CellValue> => Boolean(cell?.enough))
       .map((cell) => cell.value);
     if (values.length === 0) return { min: 0, max: 1 };
     return { min: Math.min(...values), max: Math.max(...values) };
-  }, [lookup]);
+  }, [rows]);
 
   /**
    * Green (fast / reliable) through amber to red (slow / failing). Colour only
@@ -238,20 +308,45 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
         </div>
 
         {hasData ? (
-          <div className="flex flex-col gap-2">
-            <span className="text-xs uppercase tracking-widest text-gray-500">
-              Row order
-            </span>
-            <button
-              className="rounded-lg border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm text-gray-300 transition hover:text-white"
-              type="button"
-              onClick={() => setSortRegion(null)}
-            >
-              {activeSortRegion
-                ? `Sorted by ${regionCity(activeSortRegion)} — reset`
-                : "Sorted by global median"}
-            </button>
-          </div>
+          <>
+            <div className="flex flex-col gap-2">
+              <span className="text-xs uppercase tracking-widest text-gray-500">
+                Detail
+              </span>
+              <button
+                aria-pressed={byModel}
+                className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition ${
+                  byModel
+                    ? "border-purple-600 bg-purple-950/40 text-white"
+                    : "border-gray-800 bg-gray-900/60 text-gray-300 hover:text-white"
+                }`}
+                type="button"
+                onClick={() => setByModel((open) => !open)}
+              >
+                {byModel ? (
+                  <ChevronDown className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5" />
+                )}
+                Break down by model
+              </button>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <span className="text-xs uppercase tracking-widest text-gray-500">
+                Row order
+              </span>
+              <button
+                className="rounded-lg border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm text-gray-300 transition hover:text-white"
+                type="button"
+                onClick={() => setSortRegion(null)}
+              >
+                {activeSortRegion
+                  ? `Sorted by ${regionCity(activeSortRegion)} — reset`
+                  : "Sorted by global median"}
+              </button>
+            </div>
+          </>
         ) : null}
       </div>
 
@@ -323,7 +418,7 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
               <thead>
                 <tr>
                   <th className="sticky left-0 z-20 bg-gray-950 px-4 py-3 text-left text-xs uppercase tracking-widest text-gray-500">
-                    Provider
+                    {byModel ? "Provider / model" : "Provider"}
                   </th>
                   {regions.map((region) => (
                     <th
@@ -353,42 +448,61 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
                 </tr>
               </thead>
               <tbody>
-                {sortedProviders.map((provider) => {
-                  const pinned = pinnedProvider === provider;
+                {rows.map((row) => {
+                  const pinned = pinnedVendor === row.vendor;
                   return (
                     <tr
-                      key={provider}
+                      key={row.key}
                       className={
                         pinned
                           ? "bg-purple-950/20"
-                          : hover?.provider === provider
+                          : hover?.vendor === row.vendor
                             ? "bg-gray-900/60"
                             : ""
                       }
                     >
                       <th
-                        className={`sticky left-0 z-10 whitespace-nowrap px-4 py-2 text-left font-medium ${
-                          pinned ? "bg-purple-950/60 text-white" : "bg-gray-950 text-gray-200"
+                        className={`sticky left-0 z-10 whitespace-nowrap px-4 py-2 text-left ${
+                          row.isModel ? "font-normal" : "font-medium"
+                        } ${
+                          pinned
+                            ? "bg-purple-950/60 text-white"
+                            : `bg-gray-950 ${row.isModel ? "text-gray-400" : "text-gray-200"}`
                         }`}
                         scope="row"
                       >
-                        <button
-                          className="flex items-center gap-2 transition hover:text-purple-300"
-                          title="Pin this provider"
-                          type="button"
-                          onClick={() =>
-                            setPinnedProvider((current) =>
-                              current === provider ? null : provider,
-                            )
-                          }
-                        >
-                          {pinned ? <Pin className="h-3 w-3" /> : null}
-                          {providerDisplayName(provider)}
-                        </button>
+                        {row.isModel ? (
+                          <span className="flex items-center gap-2 pl-6">
+                            <span
+                              aria-hidden="true"
+                              className="h-4 w-px shrink-0 bg-gray-800"
+                            />
+                            {row.label}
+                            {row.isDefaultModel ? (
+                              <span className="rounded-full border border-purple-500/40 px-1.5 text-[10px] uppercase tracking-wider text-purple-300">
+                                default
+                              </span>
+                            ) : null}
+                          </span>
+                        ) : (
+                          <button
+                            className="flex items-center gap-2 transition hover:text-purple-300"
+                            title="Pin this provider"
+                            type="button"
+                            onClick={() =>
+                              setPinnedVendor((current) =>
+                                current === row.vendor ? null : row.vendor,
+                              )
+                            }
+                          >
+                            {pinned ? <Pin className="h-3 w-3" /> : null}
+                            {row.label}
+                          </button>
+                        )}
                       </th>
 
                       {regions.map((region) => {
-                        const cell = cellFor(provider, region);
+                        const cell = row.cells.get(region) ?? null;
                         const isHome = activeHomeRegion === region;
 
                         if (!cell || !cell.enough) {
@@ -403,7 +517,9 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
                                   ? `${cell.samples.toLocaleString()} attempts — fewer than the ${minSamples.toLocaleString()} this metric needs`
                                   : "No attempts recorded"
                               }
-                              onMouseEnter={() => setHover({ provider, region })}
+                              onMouseEnter={() =>
+                                setHover({ vendor: row.vendor, region })
+                              }
                               onMouseLeave={() => setHover(null)}
                             >
                               <span aria-label="not enough data">—</span>
@@ -418,8 +534,8 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
                               isHome ? "ring-1 ring-inset ring-purple-500/40" : ""
                             }`}
                             style={cellStyle(cell.value)}
-                            title={`${providerDisplayName(provider)} in ${regionCity(region)} — ${cell.samples.toLocaleString()} attempts`}
-                            onMouseEnter={() => setHover({ provider, region })}
+                            title={`${row.label} in ${regionCity(region)} — ${cell.samples.toLocaleString()} attempts`}
+                            onMouseEnter={() => setHover({ vendor: row.vendor, region })}
                             onMouseLeave={() => setHover(null)}
                           >
                             {format(cell.value)}
@@ -442,7 +558,11 @@ export default function LatencyMatrix({ matrices, defaultBucket }: Props) {
             {metric === "p99"
               ? " — p99 asks for more of them than the other metrics, because a 99th percentile drawn from a small sample is really just its slowest call"
               : ""}
-            . Click a region to sort by it, or a provider to pin its row.
+            .{" "}
+            {byModel
+              ? "A model row counts only the attempts that ran on that model, so it falls under that bar long before its provider row does. "
+              : ""}
+            Click a region to sort by it, or a provider to pin its row.
           </p>
         </>
       )}

--- a/nextjs/lib/latency/providers.ts
+++ b/nextjs/lib/latency/providers.ts
@@ -1,50 +1,164 @@
 /**
- * Backend provider id → display name.
+ * The names the /latency page prints, mirrored from the catalog the desktop
+ * apps read.
  *
- * The source of truth is `shared-app-classification/cloud-stt-catalog.json`,
- * where each entry's `sttProvider` field is the backend id and `displayName` is
- * the name users see. That file sits outside this Next.js app's build root, so
- * the mapping is mirrored here rather than imported. The catalog's `sttProvider`
- * values match these keys 1:1 for all 11 providers.
+ * The source of truth is `shared-app-classification/cloud-stt-catalog.json`.
+ * That file sits outside this Next.js app's build root, so it is copied here
+ * rather than imported; `tests/latency-report-validation.test.ts` reads the real
+ * catalog as data and fails when this copy drifts from it.
  *
- * VENDOR ONLY — no model or version suffix. The aggregate in
- * src/content/latency.ts groups by provider and region, not by model, while
- * users can pin a per-provider model in the desktop apps and both of them pass
- * that pick through. So a Deepgram cell blends nova-3, nova-2-general and
- * nova-2-medical timings, and an OpenAI cell is mostly gpt-4o-transcribe, its
- * default. A label naming one of those models would be wrong for most of the
- * rows underneath it — and would get quietly wronger every time a provider
- * moves its default, which this codebase has already documented happening twice
- * (stt-models.ts, AssemblyAI and Soniox). The page copy states plainly that a
- * cell covers whichever model of that provider ran. The `model` column is
- * written on every row, so cutting the aggregate by model later is a query
- * change, not a data migration.
+ * Two names are mirrored, and they are the two the apps show:
  *
- * An unmapped provider still renders — it shows its raw backend id — so a
- * provider added to the edge service appears on the page immediately, looking
+ *  - `vendorDisplayName` — the app's Provider dropdown. A row on the page is a
+ *    vendor, so it is named the way the app names it. Chirp and Gemini both
+ *    carry `vendor: "google"`, so the app collapses them into one **Google**
+ *    row and picking a Gemini model under it is what switches the backend
+ *    provider (macOS `CloudSTTCatalog.cloudTierVendorGroups` /
+ *    `tierOwningModel`). The page does the same, so a visitor comparing the page
+ *    against their own Provider dropdown sees one list, not two spellings of
+ *    one.
+ *  - a model's `displayName` — the app's Model dropdown, printed on the model
+ *    rows the page shows when "Break down by model" is on.
+ *
+ * Names are never invented here. The page used to keep its own vendor-only
+ * labels ("Microsoft MAI-Transcribe", "xAI Grok") because a provider row blends
+ * every model of that provider and a label naming one model would be wrong for
+ * most of the rows under it. That reasoning still holds — it is why the vendor
+ * row is a vendor NAME and the model rows underneath are where models get named
+ * — but the labels themselves now come from the catalog, so the page cannot
+ * drift from the app by an edit in one place.
+ *
+ * An unmapped provider or model still renders — it shows its raw backend id — so
+ * something added to the edge service appears on the page immediately, looking
  * unfinished rather than being silently dropped.
  */
-export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  deepgram: "Deepgram",
-  groq: "Groq",
-  elevenlabs: "ElevenLabs",
-  grok: "xAI Grok",
-  "azure-mai": "Microsoft MAI-Transcribe",
-  "google-chirp": "Google Chirp",
-  openai: "OpenAI",
-  gemini: "Google Gemini",
-  assemblyai: "AssemblyAI",
-  mistral: "Mistral",
-  soniox: "Soniox",
+export type CatalogModel = {
+  /** The model id the edge service reports. Empty when the provider takes none. */
+  id: string;
+  displayName: string;
+  isDefault?: boolean;
 };
 
+export type CatalogEntry = {
+  /** Backend provider id, as stored in `stt_latency_samples.provider`. */
+  sttProvider: string;
+  /** Catalog `vendor` key — what collapses Chirp and Gemini into one row. */
+  vendor: string;
+  vendorDisplayName: string;
+  /** In catalog order, which is the order the app's Model dropdown lists them. */
+  models: readonly CatalogModel[];
+};
+
+/** Mirrors `cloud-stt-catalog.json`'s `providers[]`, in catalog order. */
+export const STT_CATALOG: readonly CatalogEntry[] = [
+  {
+    sttProvider: "groq",
+    vendor: "groq",
+    vendorDisplayName: "Groq",
+    models: [
+      { id: "whisper-large-v3-turbo", displayName: "Whisper Large v3 Turbo", isDefault: true },
+      { id: "whisper-large-v3", displayName: "Whisper Large v3" },
+    ],
+  },
+  {
+    sttProvider: "deepgram",
+    vendor: "deepgram",
+    vendorDisplayName: "Deepgram",
+    models: [
+      { id: "nova-3-general", displayName: "Nova 3 General", isDefault: true },
+      { id: "nova-3-medical", displayName: "Nova 3 Medical" },
+      { id: "nova-2-general", displayName: "Nova 2 General" },
+      { id: "nova-2-medical", displayName: "Nova 2 Medical" },
+    ],
+  },
+  {
+    sttProvider: "grok",
+    vendor: "xai",
+    vendorDisplayName: "xAI",
+    models: [
+      // Empty id, like the catalog: the endpoint takes no model parameter, so
+      // the ingest stores null and modelDisplayName() normalises the two.
+      { id: "", displayName: "Grok Speech-to-Text", isDefault: true },
+    ],
+  },
+  {
+    sttProvider: "azure-mai",
+    vendor: "azure",
+    vendorDisplayName: "Microsoft",
+    models: [{ id: "mai-transcribe-1.5", displayName: "MAI-Transcribe 1.5", isDefault: true }],
+  },
+  {
+    sttProvider: "google-chirp",
+    vendor: "google",
+    vendorDisplayName: "Google",
+    models: [{ id: "chirp_3", displayName: "Chirp 3", isDefault: true }],
+  },
+  {
+    sttProvider: "elevenlabs",
+    vendor: "elevenlabs",
+    vendorDisplayName: "ElevenLabs",
+    models: [{ id: "scribe_v2", displayName: "Scribe v2", isDefault: true }],
+  },
+  {
+    sttProvider: "openai",
+    vendor: "openai",
+    vendorDisplayName: "OpenAI",
+    models: [
+      { id: "gpt-4o-transcribe", displayName: "GPT-4o Transcribe", isDefault: true },
+      { id: "gpt-4o-mini-transcribe", displayName: "GPT-4o Mini Transcribe" },
+      { id: "whisper-1", displayName: "Whisper" },
+      { id: "gpt-transcribe", displayName: "GPT Transcribe" },
+      { id: "gpt-live-transcribe", displayName: "GPT Live Transcribe" },
+    ],
+  },
+  {
+    sttProvider: "assemblyai",
+    vendor: "assemblyai",
+    vendorDisplayName: "AssemblyAI",
+    models: [
+      { id: "universal-3-pro", displayName: "Universal-3 Pro" },
+      { id: "universal-3-5-pro", displayName: "Universal-3.5 Pro", isDefault: true },
+      { id: "universal-2", displayName: "Universal-2" },
+    ],
+  },
+  {
+    sttProvider: "mistral",
+    vendor: "mistral",
+    vendorDisplayName: "Mistral",
+    models: [{ id: "voxtral-mini-latest", displayName: "Voxtral Mini", isDefault: true }],
+  },
+  {
+    sttProvider: "soniox",
+    vendor: "soniox",
+    vendorDisplayName: "Soniox",
+    models: [
+      { id: "stt-async-v4", displayName: "Async v4" },
+      { id: "stt-async-v5", displayName: "Async v5", isDefault: true },
+    ],
+  },
+  {
+    sttProvider: "gemini",
+    vendor: "google",
+    vendorDisplayName: "Google",
+    models: [
+      { id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash", isDefault: true },
+      { id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash Lite" },
+      { id: "gemini-2.5-pro", displayName: "Gemini 2.5 Pro" },
+      { id: "gemini-3-flash-preview", displayName: "Gemini 3 Flash" },
+      { id: "gemini-3.1-pro-preview", displayName: "Gemini 3.1 Pro" },
+    ],
+  },
+];
+
+const ENTRY_BY_PROVIDER = new Map(STT_CATALOG.map((entry) => [entry.sttProvider, entry]));
+
 /**
- * The provider ids the ingest route stores, derived from the display map rather
- * than listed a second time.
+ * The provider ids the ingest route stores, derived from the catalog mirror
+ * rather than listed a second time.
  *
  * A hand-kept second copy drifts silently and asymmetrically: a provider added
- * to the map above renders on the page while every row the edge service reports
- * for it is rejected at ingest as an unknown provider, so the column stays
+ * to the mirror above renders on the page while every row the edge service
+ * reports for it is rejected at ingest as an unknown provider, so the row stays
  * permanently empty and nothing says why. Deriving makes "these two lists match
  * 1:1" true by construction instead of by comment.
  *
@@ -52,8 +166,67 @@ export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
  * that one is justified: it is a different deployable across a service
  * boundary, which is exactly what the ingest is validating.
  */
-export const KNOWN_PROVIDERS: readonly string[] = Object.keys(PROVIDER_DISPLAY_NAMES);
+export const KNOWN_PROVIDERS: readonly string[] = STT_CATALOG.map(
+  (entry) => entry.sttProvider,
+);
 
-export function providerDisplayName(id: string): string {
-  return PROVIDER_DISPLAY_NAMES[id] ?? id;
+/** The name the app's Provider dropdown shows for a vendor key. */
+export function vendorDisplayName(vendorKey: string): string {
+  const entry = STT_CATALOG.find((candidate) => candidate.vendor === vendorKey);
+  return entry?.vendorDisplayName ?? vendorKey;
+}
+
+/**
+ * The name the app's Model dropdown shows for one stored row's model.
+ *
+ * A null model and an empty one are the same thing — the ingest stores null for
+ * a provider whose endpoint takes no model id, and the catalog spells that same
+ * model with an empty id — so both resolve to the provider's single entry rather
+ * than to an unnamed row.
+ */
+export function modelDisplayName(providerId: string, modelId: string | null): string {
+  const id = modelId ?? "";
+  const model = ENTRY_BY_PROVIDER.get(providerId)?.models.find(
+    (candidate) => candidate.id === id,
+  );
+  return model?.displayName ?? (id === "" ? providerId : id);
+}
+
+/**
+ * Whether a stored row's model is the one a fresh pick of its VENDOR lands on.
+ *
+ * Scoped to the vendor, not the entry, because a row on the page is a vendor.
+ * Google owns two entries and each marks a default of its own — chirp_3 and
+ * gemini-2.5-flash — but selecting Google in the app lands on the vendor group's
+ * first entry in catalog order and then on that entry's default
+ * (`VendorGroup.defaultEntry` / `CloudSTTCatalog.defaultModel`), so exactly one
+ * of the two is what a visitor would actually get. Badging both would tell them
+ * a choice exists that the app never offers.
+ */
+export function isDefaultModel(providerId: string, modelId: string | null): boolean {
+  const entry = ENTRY_BY_PROVIDER.get(providerId);
+  if (!entry) return false;
+  const first = STT_CATALOG.find((candidate) => candidate.vendor === entry.vendor);
+  if (!first || first.sttProvider !== providerId) return false;
+  const fallsBackTo = first.models.find((model) => model.isDefault) ?? first.models[0];
+  return fallsBackTo?.id === (modelId ?? "");
+}
+
+/**
+ * Catalog position of one (provider, model) pair, used to order the model rows
+ * under a vendor exactly as the app's Model dropdown orders them. A pair the
+ * catalog does not know sorts last, so a model the edge service starts reporting
+ * before this mirror is updated appears at the bottom of its vendor instead of
+ * silently taking someone else's place.
+ */
+export function modelSortIndex(providerId: string, modelId: string | null): number {
+  const id = modelId ?? "";
+  let index = 0;
+  for (const entry of STT_CATALOG) {
+    for (const model of entry.models) {
+      if (entry.sttProvider === providerId && model.id === id) return index;
+      index += 1;
+    }
+  }
+  return Number.MAX_SAFE_INTEGER;
 }

--- a/nextjs/lib/latency/types.ts
+++ b/nextjs/lib/latency/types.ts
@@ -41,8 +41,19 @@ export function bucketForSeconds(seconds: number): DurationBucket {
 /** The bucket most clips land in, so the page opens on the busiest data. */
 export const DEFAULT_BUCKET: DurationBucket = "short";
 
-/** Trailing window the page reports on. Raw rows live for a year. */
-export const WINDOW_DAYS = 30;
+/**
+ * Trailing window the page reports on. Raw rows live for a year, so this can
+ * move without a data migration.
+ *
+ * 90 days rather than 30 because the page now cuts each vendor into its models,
+ * and a model row counts only the attempts that ran on that model. A 30-day
+ * window left most model rows under MIN_SAMPLES_PER_CELL, and p99 needs 500
+ * attempts in a single cell — a bar a per-model cell reaches only with a window
+ * this long. The cost is that a provider's recent improvement takes longer to
+ * show; the page states the window in its header, so nobody reads a 90-day
+ * figure as a reading of today.
+ */
+export const WINDOW_DAYS = 90;
 
 /**
  * A cell below this many attempts shows "not enough data" instead of a number.
@@ -92,8 +103,8 @@ export const BUCKET_LABELS: Record<DurationBucket, string> = Object.fromEntries(
   DURATION_BUCKET_MODEL.map((bucket) => [bucket.id, bucket.label]),
 ) as Record<DurationBucket, string>;
 
+/** One region's numbers for one row of the table. */
 export type LatencyCell = {
-  provider: string;
   region: string;
   samples: number;
   p50: number;
@@ -103,9 +114,43 @@ export type LatencyCell = {
   errorRate: number;
 };
 
-export type LatencyMatrixData = {
+/**
+ * One model of one vendor — a row the table shows only while "Break down by
+ * model" is on.
+ *
+ * `provider` is the backend id the model belongs to, kept beside the model id
+ * because a vendor can span several: selecting a Gemini model under the merged
+ * Google row is what moves the backend provider from google-chirp to gemini.
+ */
+export type LatencyModelRow = {
+  provider: string;
+  /** Null for a provider whose endpoint takes no model id. */
+  model: string | null;
+  label: string;
+  /** The model a fresh install lands on, badged as such in the table. */
+  isDefault: boolean;
   cells: LatencyCell[];
-  providers: string[];
+};
+
+/**
+ * One vendor — a row of the table, named the way the app's Provider dropdown
+ * names it.
+ *
+ * Its cells are NOT a blend of the model rows below it. Percentiles do not
+ * average, so both levels are aggregated separately in Postgres over the same
+ * rows; see src/content/latency.ts.
+ */
+export type LatencyVendorRow = {
+  /** Catalog `vendor` key. Google covers both Chirp and Gemini. */
+  vendor: string;
+  label: string;
+  cells: LatencyCell[];
+  /** In the order the app's Model dropdown lists them. */
+  models: LatencyModelRow[];
+};
+
+export type LatencyMatrixData = {
+  vendors: LatencyVendorRow[];
   regions: string[];
   totalSamples: number;
   windowDays: number;

--- a/nextjs/src/content/latency.ts
+++ b/nextjs/src/content/latency.ts
@@ -11,7 +11,16 @@ import {
   type DurationBucket,
   type LatencyCell,
   type LatencyMatrixData,
+  type LatencyModelRow,
+  type LatencyVendorRow,
 } from "@/lib/latency/types";
+import {
+  STT_CATALOG,
+  isDefaultModel,
+  modelDisplayName,
+  modelSortIndex,
+  vendorDisplayName,
+} from "@/lib/latency/providers";
 
 function toNumber(value: unknown): number {
   const parsed = typeof value === "number" ? value : Number(value);
@@ -31,16 +40,53 @@ function toNumber(value: unknown): number {
  */
 const IS_BUILD_PRERENDER = process.env.NEXT_PHASE === "phase-production-build";
 
+/**
+ * `provider` mapped to its catalog vendor, in SQL, so Postgres can group at the
+ * level the table's rows are named at.
+ *
+ * The mapping cannot be applied after the query: a vendor row is a percentile
+ * over that vendor's attempts, and percentiles do not average. Blending
+ * google-chirp's p95 with gemini's — by sample count or any other weight — would
+ * print a number no call ever took. The `else` arm keeps a provider this app has
+ * not learned yet as its own row rather than dropping it.
+ *
+ * Written once, into a subquery column, and grouped on by name — never repeated
+ * inline in the GROUP BY. A grouping element has to be the same expression as
+ * the one it groups, and drizzle parameterises each catalog id, so a second
+ * textual copy of this CASE is a different set of parameter placeholders and
+ * Postgres rejects the query outright.
+ */
+const VENDOR_EXPR = sql.join(
+  [
+    sql`case`,
+    ...STT_CATALOG.map(
+      (entry) =>
+        sql`when ${sttLatencySamples.provider} = ${entry.sttProvider} then ${entry.vendor}`,
+    ),
+    sql`else ${sttLatencySamples.provider} end`,
+  ],
+  sql` `,
+);
+
 /** The shape a bucket with no rows has. Also what a build-time failure renders. */
 function emptyMatrix(): LatencyMatrixData {
-  return { cells: [], providers: [], regions: [], totalSamples: 0, windowDays: WINDOW_DAYS };
+  return { vendors: [], regions: [], totalSamples: 0, windowDays: WINDOW_DAYS };
 }
 
 /**
- * Aggregates the trailing 30-day window for one clip-length bucket, grouped by
- * provider and region. Postgres computes the percentiles — pulling raw rows into
- * the page and sorting them in JavaScript would not survive real volume. The
+ * Aggregates the trailing window for one clip-length bucket, at both levels the
+ * table shows: one set of cells per vendor, and one per (provider, model) inside
+ * it. Postgres computes the percentiles — pulling raw rows into the page and
+ * sorting them in JavaScript would not survive real volume. The
  * (duration_bucket, created_at, provider, fly_region) index matches this shape.
+ *
+ * Both levels come from ONE pass over the window, via GROUP BY GROUPING SETS.
+ * Two queries would scan the same 90 days twice for numbers that must agree with
+ * each other, and the vendor level cannot be derived from the model level anyway
+ * (see VENDOR_EXPR). The two kinds of row are told apart by `provider`, which is
+ * NOT NULL in the table and so is null only on the vendor rollup — no
+ * `grouping()` bitmask to decode. `model` is genuinely nullable, which is why it
+ * cannot play that part.
  *
  * Percentiles cover every attempt, failed ones included: a timeout is time the
  * user actually waited, so excluding it would flatter the slowest providers. The
@@ -52,14 +98,14 @@ function emptyMatrix(): LatencyMatrixData {
  *  - During `next build`, /en/latency is prerendered like every other static
  *    page. Throwing there fails `next build` outright — "Export encountered an
  *    error, exiting the build" — and takes every unrelated page of the deploy
- *    with it, for a page whose entire content is a 30-day average. A deploy must
+ *    with it, for a page whose entire content is a 90-day average. A deploy must
  *    not depend on Postgres being reachable from the builder, so at build time
  *    the failure is logged and the page ships in its empty state; the first
  *    revalidation an hour later fills it in.
  *  - At runtime the error propagates. Next treats a returned value — empty data
  *    included — as a successful render, so swallowing it during a background
  *    revalidation would REPLACE a good page with "0 provider attempts over the
- *    last 30 days" and cache that for an hour. Throwing leaves the last good
+ *    last 90 days" and cache that for an hour. Throwing leaves the last good
  *    page in the ISR cache, which is both correct and fresher than anything this
  *    function could invent, and Next retries on the next request.
  *
@@ -84,18 +130,44 @@ export async function getLatencyMatrix(
   }
 }
 
+type AggregateRow = {
+  vendor: string;
+  /** Null on a vendor rollup row; the backend provider id on a model row. */
+  provider: string | null;
+  model: string | null;
+  region: string;
+  samples: string;
+  p50: string;
+  p95: string;
+  p99: string;
+  errorRate: string;
+};
+
+function toCell(row: AggregateRow): LatencyCell {
+  return {
+    region: row.region,
+    samples: toNumber(row.samples),
+    p50: Math.round(toNumber(row.p50)),
+    p95: Math.round(toNumber(row.p95)),
+    p99: Math.round(toNumber(row.p99)),
+    errorRate: toNumber(row.errorRate),
+  };
+}
+
 async function queryLatencyMatrix(bucket: DurationBucket): Promise<LatencyMatrixData> {
   const since = new Date(Date.now() - WINDOW_DAYS * 24 * 60 * 60 * 1000);
 
-  const rows = await db
+  // The window's attempts with their vendor named. Filtering here keeps the
+  // whole scan on the (duration_bucket, created_at, …) index, and naming the
+  // vendor once is what lets both grouping sets below refer to it by column.
+  const attempt = db
     .select({
+      vendor: VENDOR_EXPR.as("vendor"),
       provider: sttLatencySamples.provider,
+      model: sttLatencySamples.model,
       region: sttLatencySamples.flyRegion,
-      samples: sql<string>`count(*)`,
-      p50: sql<string>`percentile_cont(0.5) within group (order by ${sttLatencySamples.latencyMs})`,
-      p95: sql<string>`percentile_cont(0.95) within group (order by ${sttLatencySamples.latencyMs})`,
-      p99: sql<string>`percentile_cont(0.99) within group (order by ${sttLatencySamples.latencyMs})`,
-      errorRate: sql<string>`avg(case when ${sttLatencySamples.ok} then 0 else 1 end)`,
+      latencyMs: sttLatencySamples.latencyMs,
+      ok: sttLatencySamples.ok,
     })
     .from(sttLatencySamples)
     .where(
@@ -104,29 +176,111 @@ async function queryLatencyMatrix(bucket: DurationBucket): Promise<LatencyMatrix
         eq(sttLatencySamples.durationBucket, bucket),
       ),
     )
-    .groupBy(sttLatencySamples.provider, sttLatencySamples.flyRegion);
+    .as("attempt");
 
-  const cells: LatencyCell[] = rows.map((row) => ({
-    provider: row.provider,
-    region: row.region,
-    samples: toNumber(row.samples),
-    p50: Math.round(toNumber(row.p50)),
-    p95: Math.round(toNumber(row.p95)),
-    p99: Math.round(toNumber(row.p99)),
-    errorRate: toNumber(row.errorRate),
-  }));
+  const rows = await db
+    .select({
+      vendor: attempt.vendor,
+      // Null on the vendor rollup rows — see the grouping sets below.
+      provider: sql<string | null>`${attempt.provider}`,
+      model: attempt.model,
+      region: attempt.region,
+      samples: sql<string>`count(*)`,
+      p50: sql<string>`percentile_cont(0.5) within group (order by ${attempt.latencyMs})`,
+      p95: sql<string>`percentile_cont(0.95) within group (order by ${attempt.latencyMs})`,
+      p99: sql<string>`percentile_cont(0.99) within group (order by ${attempt.latencyMs})`,
+      errorRate: sql<string>`avg(case when ${attempt.ok} then 0 else 1 end)`,
+    })
+    .from(attempt)
+    .groupBy(
+      sql`grouping sets (
+        (${attempt.vendor}, ${attempt.region}),
+        (${attempt.vendor}, ${attempt.provider}, ${attempt.model}, ${attempt.region})
+      )`,
+    );
 
-  // Axes come from what the data holds. There is no declared region list in
-  // this repo, and a hardcoded one would rot the first time a region is added
-  // or retired.
-  const providers = Array.from(new Set(cells.map((cell) => cell.provider))).sort();
-  const regions = Array.from(new Set(cells.map((cell) => cell.region))).sort();
-  const totalSamples = cells.reduce((sum, cell) => sum + cell.samples, 0);
+  return buildMatrix(rows as AggregateRow[]);
+}
+
+/**
+ * Turns the flat aggregate into the nested rows the table draws.
+ *
+ * Axes and rows come from what the data holds. There is no declared region list
+ * in this repo, and a hardcoded one would rot the first time a region is added
+ * or retired. A vendor with no rows in this bucket is likewise absent rather
+ * than present and empty.
+ */
+function buildMatrix(rows: AggregateRow[]): LatencyMatrixData {
+  // Arrays hold the result and Maps only index into them: this tsconfig targets
+  // es5, where iterating a Map is a type error (TS2802) rather than a runtime
+  // one. `get` and `set` are fine.
+  const vendors: LatencyVendorRow[] = [];
+  const vendorIndex = new Map<string, LatencyVendorRow>();
+  const modelIndex = new Map<string, LatencyModelRow>();
+  const regions: string[] = [];
+  const seenRegions = new Map<string, true>();
+  let totalSamples = 0;
+
+  const vendorRowFor = (key: string): LatencyVendorRow => {
+    const existing = vendorIndex.get(key);
+    if (existing) return existing;
+    const created: LatencyVendorRow = {
+      vendor: key,
+      label: vendorDisplayName(key),
+      cells: [],
+      models: [],
+    };
+    vendorIndex.set(key, created);
+    vendors.push(created);
+    return created;
+  };
+
+  for (const row of rows) {
+    if (!seenRegions.has(row.region)) {
+      seenRegions.set(row.region, true);
+      regions.push(row.region);
+    }
+
+    const vendor = vendorRowFor(row.vendor);
+
+    if (row.provider === null) {
+      // The vendor rollup. Only these are totalled: the model rows partition the
+      // very same attempts, so counting both would report the window twice.
+      const cell = toCell(row);
+      vendor.cells.push(cell);
+      totalSamples += cell.samples;
+      continue;
+    }
+
+    const key = `${row.vendor}|${row.provider}|${row.model ?? ""}`;
+    let model = modelIndex.get(key);
+    if (!model) {
+      model = {
+        provider: row.provider,
+        model: row.model,
+        label: modelDisplayName(row.provider, row.model),
+        isDefault: isDefaultModel(row.provider, row.model),
+        cells: [],
+      };
+      modelIndex.set(key, model);
+      vendor.models.push(model);
+    }
+    model.cells.push(toCell(row));
+  }
+
+  for (const vendor of vendors) {
+    // Catalog order, so the rows read like the app's Model dropdown rather than
+    // like whatever order Postgres happened to return.
+    vendor.models.sort(
+      (a, b) => modelSortIndex(a.provider, a.model) - modelSortIndex(b.provider, b.model),
+    );
+  }
 
   return {
-    cells,
-    providers,
-    regions,
+    // Alphabetical by name is only the starting order — the client sorts by the
+    // metric on screen — but it keeps the server's output stable between builds.
+    vendors: vendors.sort((a, b) => a.label.localeCompare(b.label)),
+    regions: regions.sort(),
     totalSamples,
     windowDays: WINDOW_DAYS,
   };

--- a/nextjs/src/db/schema/stt-latency-samples.ts
+++ b/nextjs/src/db/schema/stt-latency-samples.ts
@@ -37,10 +37,11 @@ export const sttLatencySamples = pgTable(
     // stores the model it was ATTEMPTED with, since no model ever ran. Null when
     // the provider takes no model id.
     //
-    // Nothing reads this column yet — src/content/latency.ts groups by provider
-    // and region only, and the page labels rows by vendor alone for exactly that
-    // reason (lib/latency/providers.ts). It is written so cutting the aggregate
-    // by model later needs a new query rather than a year of new data.
+    // Read by the public page's "Break down by model" rows: src/content/latency.ts
+    // aggregates the same window at two levels in one pass, by vendor and by
+    // (provider, model). Written since the table existed, which is why that view
+    // covers the whole retained window rather than starting from the day it
+    // shipped.
     model: text("model"),
     // process.env.FLY_REGION of the machine that ran the attempt. Always a real
     // three-letter Fly region: a machine off Fly does not report at all, and the
@@ -83,13 +84,19 @@ export const sttLatencySamples = pgTable(
   },
   (table) => [
     // Serves the page's only query: `duration_bucket = $1 AND created_at >=
-    // now() - 30 days`, grouped by provider and region.
+    // now() - 90 days`, grouped by vendor and region and by (provider, model)
+    // and region.
     //
     // The EQUALITY column leads, then the range column. A btree can only bound
     // its scan on the leading column, so leading with created_at made every one
-    // of the three per-revalidation calls walk the whole 30-day range and throw
-    // away the ~2/3 of it belonging to the other two buckets. This way each call
+    // of the three per-revalidation calls walk the whole window and throw away
+    // the ~2/3 of it belonging to the other two buckets. This way each call
     // descends straight to its bucket and scans only that bucket's window.
+    //
+    // `model` is deliberately NOT appended, even though the aggregate now groups
+    // on it. The scan has to visit the heap either way — `latency_ms` is what the
+    // percentiles read and it is not in the index — so the extra column would buy
+    // no index-only scan, only a wider index on every write.
     index("stt_latency_samples_agg_idx").on(
       table.durationBucket,
       table.createdAt,

--- a/nextjs/tests/latency-report-validation.test.ts
+++ b/nextjs/tests/latency-report-validation.test.ts
@@ -12,9 +12,9 @@ const MODULE_PATH = "../app/api/internal/latency/validation.ts";
 const TYPES_MODULE_PATH = "../lib/latency/types.ts";
 const loadTypes = () => import(TYPES_MODULE_PATH);
 
-// The one list of provider ids, derived from the page's display map. The ingest
-// takes it as an argument rather than importing it, so the tests exercise the
-// real list by handing it in the same way route.ts does.
+// The one list of provider ids, derived from the page's catalog mirror. The
+// ingest takes it as an argument rather than importing it, so the tests exercise
+// the real list by handing it in the same way route.ts does.
 const PROVIDERS_MODULE_PATH = "../lib/latency/providers.ts";
 const loadProviders = () => import(PROVIDERS_MODULE_PATH);
 
@@ -118,57 +118,147 @@ test("accepts every provider the page can display", async () => {
   }
 });
 
-test("the page's provider ids are the catalog's backend ids", async () => {
-  const { PROVIDER_DISPLAY_NAMES } = await loadProviders();
+type CatalogFile = {
+  providers: {
+    sttProvider: string;
+    vendor: string;
+    vendorDisplayName: string;
+    models: { id: string; displayName: string; isDefault?: boolean }[];
+  }[];
+};
 
-  // KNOWN_PROVIDERS is `Object.keys(PROVIDER_DISPLAY_NAMES)`, so comparing the
-  // two only restates that line. The claim worth pinning is the one this app
-  // cannot enforce by construction: PROVIDER_DISPLAY_NAMES mirrors
-  // shared-app-classification/cloud-stt-catalog.json, which lives outside the
-  // Next.js build root and so is copied rather than imported. If the catalog
-  // gains a provider, or renames a backend id, the copy here goes stale — the
-  // page silently stops rendering that provider's column AND the ingest starts
-  // rejecting its rows as an unknown provider. Read as data, not imported: the
-  // point is precisely that the two deployables do not share a module system.
+/**
+ * The real catalog, read as data rather than imported — the point is precisely
+ * that the two deployables do not share a module system.
+ * shared-app-classification/cloud-stt-catalog.json lives outside the Next.js
+ * build root, so lib/latency/providers.ts copies it. If the catalog gains a
+ * provider, renames a backend id, or renames a model, the copy goes stale: the
+ * page silently stops rendering that provider AND the ingest starts rejecting
+ * its rows as an unknown provider.
+ */
+function readCatalog(): CatalogFile {
   const catalogPath = fileURLToPath(
     new URL("../../shared-app-classification/cloud-stt-catalog.json", import.meta.url),
   );
-  const catalog = JSON.parse(readFileSync(catalogPath, "utf8")) as {
-    providers: { sttProvider: string }[];
-  };
-  const catalogIds = catalog.providers.map((entry) => entry.sttProvider).sort();
+  return JSON.parse(readFileSync(catalogPath, "utf8")) as CatalogFile;
+}
 
-  assert.deepEqual(Object.keys(PROVIDER_DISPLAY_NAMES).sort(), catalogIds);
+test("the page's catalog mirror matches the catalog the apps read", async () => {
+  const { STT_CATALOG } = await loadProviders();
+
+  const shape = (entry: CatalogFile["providers"][number]) => ({
+    sttProvider: entry.sttProvider,
+    vendor: entry.vendor,
+    vendorDisplayName: entry.vendorDisplayName,
+    // Order matters as well as content: it is what puts a vendor's model rows in
+    // the same order as the app's Model dropdown.
+    models: entry.models.map((model) => ({
+      id: model.id,
+      displayName: model.displayName,
+      isDefault: model.isDefault === true,
+    })),
+  });
+
+  assert.deepEqual(
+    (STT_CATALOG as CatalogFile["providers"]).map(shape),
+    readCatalog().providers.map(shape),
+  );
 });
 
-test("no display label names a model the cell does not isolate", async () => {
-  const { PROVIDER_DISPLAY_NAMES } = await loadProviders();
+test("a provider row is named after a vendor, never after one of its models", async () => {
+  const { STT_CATALOG, vendorDisplayName } = await loadProviders();
 
-  // src/content/latency.ts groups by provider and region, never by model, while
-  // users can pin a per-provider model in either desktop app. So a label naming
-  // a model makes a claim about the rows underneath it that the query does not
-  // — "Deepgram Nova 3" over a cell that also holds nova-2 timings, "OpenAI
-  // Whisper" over a cell that is mostly gpt-4o-transcribe. The catalog's own
-  // displayName carries those suffixes, which is exactly why this app keeps its
-  // own vendor-only labels instead of reusing them.
+  // A provider row blends every model of that vendor, so a label naming one of
+  // them makes a claim about the rows underneath that the aggregate does not —
+  // "Deepgram Nova 3" over cells that also hold nova-2 timings. Naming models is
+  // the model rows' job. The catalog's per-entry `displayName` carries those
+  // suffixes, which is why the page reads `vendorDisplayName` instead.
   //
   // Two shapes to catch: a version number ("Nova 3", "Scribe v2",
-  // "MAI-Transcribe 1.5"), and a bare model family name. `\b` keeps
-  // "MAI-Transcribe" out of the `scribe` case — that is a product name, not a
-  // model this page blends.
+  // "MAI-Transcribe 1.5"), and a bare model family name.
   const version = /\d/;
-  const modelFamily = /\b(whisper|nova|voxtral|universal|scribe)/i;
-  const labels = PROVIDER_DISPLAY_NAMES as Record<string, string>;
-  for (const [id, label] of Object.entries(labels)) {
+  const modelFamily = /\b(whisper|nova|voxtral|universal|scribe|chirp|gemini|grok)/i;
+  for (const entry of STT_CATALOG as CatalogFile["providers"]) {
+    const label = vendorDisplayName(entry.vendor);
     assert.ok(
       !version.test(label),
-      `${id}: "${label}" names a model version, but the cell blends every model of that provider`,
+      `${entry.vendor}: "${label}" names a model version, but the row blends every model of that vendor`,
     );
     assert.ok(
       !modelFamily.test(label),
-      `${id}: "${label}" names a model family, but the cell blends every model of that provider`,
+      `${entry.vendor}: "${label}" names a model family, but the row blends every model of that vendor`,
     );
   }
+});
+
+test("Chirp and Gemini share one row, the way the app's Provider menu shows them", async () => {
+  const { STT_CATALOG, vendorDisplayName } = await loadProviders();
+
+  // The merge is the catalog's, not this app's: both entries carry
+  // vendor "google", which is what macOS's cloudTierVendorGroups collapses on.
+  // Splitting them here would put two rows on the page that the app never names
+  // separately.
+  const google = (STT_CATALOG as CatalogFile["providers"]).filter(
+    (entry) => entry.vendor === "google",
+  );
+  assert.deepEqual(
+    google.map((entry) => entry.sttProvider).sort(),
+    ["gemini", "google-chirp"],
+  );
+  assert.equal(vendorDisplayName("google"), "Google");
+});
+
+test("every model row is named the way the app's Model menu names it", async () => {
+  const { modelDisplayName, isDefaultModel, modelSortIndex } = await loadProviders();
+
+  for (const entry of readCatalog().providers) {
+    for (const model of entry.models) {
+      assert.equal(
+        modelDisplayName(entry.sttProvider, model.id),
+        model.displayName,
+        `${entry.sttProvider}/${model.id}`,
+      );
+      assert.ok(modelSortIndex(entry.sttProvider, model.id) < Number.MAX_SAFE_INTEGER);
+    }
+  }
+
+  // The ingest stores null for a provider whose endpoint takes no model id, and
+  // the catalog spells that same model with an empty id. Both must resolve to
+  // the one model, or xAI's only row would print its raw backend id.
+  assert.equal(modelDisplayName("grok", null), "Grok Speech-to-Text");
+  assert.equal(modelDisplayName("grok", ""), "Grok Speech-to-Text");
+  assert.equal(isDefaultModel("grok", null), true);
+
+  // A model the mirror has not learned yet keeps its raw id and sorts last,
+  // rather than borrowing another model's name or position.
+  assert.equal(modelDisplayName("openai", "gpt-5-transcribe"), "gpt-5-transcribe");
+  assert.equal(modelSortIndex("openai", "gpt-5-transcribe"), Number.MAX_SAFE_INTEGER);
+});
+
+test("exactly one model per vendor is badged as the default", async () => {
+  const { STT_CATALOG, isDefaultModel } = await loadProviders();
+
+  // A row on the page is a vendor, so "default" has to mean what the app means
+  // by it: what picking that vendor and touching nothing else gives you. Google
+  // marks a default inside BOTH its entries (chirp_3 and gemini-2.5-flash), but
+  // selecting Google lands on the first entry in catalog order and then on that
+  // entry's default — one model, not two.
+  const badged = new Map<string, string[]>();
+  for (const entry of STT_CATALOG as CatalogFile["providers"]) {
+    for (const model of entry.models) {
+      if (!isDefaultModel(entry.sttProvider, model.id)) continue;
+      badged.set(entry.vendor, [...(badged.get(entry.vendor) ?? []), model.displayName]);
+    }
+  }
+
+  for (const entry of STT_CATALOG as CatalogFile["providers"]) {
+    assert.deepEqual(
+      badged.get(entry.vendor)?.length,
+      1,
+      `${entry.vendor}: ${JSON.stringify(badged.get(entry.vendor))}`,
+    );
+  }
+  assert.deepEqual(badged.get("google"), ["Chirp 3"]);
 });
 
 test("rejects a failure sample with no failure kind", async () => {
@@ -320,7 +410,7 @@ test("stores the arrival hour, not the instant, so a chain cannot be reassembled
     coarseCreatedAt(at).getTime(),
     coarseCreatedAt(Date.UTC(2026, 7, 4, 13, 59, 59, 999)).getTime(),
   );
-  // The next hour is a different value, so a 30-day window still moves.
+  // The next hour is a different value, so the trailing window still moves.
   assert.notEqual(
     coarseCreatedAt(at).getTime(),
     coarseCreatedAt(Date.UTC(2026, 7, 4, 14, 0, 0, 0)).getTime(),


### PR DESCRIPTION
Two changes to `/en/latency`, plus a longer window.

## 1. Provider names match the app

The page kept its own labels. They now come from a mirror of `shared-app-classification/cloud-stt-catalog.json` — the file both desktop apps read.

| Page before | Now |
|---|---|
| xAI Grok | xAI |
| Microsoft MAI-Transcribe | Microsoft |
| Google Chirp | Google |
| Google Gemini | Google (same row) |

The other seven names were already the app's. **Chirp and Gemini merge into one Google row**, because the catalog gives both entries `vendor: "google"` and that is exactly what the app's Provider menu collapses on (`CloudSTTCatalog.cloudTierVendorGroups`). Splitting them here would name two things the app never names separately.

## 2. Break down by model

A new toggle, **off by default**. On, each vendor row opens into its models — named the way the app's Model menu names them, in the same order, with one `default` badge per vendor: the model a fresh pick of that vendor actually lands on, not one per catalog entry (Google marks a default inside both of its entries; only Chirp 3 is what selecting Google gives you).

It is off by default because a model row counts only the attempts that ran on that model, so it is a thinner, noisier view of the same window, and the question most visitors arrive with is about providers.

## 3. Window: 30 days → 90

A model cell needs 3 attempts before it prints a number, and p99 needs 500. At 30 days most model cells sat under the floor. The page states its window in the header, so nobody reads a 90-day figure as a reading of today.

## How it is queried

One pass. A subquery names each attempt's vendor, then `GROUP BY GROUPING SETS` aggregates by vendor and by `(provider, model)` over the same rows. Vendor rows are **not** derived from model rows: percentiles do not average, so blending Chirp's p95 with Gemini's would print a number no call ever took. Rollup rows are told apart by `provider IS NULL` — `provider` is `NOT NULL` in the table, and `model` is genuinely nullable so it cannot play that part.

## No migration

- `model` has been written on every row since the table existed, and rows are retained for a year, so the breakdown covers the whole retained window rather than starting today.
- The aggregate index is deliberately unchanged. The scan visits the heap for `latency_ms` either way, so adding `model` to the index buys no index-only scan — only a wider index on every write.

## Verification

- `node --test --experimental-strip-types tests/latency-report-validation.test.ts` — 27 pass. New tests pin the mirror against the real catalog (ids, vendors, model names, order), the one-default-per-vendor rule, the Google merge, and the null/empty model id equivalence.
- `npx tsc --noEmit` — clean for these files (three unrelated pre-existing errors in `CustomersClient.tsx` / `TRPCProvider.tsx` remain).
- Ran the real query against Postgres 16 with seeded rows across both Google providers, a null-model provider, and an unknown provider: totals match, model rows partition their vendor exactly, the unknown provider falls through to its raw id.
- Rendered `/en/latency` against that database and toggled the breakdown in a browser — no console errors from the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7nbEsh7TjMgW9k4YEDWsX