### PR TITLE
Fix infinite Parakeet prepare loop that pegs a core and blocks the menu bar

### DIFF
--- a/app/macos/hyperwhisper/Managers/Transcription/Models/ParakeetModelManager.swift
+++ b/app/macos/hyperwhisper/Managers/Transcription/Models/ParakeetModelManager.swift
@@ -217,7 +217,19 @@ final class ParakeetModelManager: ObservableObject {
             localURL: v3Exists ? v3Directory : nil
         ))
 
-        availableModels = models
+        // PUBLISH ONLY ON AN ACTUAL CHANGE:
+        // `@Published` fires on every assignment, equal value or not. Assigning
+        // unconditionally here closes a feedback cycle that never settles:
+        // the root view's `.onReceive($availableModels)` calls
+        // `refreshParakeetReadiness` -> `prepareModel(for:)` -> `refreshState()`,
+        // which publishes again. `.removeDuplicates()` on that subscription
+        // cannot break it, because `prepareModel` moves `modelReadyState` from
+        // `.loading` to `.ready`, re-evaluating the root body and rebuilding the
+        // operator chain with no memory of the previous value.
+        // See ParakeetRefreshStateRepublishTests.
+        if availableModels != models {
+            availableModels = models
+        }
     }
 
     // START DOWNLOAD:

--- a/app/macos/hyperwhisperTests/ParakeetRefreshStateRepublishTests.swift
+++ b/app/macos/hyperwhisperTests/ParakeetRefreshStateRepublishTests.swift
@@ -1,0 +1,58 @@
+//
+//  ParakeetRefreshStateRepublishTests.swift
+//  hyperwhisperTests
+//
+
+import Combine
+import Testing
+@testable import HyperWhisper
+
+@MainActor
+struct ParakeetRefreshStateRepublishTests {
+
+    /// `refreshState()` derives `availableModels` entirely from what is on disk.
+    /// Two consecutive calls with no download or delete in between therefore
+    /// describe an identical state, so the second must not publish.
+    ///
+    /// Publishing regardless closes a feedback cycle through the root view:
+    ///
+    ///   hyperwhisperApp.swift  .onReceive(parakeetModelManager.$availableModels)
+    ///     -> TranscriptionPipeline.refreshParakeetReadiness(forModeId:)
+    ///     -> TranscriptionPipeline.refreshPendingParakeetReadinessIfReady()
+    ///     -> TranscriptionModelManager.prepareModel(for:)
+    ///     -> ParakeetModelManager.refreshState()
+    ///     -> publish, and round again
+    ///
+    /// The `.dropFirst().removeDuplicates()` on that subscription cannot break
+    /// the cycle, because `prepareModel` moves `modelReadyState` from `.loading`
+    /// to `.ready`, which re-evaluates the root body and rebuilds the operator
+    /// chain; a rebuilt `removeDuplicates` has no memory of the previous value.
+    ///
+    /// Measured on 2.43.0 before the fix: one core saturated, the menu bar
+    /// status item re-committing its scene about 74 times a second, and the
+    /// status label flipping between "Parakeet V3" and "Parakeet V3 (Loading...)"
+    /// about 22 times a second.
+    ///
+    /// This test is deliberately independent of whether any Parakeet weights are
+    /// installed: it asserts that two consecutive reads of the same disk state
+    /// agree, not what that state is.
+    @Test func refreshStateDoesNotRepublishWhenNothingChanged() {
+        let manager = ParakeetModelManager()
+
+        // `init()` already performed the one legitimate refresh, so the manager
+        // is settled by this point. `dropFirst()` then discards the current
+        // value that Combine replays on subscription, leaving only genuinely
+        // new publications to be counted.
+        var republishCount = 0
+        let cancellable = manager.$availableModels
+            .dropFirst()
+            .sink { _ in republishCount += 1 }
+
+        manager.refreshState()
+        manager.refreshState()
+
+        cancellable.cancel()
+
+        #expect(republishCount == 0)
+    }
+}


### PR DESCRIPTION
## The bug

Selecting a mode whose transcription model is Parakeet puts the app into an unbounded SwiftUI update loop. It never settles.

Measured on 2.43.0 (build 112), macOS 26.0, idle app, no recording in progress:

| | before |
|---|---|
| CPU | 86 to 102% of one core, indefinitely |
| menu bar status item scene commits | ~74 per second |
| status label | flips "Parakeet V3" to "Parakeet V3 (Loading...)" ~22 times per second |
| main thread | ~88% of samples inside `GraphHost.flushTransactions` / `AG::Subgraph::update`, no timer involved |

The user-visible damage is worse than the CPU cost: because the `MenuBarExtra` scene is torn down and rebuilt ~74 times a second, its menu items cannot be clicked. The menu is rebuilt out from under the pointer before a click can land, so the app becomes unreachable from the menu bar, which is its primary entry point when Show in Dock is off.

`log show` for the process is full of:

```
[com.apple.controlcenter:...-Aux[1]-NSStatusItemView] Dropping transition context because the scene is reconnecting
[BSBlockSentinel:FBSWorkspaceScenesClient] failed!
```

## Root cause

`ParakeetModelManager.refreshState()` rebuilds `models` from disk and then assigns it unconditionally:

```swift
// ParakeetModelManager.swift:220
availableModels = models
```

`@Published` fires on every assignment regardless of equality, so a refresh that observed no change on disk still publishes. That closes a cycle:

```
hyperwhisperApp.swift:319   .onReceive(parakeetModelManager.$availableModels.dropFirst().removeDuplicates())
  -> TranscriptionPipeline+Models.swift:73    refreshParakeetReadiness(forModeId:)
  -> TranscriptionPipeline+Models.swift:84    refreshPendingParakeetReadinessIfReady()
  -> TranscriptionPipeline+Models.swift:114   prepareModel(for:)
  -> TranscriptionModelManager.swift:303      parakeetModelManager.refreshState()
  -> ParakeetModelManager.swift:220           publish, and round again
```

The `.removeDuplicates()` on that subscription looks like it should break the cycle, but it cannot. `prepareModel` sets `modelReadyState` to `.loading(name:)` and then `.ready(name:)`, which re-evaluates the root body, which rebuilds the `.dropFirst().removeDuplicates()` chain. A freshly built `removeDuplicates` has no memory of the previous value, so the next publication passes straight through.

Two details worth noting for review:

- The cycle is gated on the mode's model being Parakeet, at `TranscriptionModelManager.swift` (`isParakeetModel`) and again at `TranscriptionPipeline+Models.swift:110` (`canonicalModelId`). Pointing the mode at any non-Parakeet model stops it, which is the only workaround available to users today.
- The third subscriber, `TranscriptionModelManager.observeParakeetAvailability` at line 151, is **not** part of the loop. It is guarded on `pendingParakeetPreparation` plus a `.unavailable` state, so it is inert once the weights are installed.

## The fix

Guard the publish on an actual change. `ParakeetModel` is already `Equatable`, so this is a one-line change with no other call sites affected. Every existing caller of `refreshState()` (init, `didBecomeActiveNotification`, and post download/delete) still publishes whenever disk state genuinely differs.

## Why this is two commits

The first commit adds only the test, the second adds the guard, so the test is shown to catch the bug rather than merely passing alongside the fix. Checking out `a8439a0` alone and running `-only-testing:hyperwhisperTests/ParakeetRefreshStateRepublishTests` gives the red run.

To be precise about what I did and did not verify: I could not produce that red run in CI myself, because workflow runs on a first-time contributor's fork sit at `action_required` until a maintainer approves them. I also could not build locally (the pinned Xcode 26.3 is not available to me), so the in-repo test above is unrun by me. What I did verify is below.

I also verified the fix in an isolated Combine harness that models the resubscribe-per-body-evaluation behaviour, with both arms:

- current code, unconditional assign: hit the 5000 iteration budget, 5001 publishes, runaway
- with the guard: settles after 1 publish (the genuine empty to populated transition) and 1 delivery, then silent

## Relationship to #139

#139 identified the same root cause and proposed the same one-line guard, then was closed by its author 13 minutes later without merging and the branch was deleted, with no explanation recorded. If it was withdrawn for a reason that still stands, I would genuinely like to know what it was, since the bug is still reproducible on 2.43.0 and the code path is unchanged in 2.44.0. This PR adds the regression test that #139 did not have.
