### PR TITLE
feat(nextjs): add /choosing-a-model, a 100-point model chooser

### DIFF
--- a/nextjs/app/[locale]/choosing-a-model/page.tsx
+++ b/nextjs/app/[locale]/choosing-a-model/page.tsx
@@ -1,0 +1,217 @@
+import { notFound } from "next/navigation";
+
+import ModelPicker from "@/components/choosing-a-model/ModelPicker";
+import { getMeasuredLatency } from "@/src/content/choosing-a-model";
+import { CLOUD_MODELS, DEVICE_MODELS } from "@/lib/choosing-a-model/catalog";
+
+export const dynamic = "force-static";
+export const revalidate = 3600;
+
+const TITLE = "Choosing a speech-to-text model";
+const DESCRIPTION =
+  "Split 100 points across accuracy, speed, cost and privacy, and see which of the models HyperWhisper ships actually fits — cloud and on-device, ranked side by side.";
+
+export async function generateMetadata() {
+  return {
+    title: TITLE,
+    description: DESCRIPTION,
+    alternates: {
+      canonical: "https://hyperwhisper.com/en/choosing-a-model",
+    },
+  };
+}
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+/**
+ * The model chooser. English only, like /latency and the blog — the page is
+ * mostly numbers, and translating 40 copies of them buys nothing.
+ *
+ * Static with an hourly revalidate. The measured timings behind it are a 90-day
+ * aggregate, so an hour-old page tells the same story as a fresh one, and the
+ * one thing that really is per-visitor — which region they are closest to — is
+ * fetched by the client from a small dynamic endpoint after paint.
+ */
+export default async function ChoosingAModelPage({ params }: Props) {
+  const { locale } = await params;
+  if (locale !== "en") {
+    notFound();
+  }
+
+  const measured = await getMeasuredLatency();
+
+  // Busiest regions first, so the default selection is a region we know well
+  // and the dropdown opens on something useful even if geolocation is blocked.
+  const regions = Object.keys(measured).sort(
+    (a, b) => Object.keys(measured[b]).length - Object.keys(measured[a]).length,
+  );
+
+  return (
+    <div className="w-full py-16 md:py-24">
+      <header className="mx-auto max-w-3xl text-center">
+        <h1 className="bg-gradient-to-r from-white to-gray-400 bg-clip-text text-4xl font-bold text-transparent md:text-5xl">
+          You have 100 points. Spend them.
+        </h1>
+        <p className="mx-auto mt-6 text-lg text-gray-400">
+          Every speech-to-text trade-off is zero-sum — the most accurate model is
+          rarely the cheapest or the fastest, and the most private one runs on
+          your own hardware. So instead of rating everything &ldquo;very
+          important&rdquo;, split 100 points across four priorities. Push one up
+          and the others give way.
+        </p>
+        <p className="mx-auto mt-4 text-sm text-gray-500">
+          We rank the {CLOUD_MODELS.length} cloud models and{" "}
+          {DEVICE_MODELS.length} on-device models HyperWhisper actually ships
+          across macOS and Windows — not a general leaderboard. Pick your
+          platform below and the list narrows to what you can run.
+        </p>
+      </header>
+
+      <ModelPicker measured={measured} regions={regions} />
+
+      <section className="mx-auto mt-20 max-w-3xl border-t border-gray-800 pt-10">
+        <h2 className="text-xl font-semibold text-white">
+          Cloud and on-device are different bargains
+        </h2>
+        <p className="mt-4 text-sm leading-6 text-gray-400">
+          Every row on this page is one or the other, and the badge says which.
+          The distinction is not a detail — it changes what you pay, what you
+          wait for, and where your voice ends up.
+        </p>
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="rounded-lg border border-sky-800/50 bg-sky-950/20 p-5">
+            <h3 className="text-sm font-semibold text-sky-300">Cloud models</h3>
+            <p className="mt-2 text-sm leading-6 text-gray-400">
+              Your audio is uploaded to HyperWhisper Cloud, which hands it to the
+              provider and sends the text back. You get the strongest accuracy
+              available and no download, and you pay per audio minute in credits.
+              These are the models with published error rates, because a hosted
+              model is something a third party can measure.
+            </p>
+          </div>
+          <div className="rounded-lg border border-emerald-800/50 bg-emerald-950/20 p-5">
+            <h3 className="text-sm font-semibold text-emerald-300">
+              On-device models
+            </h3>
+            <p className="mt-2 text-sm leading-6 text-gray-400">
+              The model is downloaded once and runs on your own Mac or PC. The
+              audio never leaves the machine, there is nothing to pay per minute,
+              and it works with no network at all. What you give up is the top of
+              the accuracy table, and a few gigabytes of disk.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto mt-16 max-w-3xl border-t border-gray-800 pt-10">
+        <h2 className="text-xl font-semibold text-white">
+          Where these numbers come from
+        </h2>
+        <dl className="mt-6 space-y-6 text-sm leading-6 text-gray-400">
+          <div>
+            <dt className="font-medium text-gray-200">Accuracy</dt>
+            <dd className="mt-1">
+              Word error rate comes from the{" "}
+              <a
+                className="text-purple-300 underline underline-offset-4 transition hover:text-purple-200"
+                href="https://artificialanalysis.ai/speech-to-text/non-streaming"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                Artificial Analysis speech-to-text leaderboard
+              </a>{" "}
+              — an independent third party, not us. We do not publish an accuracy
+              claim of our own here. A model they have not measured shows a dash
+              and is marked <span className="text-gray-200">not benchmarked</span>;
+              it scores neutrally rather than being flattered by a number we
+              invented.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">
+              Why some on-device models borrow a cloud model&apos;s score
+            </dt>
+            <dd className="mt-1">
+              Whisper and Parakeet are open weights. The leaderboard measured the
+              same weight files we download, just running on someone else&apos;s
+              hardware — so the error rate carries over and is marked{" "}
+              <span className="text-gray-200">same weights</span>. Speed does not
+              carry over, which is why those rows never borrow a speed figure.
+              The remaining local models have no published benchmark at all and
+              fall back to the app&apos;s own accuracy rating, marked{" "}
+              <span className="text-gray-200">app rating</span>. Without that
+              fallback the smallest, roughest models would score like frontier
+              ones purely for being free and private.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">Cost</dt>
+            <dd className="mt-1">
+              Credits per audio minute, read from the same catalog the desktop
+              apps read, so the price here is the price the app charges you.
+              1,000 credits are $1, which makes a model at 4.5 credits a minute
+              $4.50 per 1,000 minutes of audio. On-device models cost nothing to
+              run, so they score full marks on cost no matter how you weight it.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">Speed</dt>
+            <dd className="mt-1">
+              Where we have measured a provider from your nearest region, the
+              number is our own median from the last 90 days — the same
+              measurements behind{" "}
+              <a
+                className="text-purple-300 underline underline-offset-4 transition hover:text-purple-200"
+                href="/en/latency"
+              >
+                the latency page
+              </a>
+              , taken from short clips because that is what dictation is. Those
+              rows carry a dot. Everything else falls back to the
+              leaderboard&apos;s published speed factor. On-device timings are an
+              estimate from the app&apos;s own speed rating and depend on your
+              hardware, so read them as an ordering, not a promise.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">Privacy</dt>
+            <dd className="mt-1">
+              Three steps, by where the audio goes. On-device scores full marks:
+              nothing is transmitted. A model you can use with your own API key
+              scores half: the audio still reaches the vendor, but on your
+              account rather than through us. A cloud-tier-only model scores
+              lowest. Turn the privacy slider up and the ranking moves to
+              on-device models, which is the honest answer to that question.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">Your region</dt>
+            <dd className="mt-1">
+              HyperWhisper Cloud runs in 17 regions and routes you to the nearest
+              one. We ask a small endpoint which of those you are closest to so
+              the speed numbers are the ones you would actually get; the answer
+              is used once to pick a row and is never stored. You can override it
+              with the dropdown. Off our edge — a local dev server, say — nothing
+              is detected and the busiest region is selected instead.
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-gray-200">
+              What this page will not tell you
+            </dt>
+            <dd className="mt-1">
+              A ranking is not a recommendation for a job it has never seen. If
+              you dictate medical or legal terms, transcribe heavy accents, or
+              need speaker labels, the model that wins here on paper may still
+              lose on your audio. Every model listed is switchable in Settings →
+              Transcription, so the last word is a minute of your own speech, not
+              a number on a website.
+            </dd>
+          </div>
+        </dl>
+      </section>
+    </div>
+  );
+}

--- a/nextjs/components/choosing-a-model/ModelPicker.tsx
+++ b/nextjs/components/choosing-a-model/ModelPicker.tsx
@@ -1,0 +1,557 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Cloud, Laptop, MapPin } from "lucide-react";
+
+import {
+  CREDITS_PER_DOLLAR,
+  isCloud,
+  isDevice,
+  modelsForPlatform,
+  type Model,
+  type Platform,
+} from "@/lib/choosing-a-model/catalog";
+import {
+  DEFAULT_WEIGHTS,
+  PRESETS,
+  PRIORITIES,
+  PRIORITY_LABELS,
+  buildPool,
+  creditsPerMinute,
+  rankModels,
+  rebalance,
+  type LanguageNeed,
+  type Priority,
+  type Requirements,
+  type ScoredModel,
+  type Weights,
+} from "@/lib/choosing-a-model/scoring";
+import { regionCity } from "@/lib/latency/fly-regions";
+
+type MeasuredLatencyByRegion = Record<string, Record<string, number>>;
+
+type Props = {
+  measured: MeasuredLatencyByRegion;
+  /** Regions we hold measurements for, most-measured first. */
+  regions: string[];
+};
+
+const PRIORITY_HINTS: Record<Priority, string> = {
+  accuracy: "How often it gets a word wrong",
+  latency: "How long you wait for the text",
+  cost: "What a minute of audio costs you",
+  privacy: "Whether the audio leaves your machine",
+};
+
+/**
+ * Bar colours, one per priority. They repeat in the budget bar, the sliders and
+ * every row's breakdown, so a colour always means the same thing on this page.
+ */
+const PRIORITY_BAR: Record<Priority, string> = {
+  accuracy: "bg-purple-500",
+  latency: "bg-blue-500",
+  cost: "bg-emerald-500",
+  privacy: "bg-amber-500",
+};
+
+const PRIORITY_ACCENT: Record<Priority, string> = {
+  accuracy: "accent-purple-500",
+  latency: "accent-blue-500",
+  cost: "accent-emerald-500",
+  privacy: "accent-amber-500",
+};
+
+const LANGUAGE_OPTIONS: { id: LanguageNeed; label: string }[] = [
+  { id: "english", label: "English only" },
+  { id: "european", label: "European" },
+  { id: "wide", label: "Wide multilingual" },
+];
+
+const REQUIREMENT_OPTIONS: { id: keyof Requirements; label: string }[] = [
+  { id: "streaming", label: "Live streaming" },
+  { id: "customVocabulary", label: "Custom vocabulary" },
+  { id: "stableOnly", label: "No preview models" },
+];
+
+function formatCost(model: Model): string {
+  if (isDevice(model)) return "Free";
+  const credits = creditsPerMinute(model);
+  return `${credits.toFixed(2).replace(/\.?0+$/, "")} cr/min`;
+}
+
+function formatDollars(model: Model): string | null {
+  if (isDevice(model)) return null;
+  const perThousand = creditsPerMinute(model) * (1000 / CREDITS_PER_DOLLAR);
+  return `$${perThousand.toFixed(2)} per 1,000 min`;
+}
+
+function formatSeconds(seconds: number | null): string {
+  if (seconds === null) return "—";
+  return seconds < 1
+    ? `${Math.round(seconds * 1000)} ms`
+    : `${seconds.toFixed(1)} s`;
+}
+
+/** The one badge that answers "does my audio leave this machine?". */
+function PlacementBadge({ model }: { model: Model }) {
+  if (isDevice(model)) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-emerald-300">
+        <Laptop className="h-3 w-3" aria-hidden="true" />
+        On device
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-sky-500/40 bg-sky-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-sky-300">
+      <Cloud className="h-3 w-3" aria-hidden="true" />
+      Cloud
+    </span>
+  );
+}
+
+function AccuracyNote({ model }: { model: Model }) {
+  const label =
+    model.accuracyBasis === "sameWeights"
+      ? "same weights"
+      : model.accuracyBasis === "appRating"
+        ? "app rating"
+        : model.accuracyBasis === "none"
+          ? "not benchmarked"
+          : null;
+
+  if (label === null) return null;
+  return (
+    <span className="rounded-full border border-gray-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-gray-500">
+      {label}
+    </span>
+  );
+}
+
+export default function ModelPicker({ measured, regions }: Props) {
+  const [weights, setWeights] = useState<Weights>(DEFAULT_WEIGHTS);
+  const [platform, setPlatform] = useState<Platform>("macos");
+  const [language, setLanguage] = useState<LanguageNeed>("english");
+  const [requirements, setRequirements] = useState<Requirements>({
+    streaming: false,
+    customVocabulary: false,
+    stableOnly: false,
+  });
+  const [region, setRegion] = useState<string | null>(regions[0] ?? null);
+  const [detectedCity, setDetectedCity] = useState<string | null>(null);
+  const regionPickedByUser = useRef(false);
+
+  const regionsKey = regions.join(",");
+
+  // Ask the edge which region this reader is nearest to, the same way /latency
+  // does. Nothing is stored; a failure just leaves the default region selected.
+  useEffect(() => {
+    if (regionsKey === "") return;
+    const controller = new AbortController();
+
+    fetch(`/api/geo/nearest-region?regions=${encodeURIComponent(regionsKey)}`, {
+      signal: controller.signal,
+    })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((result) => {
+        // A hand-picked region always wins, even if the answer lands later.
+        if (regionPickedByUser.current || !result?.region) return;
+        setRegion(result.region);
+        setDetectedCity(result.city ?? regionCity(result.region));
+      })
+      .catch(() => {
+        // A missing default is not worth an error message.
+      });
+
+    return () => controller.abort();
+  }, [regionsKey]);
+
+  const ranked: ScoredModel[] = useMemo(() => {
+    const pool = buildPool(
+      modelsForPlatform(platform),
+      language,
+      requirements,
+    );
+    return rankModels(pool, {
+      weights,
+      measured: (region && measured[region]) || {},
+    });
+  }, [weights, platform, language, requirements, region, measured]);
+
+  const best = ranked[0] ?? null;
+  const cloudCount = ranked.filter((entry) => isCloud(entry.model)).length;
+  const deviceCount = ranked.length - cloudCount;
+  const hasMeasurements = regions.length > 0;
+
+  function setPriority(priority: Priority, value: number) {
+    setWeights((current) => rebalance(current, priority, value));
+  }
+
+  function toggleRequirement(id: keyof Requirements) {
+    setRequirements((current) => ({ ...current, [id]: !current[id] }));
+  }
+
+  return (
+    <div className="mt-12 grid gap-8 lg:grid-cols-[380px_minmax(0,1fr)]">
+      {/* ---------------- Controls ---------------- */}
+      <div className="lg:sticky lg:top-6 lg:self-start">
+        <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-6 backdrop-blur-xl">
+          <div className="flex items-baseline justify-between gap-3">
+            <h2 className="text-sm font-semibold uppercase tracking-widest text-gray-400">
+              Your 100 points
+            </h2>
+            <span className="text-xs text-gray-500">
+              {Math.round(weights.accuracy)} / {Math.round(weights.latency)} /{" "}
+              {Math.round(weights.cost)} / {Math.round(weights.privacy)}
+            </span>
+          </div>
+
+          <div className="mt-4 flex h-3 overflow-hidden rounded-full border border-gray-800">
+            {PRIORITIES.map((priority) => (
+              <span
+                key={priority}
+                className={PRIORITY_BAR[priority]}
+                style={{ width: `${weights[priority]}%` }}
+              />
+            ))}
+          </div>
+
+          <div className="mt-4 flex flex-wrap gap-1">
+            {PRESETS.map((preset) => (
+              <button
+                key={preset.id}
+                className="rounded-md border border-dashed border-gray-700 px-2.5 py-1 text-xs text-gray-400 transition hover:border-solid hover:border-purple-500/60 hover:text-white"
+                type="button"
+                onClick={() => setWeights(preset.weights)}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="mt-6 space-y-5">
+            {PRIORITIES.map((priority) => (
+              <div key={priority}>
+                <div className="flex items-baseline justify-between gap-2">
+                  <label
+                    className="text-sm font-medium text-white"
+                    htmlFor={`weight-${priority}`}
+                  >
+                    {PRIORITY_LABELS[priority]}
+                  </label>
+                  <span className="font-mono text-sm tabular-nums text-gray-300">
+                    {Math.round(weights[priority])}
+                  </span>
+                </div>
+                <p className="mt-0.5 text-xs text-gray-500">
+                  {PRIORITY_HINTS[priority]}
+                </p>
+                <input
+                  className={`mt-2 w-full ${PRIORITY_ACCENT[priority]}`}
+                  id={`weight-${priority}`}
+                  max={100}
+                  min={0}
+                  type="range"
+                  value={Math.round(weights[priority])}
+                  onChange={(event) =>
+                    setPriority(priority, Number(event.target.value))
+                  }
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-6 border-t border-gray-800 pt-5">
+            <span className="text-xs uppercase tracking-widest text-gray-500">
+              Your platform
+            </span>
+            <div className="mt-2 flex gap-1 rounded-lg border border-gray-800 bg-gray-900/60 p-1">
+              {(["macos", "windows"] as const).map((option) => (
+                <button
+                  key={option}
+                  className={`flex-1 rounded-md px-3 py-1.5 text-sm transition ${
+                    platform === option
+                      ? "bg-purple-600 text-white"
+                      : "text-gray-400 hover:text-white"
+                  }`}
+                  type="button"
+                  onClick={() => setPlatform(option)}
+                >
+                  {option === "macos" ? "macOS" : "Windows"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-5">
+            <span className="text-xs uppercase tracking-widest text-gray-500">
+              Languages you dictate
+            </span>
+            <div className="mt-2 flex flex-wrap gap-1">
+              {LANGUAGE_OPTIONS.map((option) => (
+                <button
+                  key={option.id}
+                  className={`rounded-full border px-3 py-1 text-xs transition ${
+                    language === option.id
+                      ? "border-purple-500/60 bg-purple-600/20 text-white"
+                      : "border-gray-700 text-gray-400 hover:text-white"
+                  }`}
+                  type="button"
+                  onClick={() => setLanguage(option.id)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="mt-5">
+            <span className="text-xs uppercase tracking-widest text-gray-500">
+              Must have
+            </span>
+            <div className="mt-2 flex flex-wrap gap-1">
+              {REQUIREMENT_OPTIONS.map((option) => (
+                <button
+                  key={option.id}
+                  aria-pressed={requirements[option.id]}
+                  className={`rounded-full border px-3 py-1 text-xs transition ${
+                    requirements[option.id]
+                      ? "border-purple-500/60 bg-purple-600/20 text-white"
+                      : "border-gray-700 text-gray-400 hover:text-white"
+                  }`}
+                  type="button"
+                  onClick={() => toggleRequirement(option.id)}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {hasMeasurements ? (
+            <div className="mt-5">
+              <span className="text-xs uppercase tracking-widest text-gray-500">
+                Closest region
+              </span>
+              <select
+                className="mt-2 w-full rounded-lg border border-gray-800 bg-gray-900/60 px-3 py-2 text-sm text-gray-300 transition hover:text-white"
+                value={region ?? ""}
+                onChange={(event) => {
+                  regionPickedByUser.current = true;
+                  setRegion(event.target.value);
+                  setDetectedCity(null);
+                }}
+              >
+                {regions.map((code) => (
+                  <option key={code} value={code}>
+                    {regionCity(code)}
+                  </option>
+                ))}
+              </select>
+              {detectedCity !== null ? (
+                <p className="mt-2 flex items-center gap-1.5 text-xs text-purple-300">
+                  <MapPin className="h-3 w-3" aria-hidden="true" />
+                  Picked for you — closest to {detectedCity}
+                </p>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      {/* ---------------- Results ---------------- */}
+      <div>
+        {best === null ? (
+          <div className="rounded-lg border border-gray-800 bg-gray-900/50 p-10 text-center">
+            <p className="text-lg text-gray-300">
+              Nothing matches all of those requirements.
+            </p>
+            <p className="mt-2 text-sm text-gray-500">
+              Turn one of the &ldquo;must have&rdquo; filters back off.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="relative overflow-hidden rounded-lg border border-gray-800 bg-gray-900/50 p-6 backdrop-blur-xl">
+              <span className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-purple-500 to-blue-500" />
+              <p className="text-xs uppercase tracking-widest text-gray-500">
+                Best match for how you spent your points
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-3">
+                <h2 className="text-2xl font-bold text-white">
+                  {best.model.name}
+                </h2>
+                <PlacementBadge model={best.model} />
+              </div>
+              <p className="mt-1 text-sm text-gray-400">
+                {isDevice(best.model)
+                  ? `${best.model.vendorLabel} · ${
+                      platform === "windows" && best.model.sizeWindows
+                        ? best.model.sizeWindows
+                        : best.model.size
+                    } download · runs entirely on your Mac or PC`
+                  : `${best.model.vendorLabel} · runs on HyperWhisper Cloud`}
+              </p>
+
+              <dl className="mt-6 grid gap-3 sm:grid-cols-4">
+                <div className="rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2.5">
+                  <dt className="text-[10px] uppercase tracking-wider text-gray-500">
+                    Word errors
+                  </dt>
+                  <dd className="mt-1 font-mono text-lg tabular-nums text-white">
+                    {best.model.wer === null ? "—" : `${best.model.wer}%`}
+                  </dd>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2.5">
+                  <dt className="text-[10px] uppercase tracking-wider text-gray-500">
+                    Cost
+                  </dt>
+                  <dd className="mt-1 font-mono text-lg tabular-nums text-white">
+                    {formatCost(best.model)}
+                  </dd>
+                  <p className="mt-0.5 text-[10px] text-gray-500">
+                    {formatDollars(best.model) ?? "no per-minute cost"}
+                  </p>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2.5">
+                  <dt className="text-[10px] uppercase tracking-wider text-gray-500">
+                    Per audio minute
+                  </dt>
+                  <dd className="mt-1 font-mono text-lg tabular-nums text-white">
+                    {formatSeconds(best.estimatedSeconds)}
+                  </dd>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2.5">
+                  <dt className="text-[10px] uppercase tracking-wider text-gray-500">
+                    Match
+                  </dt>
+                  <dd className="mt-1 font-mono text-lg tabular-nums text-white">
+                    {Math.round(best.score * 100)}
+                  </dd>
+                </div>
+              </dl>
+
+              <p className="mt-5 border-t border-dashed border-gray-800 pt-4 text-sm text-gray-400">
+                {isDevice(best.model)
+                  ? "Your audio never leaves the machine, so there is no per-minute cost and no region to worry about."
+                  : best.latencyIsMeasured
+                    ? `That timing is our own measurement from ${regionCity(region ?? "")}, not a vendor claim.`
+                    : "We have not measured this model from your region yet, so the timing is the published speed factor."}
+              </p>
+            </div>
+
+            <div className="mt-8">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <h2 className="text-sm font-semibold uppercase tracking-widest text-gray-400">
+                  Every model, ranked
+                </h2>
+                <p className="text-xs text-gray-500">
+                  {cloudCount} cloud · {deviceCount} on-device
+                </p>
+              </div>
+
+              <div className="mt-4 overflow-x-auto rounded-lg border border-gray-800 bg-gray-950/80">
+                <table className="w-full border-collapse text-sm">
+                  <thead>
+                    <tr className="border-b border-gray-800">
+                      <th className="px-4 py-3 text-left text-xs uppercase tracking-widest text-gray-500">
+                        Model
+                      </th>
+                      <th className="px-3 py-3 text-right text-xs uppercase tracking-widest text-gray-500">
+                        WER
+                      </th>
+                      <th className="px-3 py-3 text-right text-xs uppercase tracking-widest text-gray-500">
+                        Cost
+                      </th>
+                      <th className="px-3 py-3 text-right text-xs uppercase tracking-widest text-gray-500">
+                        Per min
+                      </th>
+                      <th className="hidden px-3 py-3 text-left text-xs uppercase tracking-widest text-gray-500 md:table-cell">
+                        Why it scored
+                      </th>
+                      <th className="px-4 py-3 text-right text-xs uppercase tracking-widest text-gray-500">
+                        Match
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {ranked.map((entry, index) => (
+                      <tr
+                        key={entry.model.id}
+                        className={`border-b border-gray-900 transition hover:bg-gray-900/40 ${
+                          index === 0 ? "bg-purple-600/5" : ""
+                        }`}
+                      >
+                        <td className="px-4 py-3">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="font-medium text-white">
+                              {entry.model.name}
+                            </span>
+                            <PlacementBadge model={entry.model} />
+                            <AccuracyNote model={entry.model} />
+                          </div>
+                          <div className="mt-0.5 text-xs text-gray-500">
+                            {entry.model.vendorLabel}
+                            {isDevice(entry.model)
+                              ? ` · ${
+                                  platform === "windows" &&
+                                  entry.model.sizeWindows
+                                    ? entry.model.sizeWindows
+                                    : entry.model.size
+                                }`
+                              : ""}
+                          </div>
+                        </td>
+                        <td className="px-3 py-3 text-right font-mono tabular-nums text-gray-300">
+                          {entry.model.wer === null
+                            ? "—"
+                            : `${entry.model.wer}%`}
+                        </td>
+                        <td className="px-3 py-3 text-right font-mono tabular-nums text-gray-300">
+                          {formatCost(entry.model)}
+                        </td>
+                        <td className="px-3 py-3 text-right font-mono tabular-nums text-gray-300">
+                          {formatSeconds(entry.estimatedSeconds)}
+                          {entry.latencyIsMeasured ? (
+                            <span
+                              className="ml-1 text-purple-400"
+                              title="Measured from your region"
+                            >
+                              ●
+                            </span>
+                          ) : null}
+                        </td>
+                        <td className="hidden px-3 py-3 md:table-cell">
+                          <div className="flex h-2 w-40 overflow-hidden rounded-full bg-gray-800">
+                            {PRIORITIES.map((priority) => (
+                              <span
+                                key={priority}
+                                className={PRIORITY_BAR[priority]}
+                                style={{
+                                  width: `${entry.contributions[priority] * 100}%`,
+                                }}
+                              />
+                            ))}
+                          </div>
+                        </td>
+                        <td className="px-4 py-3 text-right font-mono font-semibold tabular-nums text-white">
+                          {Math.round(entry.score * 100)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <p className="mt-3 text-xs text-gray-500">
+                A <span className="text-purple-400">●</span> marks a timing we
+                measured ourselves from your region. Everything else is the
+                published speed factor.
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/nextjs/components/navbar.tsx
+++ b/nextjs/components/navbar.tsx
@@ -26,16 +26,23 @@ export const Navbar = () => {
   const locale = useLocale();
 
   /*
-    The latency page is English-only — it 404s on every other locale — so its
-    href is the absolute /en/latency and it is rendered with a native <a>,
-    never LocaleLink (which would prefix it into /ja/en/latency). Label is
-    hardcoded for the same reason: the page it opens is English either way.
+    The latency and model-chooser pages are English-only — they 404 on every
+    other locale — so their hrefs are the absolute /en/... and they are rendered
+    with a native <a>, never LocaleLink (which would prefix them into
+    /ja/en/latency). Labels are hardcoded for the same reason: the page each one
+    opens is English either way.
   */
   const latencyItem = { label: "Latency", href: "/en/latency", raw: true };
+  const chooseModelItem = {
+    label: "Choose a model",
+    href: "/en/choosing-a-model",
+    raw: true,
+  };
 
   const navItems = [
     { label: t("features"), href: `/${locale}#features` },
     { label: t("cloud"), href: `/${locale}#cloud` },
+    chooseModelItem,
     latencyItem,
     { label: t("faq"), href: `/${locale}#faq` },
   ];
@@ -43,6 +50,7 @@ export const Navbar = () => {
   const navMenuItems = [
     { label: t("features"), href: `/${locale}#features` },
     { label: t("cloud"), href: `/${locale}#cloud` },
+    chooseModelItem,
     latencyItem,
     { label: t("faq"), href: `/${locale}#faq` },
     { label: t("support"), href: "/support" },

--- a/nextjs/lib/choosing-a-model/catalog.ts
+++ b/nextjs/lib/choosing-a-model/catalog.ts
@@ -1,0 +1,187 @@
+/**
+ * The models the /choosing-a-model calculator ranks.
+ *
+ * Two sources, kept apart because they are different kinds of fact:
+ *
+ *  - **What we ship.** Cloud models, their prices and their capabilities are
+ *    mirrored from `shared-app-classification/cloud-stt-catalog.json`; on-device
+ *    models are mirrored from the macOS and Windows model registries. Both sit
+ *    outside this Next.js app's build root, so they are copied here rather than
+ *    imported — the same arrangement `lib/latency/providers.ts` uses, and
+ *    `tests/choosing-a-model-catalog.test.ts` reads the real catalog as data and
+ *    fails when this copy drifts from it.
+ *  - **How good they are.** Word error rate and speed factor come from the
+ *    Artificial Analysis speech-to-text leaderboard, which is a third party
+ *    measuring published models. Nothing here is our own accuracy claim.
+ *
+ * A model with no published benchmark keeps `wer: null` rather than a guess.
+ * The scoring treats that as "unknown", not as "average" — see `scoring.ts`.
+ *
+ * @see https://artificialanalysis.ai/speech-to-text/non-streaming
+ */
+
+/** Where the transcription runs. The page's most important distinction. */
+export type ModelPlacement = "cloud" | "device";
+
+/** Which desktop app can run an on-device model. */
+export type Platform = "macos" | "windows";
+
+/**
+ * How we know a model's word error rate. Shown to the reader, because
+ * "benchmarked" and "inherited from identical weights" are not the same claim.
+ */
+export type AccuracyBasis =
+  /** The leaderboard measured this exact hosted model. */
+  | "measured"
+  /**
+   * The leaderboard measured these exact open weights on a hosted runner. The
+   * weights are the same file we download, so the error rate carries over;
+   * throughput does not, which is why `speedFactor` stays null for these.
+   */
+  | "sameWeights"
+  /** No published benchmark. Local models fall back to the app's own rating. */
+  | "appRating"
+  /** No published benchmark and no rating either. */
+  | "none";
+
+export type CloudModel = {
+  placement: "cloud";
+  /** `catalogProviderId:modelId`. Unique across the catalog. */
+  id: string;
+  name: string;
+  /** The catalog's provider display name. */
+  vendorLabel: string;
+  vendor: string;
+  /**
+   * Backend provider id as the edge service reports it, and the model id
+   * beside it. Together they join a row to its measured latency on /latency.
+   */
+  sttProvider: string;
+  /** Empty for a provider whose endpoint takes no model id. */
+  modelId: string;
+  /** Credits per audio minute. 1,000 credits = $1. */
+  credits: number;
+  wer: number | null;
+  accuracyBasis: AccuracyBasis;
+  /** Audio seconds transcribed per second, from the leaderboard. */
+  speedFactor: number | null;
+  /** Documented language count. Null where the vendor does not publish one. */
+  languages: number | null;
+  streaming: boolean;
+  customVocabulary: boolean;
+  preview: boolean;
+  isDefault: boolean;
+  /** Usable with your own vendor API key instead of our credits. */
+  byok: boolean;
+};
+
+export type DeviceModel = {
+  placement: "device";
+  id: string;
+  name: string;
+  vendorLabel: string;
+  platforms: readonly Platform[];
+  /** Download size, per platform where the two differ. */
+  size: string;
+  sizeWindows?: string;
+  wer: number | null;
+  accuracyBasis: AccuracyBasis;
+  /** The app's own 1-5 ratings, from its model library. */
+  speedRating: number;
+  accuracyRating: number;
+  languages: number;
+};
+
+export type Model = CloudModel | DeviceModel;
+
+/**
+ * Mirrored from `cloud-stt-catalog.json` v7 (2026-08-13). Benchmark columns
+ * from the Artificial Analysis leaderboard, pulled 2026-08-19.
+ */
+const CLOUD_MODELS_RAW = [
+  { id: "groqWhisper:whisper-large-v3-turbo", name: "Whisper Large v3 Turbo", vendorLabel: "Groq Whisper", vendor: "Groq", sttProvider: "groq", modelId: "whisper-large-v3-turbo", credits: 0.667, wer: 4.6, speedFactor: 122.2, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "groqWhisper:whisper-large-v3", name: "Whisper Large v3", vendorLabel: "Groq Whisper", vendor: "Groq", sttProvider: "groq", modelId: "whisper-large-v3", credits: 1.85, wer: 4.1, speedFactor: 92.1, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "deepgramNova3:nova-3-general", name: "Nova 3 General", vendorLabel: "Deepgram Nova 3", vendor: "Deepgram", sttProvider: "deepgram", modelId: "nova-3-general", credits: 5.5, wer: 5.2, speedFactor: 541.1, languages: 64, streaming: true, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "deepgramNova3:nova-3-medical", name: "Nova 3 Medical", vendorLabel: "Deepgram Nova 3", vendor: "Deepgram", sttProvider: "deepgram", modelId: "nova-3-medical", credits: 5.5, wer: 5.2, speedFactor: 541.1, languages: 64, streaming: true, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "deepgramNova3:nova-2-general", name: "Nova 2 General", vendorLabel: "Deepgram Nova 3", vendor: "Deepgram", sttProvider: "deepgram", modelId: "nova-2-general", credits: 5.5, wer: null, speedFactor: null, languages: 64, streaming: true, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "deepgramNova3:nova-2-medical", name: "Nova 2 Medical", vendorLabel: "Deepgram Nova 3", vendor: "Deepgram", sttProvider: "deepgram", modelId: "nova-2-medical", credits: 5.5, wer: null, speedFactor: null, languages: 64, streaming: true, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "grokStt:", name: "Grok Speech-to-Text", vendorLabel: "Grok STT", vendor: "xAI", sttProvider: "grok", modelId: "", credits: 1.67, wer: 4.0, speedFactor: 230.1, languages: 25, streaming: true, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "azureMaiTranscribe:mai-transcribe-1.5", name: "MAI-Transcribe 1.5", vendorLabel: "Microsoft MAI-Transcribe 1.5", vendor: "Microsoft", sttProvider: "azure-mai", modelId: "mai-transcribe-1.5", credits: 6.0, wer: 2.4, speedFactor: 183.3, languages: 42, streaming: false, customVocabulary: true, preview: false, isDefault: true, byok: false },
+  { id: "googleChirp3:chirp_3", name: "Chirp 3", vendorLabel: "Google Chirp 3", vendor: "Google", sttProvider: "google-chirp", modelId: "chirp_3", credits: 16.0, wer: 4.3, speedFactor: null, languages: 111, streaming: true, customVocabulary: true, preview: false, isDefault: true, byok: false },
+  { id: "elevenLabsScribeV2:scribe_v2", name: "Scribe v2", vendorLabel: "ElevenLabs Scribe v2", vendor: "ElevenLabs", sttProvider: "elevenlabs", modelId: "scribe_v2", credits: 9.83, wer: 2.2, speedFactor: 57.0, languages: 99, streaming: false, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "openaiWhisper:gpt-4o-transcribe", name: "GPT-4o Transcribe", vendorLabel: "OpenAI Whisper", vendor: "OpenAI", sttProvider: "openai", modelId: "gpt-4o-transcribe", credits: 6.0, wer: 4.0, speedFactor: 38.1, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "openaiWhisper:gpt-4o-mini-transcribe", name: "GPT-4o Mini Transcribe", vendorLabel: "OpenAI Whisper", vendor: "OpenAI", sttProvider: "openai", modelId: "gpt-4o-mini-transcribe", credits: 3.0, wer: 4.5, speedFactor: 43.5, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "openaiWhisper:whisper-1", name: "Whisper", vendorLabel: "OpenAI Whisper", vendor: "OpenAI", sttProvider: "openai", modelId: "whisper-1", credits: 6.0, wer: 4.1, speedFactor: 29.1, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "openaiWhisper:gpt-transcribe", name: "GPT Transcribe", vendorLabel: "OpenAI Whisper", vendor: "OpenAI", sttProvider: "openai", modelId: "gpt-transcribe", credits: 4.5, wer: 3.3, speedFactor: 39.9, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "openaiWhisper:gpt-live-transcribe", name: "GPT Live Transcribe", vendorLabel: "OpenAI Whisper", vendor: "OpenAI", sttProvider: "openai", modelId: "gpt-live-transcribe", credits: 17.0, wer: null, speedFactor: null, languages: 100, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "assemblyAI:universal-3-pro", name: "Universal-3 Pro", vendorLabel: "AssemblyAI", vendor: "AssemblyAI", sttProvider: "assemblyai", modelId: "universal-3-pro", credits: 3.5, wer: 3.1, speedFactor: 112.1, languages: 98, streaming: true, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "assemblyAI:universal-3-5-pro", name: "Universal-3.5 Pro", vendorLabel: "AssemblyAI", vendor: "AssemblyAI", sttProvider: "assemblyai", modelId: "universal-3-5-pro", credits: 3.5, wer: 3.0, speedFactor: null, languages: 98, streaming: true, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "assemblyAI:universal-2", name: "Universal-2", vendorLabel: "AssemblyAI", vendor: "AssemblyAI", sttProvider: "assemblyai", modelId: "universal-2", credits: 2.5, wer: 3.8, speedFactor: 123.1, languages: 98, streaming: true, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "mistralVoxtral:voxtral-mini-latest", name: "Voxtral Mini", vendorLabel: "Mistral Voxtral", vendor: "Mistral", sttProvider: "mistral", modelId: "voxtral-mini-latest", credits: 3.0, wer: 3.8, speedFactor: 78.1, languages: 13, streaming: true, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "soniox:stt-async-v4", name: "Async v4", vendorLabel: "Soniox", vendor: "Soniox", sttProvider: "soniox", modelId: "stt-async-v4", credits: 1.67, wer: 3.9, speedFactor: 19.0, languages: 60, streaming: true, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "soniox:stt-async-v5", name: "Async v5", vendorLabel: "Soniox", vendor: "Soniox", sttProvider: "soniox", modelId: "stt-async-v5", credits: 1.67, wer: 3.8, speedFactor: 18.8, languages: 60, streaming: true, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "gemini:gemini-2.5-flash", name: "Gemini 2.5 Flash", vendorLabel: "Google Gemini", vendor: "Google", sttProvider: "gemini", modelId: "gemini-2.5-flash", credits: 2.4, wer: 5.1, speedFactor: 73.7, languages: null, streaming: false, customVocabulary: true, preview: false, isDefault: true, byok: true },
+  { id: "gemini:gemini-2.5-flash-lite", name: "Gemini 2.5 Flash Lite", vendorLabel: "Google Gemini", vendor: "Google", sttProvider: "gemini", modelId: "gemini-2.5-flash-lite", credits: 0.8, wer: 5.2, speedFactor: 70.7, languages: null, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "gemini:gemini-2.5-pro", name: "Gemini 2.5 Pro", vendorLabel: "Google Gemini", vendor: "Google", sttProvider: "gemini", modelId: "gemini-2.5-pro", credits: 7.5, wer: 2.9, speedFactor: 13.3, languages: null, streaming: false, customVocabulary: true, preview: false, isDefault: false, byok: true },
+  { id: "gemini:gemini-3-flash-preview", name: "Gemini 3 Flash", vendorLabel: "Google Gemini", vendor: "Google", sttProvider: "gemini", modelId: "gemini-3-flash-preview", credits: 3.0, wer: 2.9, speedFactor: 16.1, languages: null, streaming: false, customVocabulary: true, preview: true, isDefault: false, byok: true },
+  { id: "gemini:gemini-3.1-pro-preview", name: "Gemini 3.1 Pro", vendorLabel: "Google Gemini", vendor: "Google", sttProvider: "gemini", modelId: "gemini-3.1-pro-preview", credits: 10.0, wer: 2.8, speedFactor: 7.0, languages: null, streaming: false, customVocabulary: true, preview: true, isDefault: false, byok: true },
+] as const;
+
+export const CLOUD_MODELS: readonly CloudModel[] = CLOUD_MODELS_RAW.map(
+  (model) => ({
+    ...model,
+    placement: "cloud" as const,
+    accuracyBasis: model.wer === null ? ("none" as const) : ("measured" as const),
+  }),
+);
+
+/**
+ * Mirrored from the macOS (`ModelLibraryManager.swift`, `WhisperModel.swift`)
+ * and Windows (`ModelLibraryManager.cs`, `WhisperModelInfo.cs`) model
+ * libraries, including their 1-5 speed and accuracy ratings.
+ *
+ * Whisper and Parakeet carry a leaderboard word error rate because the
+ * leaderboard measured those same open weights on a hosted runner. The rest
+ * have no published figure and fall back to the app's own accuracy rating —
+ * which is what keeps Whisper Tiny from scoring like a frontier model.
+ */
+const DEVICE_MODELS_RAW = [
+  { id: "device:whisper-large-v3-turbo", name: "Whisper Large v3 Turbo", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "809 MB", sizeWindows: "1.5 GB", wer: 4.6, accuracyBasis: "sameWeights", speedRating: 4, accuracyRating: 3, languages: 100 },
+  { id: "device:whisper-large-v3", name: "Whisper Large v3", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "3.1 GB", wer: 4.1, accuracyBasis: "sameWeights", speedRating: 3, accuracyRating: 3, languages: 100 },
+  { id: "device:whisper-large-v2", name: "Whisper Large v2", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "2.9 GB", wer: 4.1, accuracyBasis: "sameWeights", speedRating: 3, accuracyRating: 3, languages: 100 },
+  { id: "device:whisper-medium", name: "Whisper Medium", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "1.5 GB", wer: null, accuracyBasis: "appRating", speedRating: 4, accuracyRating: 3, languages: 100 },
+  { id: "device:whisper-small", name: "Whisper Small", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "466 MB", wer: null, accuracyBasis: "appRating", speedRating: 4, accuracyRating: 2, languages: 100 },
+  { id: "device:whisper-base", name: "Whisper Base", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "142 MB", wer: null, accuracyBasis: "appRating", speedRating: 5, accuracyRating: 1, languages: 100 },
+  { id: "device:whisper-tiny", name: "Whisper Tiny", vendorLabel: "Whisper", platforms: ["macos", "windows"], size: "39 MB", wer: null, accuracyBasis: "appRating", speedRating: 5, accuracyRating: 1, languages: 100 },
+  { id: "device:parakeet-v3", name: "Parakeet V3", vendorLabel: "Parakeet", platforms: ["macos", "windows"], size: "494 MB", wer: 4.5, accuracyBasis: "sameWeights", speedRating: 5, accuracyRating: 3, languages: 25 },
+  { id: "device:parakeet-v2", name: "Parakeet V2", vendorLabel: "Parakeet", platforms: ["macos", "windows"], size: "474 MB", wer: 6.4, accuracyBasis: "sameWeights", speedRating: 5, accuracyRating: 3, languages: 1 },
+  { id: "device:nemotron-multilingual", name: "Nemotron 3.5 Multilingual", vendorLabel: "Nemotron", platforms: ["macos"], size: "1.3 GB", wer: null, accuracyBasis: "appRating", speedRating: 5, accuracyRating: 4, languages: 40 },
+  { id: "device:nemotron-latin", name: "Nemotron 3.5 Latin", vendorLabel: "Nemotron", platforms: ["macos"], size: "350 MB", wer: null, accuracyBasis: "appRating", speedRating: 5, accuracyRating: 4, languages: 6 },
+  { id: "device:nemotron-streaming", name: "Nemotron 3.5 Streaming", vendorLabel: "Nemotron", platforms: ["windows"], size: "660 MB", wer: null, accuracyBasis: "appRating", speedRating: 5, accuracyRating: 4, languages: 2 },
+  { id: "device:qwen3-asr", name: "Qwen3 ASR", vendorLabel: "Qwen3", platforms: ["macos"], size: "1.3 GB", wer: null, accuracyBasis: "appRating", speedRating: 4, accuracyRating: 1, languages: 11 },
+  { id: "device:qwen3-asr-0.6b", name: "Qwen3 ASR 0.6B", vendorLabel: "Qwen3", platforms: ["windows"], size: "985 MB", wer: null, accuracyBasis: "appRating", speedRating: 3, accuracyRating: 4, languages: 11 },
+  { id: "device:apple-speech", name: "Apple Speech", vendorLabel: "Apple", platforms: ["macos"], size: "Built in", wer: null, accuracyBasis: "appRating", speedRating: 5, accuracyRating: 3, languages: 60 },
+] as const;
+
+export const DEVICE_MODELS: readonly DeviceModel[] = DEVICE_MODELS_RAW.map(
+  (model) => ({ ...model, placement: "device" as const }),
+);
+
+export const ALL_MODELS: readonly Model[] = [...CLOUD_MODELS, ...DEVICE_MODELS];
+
+/** 1,000 credits buy $1 of transcription, so credits/min is also $/1,000 min. */
+export const CREDITS_PER_DOLLAR = 1000;
+
+export function isCloud(model: Model): model is CloudModel {
+  return model.placement === "cloud";
+}
+
+export function isDevice(model: Model): model is DeviceModel {
+  return model.placement === "device";
+}
+
+export function modelsForPlatform(platform: Platform): readonly Model[] {
+  return ALL_MODELS.filter(
+    (model) => isCloud(model) || model.platforms.includes(platform),
+  );
+}

--- a/nextjs/lib/choosing-a-model/scoring.ts
+++ b/nextjs/lib/choosing-a-model/scoring.ts
@@ -1,0 +1,319 @@
+/**
+ * Turns "how much do you care about each of four things" into a ranking.
+ *
+ * The reader spends a fixed 100 points across accuracy, latency, cost and
+ * privacy. Every model gets a 0-1 sub-score on each of the four, and its total
+ * is the weighted sum. Nothing here reads the DOM or React state, so the whole
+ * ranking is testable as data in / data out.
+ *
+ * Sub-scores are normalised against the pool actually being ranked, not against
+ * a fixed scale. That is deliberate: "cheap" means cheap compared to the other
+ * models you could pick right now, and filtering the pool should re-spread the
+ * remaining models across the full 0-1 range rather than bunching them.
+ */
+
+// Types only. This module stays a pure function of the models it is handed —
+// it never reaches into the catalog itself — so the ranking can be exercised
+// against a fixture as easily as against what we ship.
+import type { CloudModel, DeviceModel, Model } from "./catalog";
+
+/** Narrowing helpers, kept local so this module has no runtime dependencies. */
+function isCloud(model: Model): model is CloudModel {
+  return model.placement === "cloud";
+}
+
+function isDevice(model: Model): model is DeviceModel {
+  return model.placement === "device";
+}
+
+export type Priority = "accuracy" | "latency" | "cost" | "privacy";
+
+export const PRIORITIES: readonly Priority[] = [
+  "accuracy",
+  "latency",
+  "cost",
+  "privacy",
+];
+
+export type Weights = Record<Priority, number>;
+
+export const TOTAL_POINTS = 100;
+
+export const DEFAULT_WEIGHTS: Weights = {
+  accuracy: 40,
+  latency: 20,
+  cost: 30,
+  privacy: 10,
+};
+
+export type Preset = { id: string; label: string; weights: Weights };
+
+export const PRESETS: readonly Preset[] = [
+  { id: "balanced", label: "Balanced", weights: { accuracy: 35, latency: 25, cost: 30, privacy: 10 } },
+  { id: "accuracy", label: "Accuracy first", weights: { accuracy: 70, latency: 10, cost: 15, privacy: 5 } },
+  { id: "cheap", label: "Cheapest", weights: { accuracy: 20, latency: 15, cost: 60, privacy: 5 } },
+  { id: "fast", label: "Fastest", weights: { accuracy: 20, latency: 60, cost: 15, privacy: 5 } },
+  { id: "private", label: "Fully private", weights: { accuracy: 25, latency: 15, cost: 10, privacy: 50 } },
+];
+
+/** Which languages the reader needs, as a minimum documented language count. */
+export type LanguageNeed = "english" | "european" | "wide";
+
+export const LANGUAGE_MINIMUMS: Record<LanguageNeed, number> = {
+  english: 1,
+  european: 13,
+  wide: 60,
+};
+
+export type Requirements = {
+  streaming: boolean;
+  customVocabulary: boolean;
+  stableOnly: boolean;
+};
+
+export const NO_REQUIREMENTS: Requirements = {
+  streaming: false,
+  customVocabulary: false,
+  stableOnly: false,
+};
+
+/**
+ * Median milliseconds a provider took to answer, per backend provider id, from
+ * the measurements behind /latency. Keyed `sttProvider` or
+ * `sttProvider:modelId` — a model-level entry wins when we have one.
+ */
+export type MeasuredLatency = Record<string, number>;
+
+export type ScoreInput = {
+  weights: Weights;
+  /** Timings for the reader's region. Empty falls back to speed factors. */
+  measured: MeasuredLatency;
+};
+
+export type ScoredModel = {
+  model: Model;
+  /** 0-1 per priority, before weighting. */
+  parts: Record<Priority, number>;
+  /** Each priority's share of the final score. Sums to `score`. */
+  contributions: Record<Priority, number>;
+  /** 0-1. */
+  score: number;
+  /**
+   * Estimated seconds to transcribe one minute of audio, for display. Null when
+   * a cloud model has neither a measurement nor a published speed factor.
+   */
+  estimatedSeconds: number | null;
+  /** True when `estimatedSeconds` came from our own measurements. */
+  latencyIsMeasured: boolean;
+};
+
+/**
+ * Rough seconds an on-device model needs per audio minute, derived from the
+ * app's 1-5 speed rating. Real time depends on the reader's hardware, which we
+ * cannot know, so this is an ordering device — not a promise.
+ */
+function deviceSeconds(speedRating: number): number {
+  return 60 / (speedRating * 11) + 0.15;
+}
+
+/**
+ * Seconds to transcribe one audio minute.
+ *
+ * A measured median beats a published speed factor: it is our own traffic, on
+ * our own edge, including whatever the provider actually does under load. The
+ * leaderboard's speed factor is the fallback for a model we have not measured
+ * yet — a new model, or one nobody has picked.
+ */
+export function estimateSeconds(
+  model: Model,
+  measured: MeasuredLatency,
+): { seconds: number | null; isMeasured: boolean } {
+  if (isDevice(model)) {
+    return { seconds: deviceSeconds(model.speedRating), isMeasured: false };
+  }
+
+  const modelKey = `${model.sttProvider}:${model.modelId}`;
+  const ms = measured[modelKey] ?? measured[model.sttProvider];
+  if (ms !== undefined) {
+    return { seconds: ms / 1000, isMeasured: true };
+  }
+
+  if (model.speedFactor === null) {
+    return { seconds: null, isMeasured: false };
+  }
+  // Speed factor is audio seconds per wall second, so one audio minute takes
+  // 60/factor, plus a small fixed cost for the round trip.
+  return { seconds: 60 / model.speedFactor + 0.25, isMeasured: false };
+}
+
+/** Position of `value` in `[low, high]`, clamped, with an empty range at 0.5. */
+function normalise(value: number, low: number, high: number): number {
+  if (high === low) return 0.5;
+  const t = (value - low) / (high - low);
+  return Math.min(1, Math.max(0, t));
+}
+
+/**
+ * Privacy is about where the audio goes, so it is a three-step ladder rather
+ * than a spread: on-device never transmits, bring-your-own-key transmits to the
+ * vendor on the reader's own account, and our cloud tier transmits through us.
+ */
+function privacyScore(model: Model): number {
+  if (isDevice(model)) return 1;
+  return model.byok ? 0.5 : 0.15;
+}
+
+/** Credits per audio minute. On-device models cost nothing to run. */
+export function creditsPerMinute(model: Model): number {
+  return isCloud(model) ? model.credits : 0;
+}
+
+export function meetsRequirements(
+  model: Model,
+  language: LanguageNeed,
+  requirements: Requirements,
+): boolean {
+  const minimum = LANGUAGE_MINIMUMS[language];
+  // A cloud vendor that publishes no language count is not excluded — an
+  // unpublished number is not the same as a small one.
+  if (model.languages !== null && model.languages < minimum) return false;
+
+  if (isCloud(model)) {
+    if (requirements.streaming && !model.streaming) return false;
+    if (requirements.customVocabulary && !model.customVocabulary) return false;
+    if (requirements.stableOnly && model.preview) return false;
+    return true;
+  }
+
+  // On-device models transcribe as you speak and always accept a vocabulary
+  // list, and none of them are preview builds.
+  return true;
+}
+
+/**
+ * Narrows a list of models to the ones a reader could actually use. The caller
+ * supplies the list — `modelsForPlatform(platform)` in the page — so this stays
+ * independent of the catalog.
+ */
+export function buildPool(
+  models: readonly Model[],
+  language: LanguageNeed,
+  requirements: Requirements,
+): readonly Model[] {
+  return models.filter((model) =>
+    meetsRequirements(model, language, requirements),
+  );
+}
+
+/**
+ * Ranks a pool, best first.
+ *
+ * A model with no published word error rate scores a neutral 0.5 on accuracy
+ * rather than a guessed number — except on-device models, which fall back to
+ * the app's own 1-5 accuracy rating. Without that fallback Whisper Tiny would
+ * score the same as an unbenchmarked frontier model purely for being free and
+ * private, and it would win the balanced preset outright.
+ */
+export function rankModels(
+  pool: readonly Model[],
+  input: ScoreInput,
+): ScoredModel[] {
+  if (pool.length === 0) return [];
+
+  const timings = pool.map((model) => estimateSeconds(model, input.measured));
+
+  const wers = pool
+    .map((model) => model.wer)
+    .filter((wer): wer is number => wer !== null);
+  const werLow = wers.length ? Math.min(...wers) : 0;
+  const werHigh = wers.length ? Math.max(...wers) : 1;
+
+  const seconds = timings
+    .map((timing) => timing.seconds)
+    .filter((value): value is number => value !== null);
+  const secondsLow = seconds.length ? Math.min(...seconds) : 0;
+  const secondsHigh = seconds.length ? Math.max(...seconds) : 1;
+
+  const costs = pool.map(creditsPerMinute);
+  const costLow = Math.min(...costs);
+  const costHigh = Math.max(...costs);
+
+  const totalWeight =
+    PRIORITIES.reduce((sum, key) => sum + input.weights[key], 0) || 1;
+
+  const scored = pool.map((model, index) => {
+    const timing = timings[index];
+
+    const accuracy =
+      model.wer !== null
+        ? 1 - normalise(model.wer, werLow, werHigh)
+        : isDevice(model)
+          ? // 1-5 rating mapped into 0.1-0.9, so a rating of 1 still scores
+            // clearly worse than a benchmarked mid-table model.
+            (model.accuracyRating - 0.5) / 5
+          : 0.5;
+
+    const latency =
+      timing.seconds === null
+        ? 0.5
+        : 1 - normalise(timing.seconds, secondsLow, secondsHigh);
+
+    const cost = 1 - normalise(creditsPerMinute(model), costLow, costHigh);
+    const privacy = privacyScore(model);
+
+    const parts: Record<Priority, number> = { accuracy, latency, cost, privacy };
+    const contributions = {} as Record<Priority, number>;
+    let score = 0;
+    for (const key of PRIORITIES) {
+      const contribution = (parts[key] * input.weights[key]) / totalWeight;
+      contributions[key] = contribution;
+      score += contribution;
+    }
+
+    return {
+      model,
+      parts,
+      contributions,
+      score,
+      estimatedSeconds: timing.seconds,
+      latencyIsMeasured: timing.isMeasured,
+    };
+  });
+
+  return scored.sort((a, b) => b.score - a.score);
+}
+
+/**
+ * Moves one slider and takes the difference out of (or spreads it across) the
+ * other three in proportion, so the four always total 100.
+ *
+ * When the other three are all at zero there is no proportion to preserve, so
+ * the remainder is split evenly — otherwise the budget would silently stop
+ * adding up to 100.
+ */
+export function rebalance(
+  weights: Weights,
+  changed: Priority,
+  rawValue: number,
+): Weights {
+  const value = Math.min(TOTAL_POINTS, Math.max(0, rawValue));
+  const others = PRIORITIES.filter((key) => key !== changed);
+  const remaining = TOTAL_POINTS - value;
+  const othersTotal = others.reduce((sum, key) => sum + weights[key], 0);
+
+  const next = { ...weights, [changed]: value } as Weights;
+  for (const key of others) {
+    next[key] =
+      othersTotal <= 0
+        ? remaining / others.length
+        : (weights[key] / othersTotal) * remaining;
+  }
+  return next;
+}
+
+export const PRIORITY_LABELS: Record<Priority, string> = {
+  accuracy: "Accuracy",
+  latency: "Speed",
+  cost: "Cost",
+  privacy: "Privacy",
+};

--- a/nextjs/src/content/choosing-a-model.ts
+++ b/nextjs/src/content/choosing-a-model.ts
@@ -1,0 +1,84 @@
+import "server-only";
+
+import { getLatencyMatrix } from "@/src/content/latency";
+import {
+  DEFAULT_BUCKET,
+  MIN_SAMPLES_PER_CELL,
+  type LatencyCell,
+} from "@/lib/latency/types";
+import type { MeasuredLatency } from "@/lib/choosing-a-model/scoring";
+
+/**
+ * Median provider response time, per region, for the /choosing-a-model
+ * calculator.
+ *
+ * Shape is `region -> providerKey -> milliseconds`, where `providerKey` is
+ * either `sttProvider` or `sttProvider:modelId`. Both levels are emitted so the
+ * calculator can prefer a model-level measurement and fall back to its
+ * provider's when that model is too young to have its own.
+ */
+export type MeasuredLatencyByRegion = Record<string, MeasuredLatency>;
+
+/**
+ * A cell is only worth showing if enough calls went into it. This is the same
+ * floor /latency prints its dashes at, so the two pages never disagree about
+ * whether a number exists.
+ */
+function usable(cell: LatencyCell): boolean {
+  return cell.samples >= MIN_SAMPLES_PER_CELL;
+}
+
+/**
+ * Reads the short-clip bucket, because that is what dictation is: a few
+ * seconds of speech, not a podcast. Ranking a model for a HyperWhisper user on
+ * its five-minute-file timings would flatter whichever provider streams large
+ * uploads best, which is not the job this page is doing.
+ *
+ * Never throws. The calculator degrades to the published speed factors when
+ * this comes back empty, so a database blip costs the page its measured
+ * timings, not its ranking.
+ */
+export async function getMeasuredLatency(): Promise<MeasuredLatencyByRegion> {
+  const byRegion: MeasuredLatencyByRegion = {};
+  // Sample count behind each provider-level entry we have written so far, so a
+  // busier model can replace a quieter one's number as the provider fallback.
+  const providerSamples: Record<string, number> = {};
+
+  try {
+    const matrix = await getLatencyMatrix(DEFAULT_BUCKET);
+
+    for (const vendor of matrix.vendors) {
+      for (const model of vendor.models) {
+        for (const cell of model.cells) {
+          if (!usable(cell)) continue;
+
+          const region = (byRegion[cell.region] ??= {});
+          const providerKey = model.provider;
+          const modelKey =
+            model.model === null
+              ? providerKey
+              : `${providerKey}:${model.model}`;
+
+          region[modelKey] = cell.p50;
+
+          // The provider-level fallback takes the timing of whichever of its
+          // models ran most in this region — the one most people actually get.
+          const seen = `${cell.region}/${providerKey}`;
+          if (cell.samples > (providerSamples[seen] ?? 0)) {
+            providerSamples[seen] = cell.samples;
+            region[providerKey] = cell.p50;
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error(
+      "[choosing-a-model] could not read measured latency; " +
+        "falling back to published speed factors:",
+      error,
+    );
+    return {};
+  }
+
+  return byRegion;
+}

--- a/nextjs/tests/choosing-a-model-catalog.test.ts
+++ b/nextjs/tests/choosing-a-model-catalog.test.ts
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Imported through a variable specifier inside each test, the way the other
+// tests in this folder do: a static `.ts` import path is a type error under this
+// tsconfig, but `node --test --experimental-strip-types` needs the extension.
+const CATALOG_MODULE_PATH = "../lib/choosing-a-model/catalog.ts";
+const SCORING_MODULE_PATH = "../lib/choosing-a-model/scoring.ts";
+
+const loadCatalog = () => import(CATALOG_MODULE_PATH);
+const loadScoring = () => import(SCORING_MODULE_PATH);
+
+type CatalogFile = {
+  providers: {
+    id: string;
+    sttProvider: string;
+    displayName: string;
+    access: { cloudTierEligible: boolean; byokEligible: boolean };
+    features?: { streaming?: boolean };
+    languages?: { count?: number | string };
+    models: {
+      id: string;
+      displayName: string;
+      creditsPerMinute: number;
+      isDefault?: boolean;
+      previewStatus?: boolean;
+      supportsCustomVocabulary?: boolean;
+    }[];
+  }[];
+};
+
+/**
+ * The real catalog, read as data rather than imported — the point is precisely
+ * that the two deployables do not share a module system.
+ * shared-app-classification/cloud-stt-catalog.json lives outside the Next.js
+ * build root, so lib/choosing-a-model/catalog.ts copies it. When the catalog
+ * gains a model, reprices one, or renames a backend id, the copy goes stale and
+ * the page quietly ranks a model we no longer sell, or prices one wrongly.
+ */
+function readCatalog(): CatalogFile {
+  const catalogPath = fileURLToPath(
+    new URL(
+      "../../shared-app-classification/cloud-stt-catalog.json",
+      import.meta.url,
+    ),
+  );
+  return JSON.parse(readFileSync(catalogPath, "utf8")) as CatalogFile;
+}
+
+test("the page's cloud mirror matches the catalog the apps read", async () => {
+  const { CLOUD_MODELS } = await loadCatalog();
+  const catalog = readCatalog();
+
+  const expected = catalog.providers.flatMap((provider) =>
+    provider.models.map((model) => ({
+      id: `${provider.id}:${model.id}`,
+      name: model.displayName,
+      vendorLabel: provider.displayName,
+      sttProvider: provider.sttProvider,
+      modelId: model.id,
+      credits: model.creditsPerMinute,
+      streaming: provider.features?.streaming === true,
+      customVocabulary: model.supportsCustomVocabulary === true,
+      preview: model.previewStatus === true,
+      isDefault: model.isDefault === true,
+      byok: provider.access.byokEligible === true,
+    })),
+  );
+
+  const actual = CLOUD_MODELS.map((model: Record<string, unknown>) => ({
+    id: model.id,
+    name: model.name,
+    vendorLabel: model.vendorLabel,
+    sttProvider: model.sttProvider,
+    modelId: model.modelId,
+    credits: model.credits,
+    streaming: model.streaming,
+    customVocabulary: model.customVocabulary,
+    preview: model.preview,
+    isDefault: model.isDefault,
+    byok: model.byok,
+  }));
+
+  assert.deepEqual(
+    actual,
+    expected,
+    "lib/choosing-a-model/catalog.ts has drifted from cloud-stt-catalog.json",
+  );
+});
+
+test("documented language counts match the catalog", async () => {
+  const { CLOUD_MODELS } = await loadCatalog();
+  const catalog = readCatalog();
+
+  for (const model of CLOUD_MODELS) {
+    const provider = catalog.providers.find(
+      (entry) => entry.sttProvider === model.sttProvider,
+    );
+    assert.ok(provider, `no catalog provider for ${model.id}`);
+
+    const count = provider.languages?.count;
+    // A vendor that publishes no number is mirrored as null, never as a guess.
+    const expected = typeof count === "number" ? count : null;
+    assert.equal(
+      model.languages,
+      expected,
+      `${model.id} language count drifted from the catalog`,
+    );
+  }
+});
+
+test("a benchmarked model never claims an unbenchmarked basis", async () => {
+  const { ALL_MODELS } = await loadCatalog();
+
+  for (const model of ALL_MODELS) {
+    if (model.wer === null) {
+      assert.notEqual(
+        model.accuracyBasis,
+        "measured",
+        `${model.id} claims a measured WER but carries none`,
+      );
+    } else {
+      assert.notEqual(
+        model.accuracyBasis,
+        "none",
+        `${model.id} has a WER but is marked as having no basis`,
+      );
+    }
+  }
+});
+
+test("the budget always totals 100 points", async () => {
+  const { rebalance, PRIORITIES, DEFAULT_WEIGHTS, TOTAL_POINTS } =
+    await loadScoring();
+
+  let weights = DEFAULT_WEIGHTS;
+  for (const priority of PRIORITIES) {
+    for (const value of [0, 17, 50, 83, 100]) {
+      weights = rebalance(weights, priority, value);
+      const total = PRIORITIES.reduce(
+        (sum: number, key: string) => sum + weights[key],
+        0,
+      );
+      assert.ok(
+        Math.abs(total - TOTAL_POINTS) < 1e-9,
+        `budget totalled ${total} after setting ${priority} to ${value}`,
+      );
+      assert.ok(
+        Math.abs(weights[priority] - value) < 1e-9,
+        `${priority} did not take the value it was given`,
+      );
+    }
+  }
+});
+
+test("zeroing three priorities still spreads the remainder", async () => {
+  const { rebalance, PRIORITIES } = await loadScoring();
+
+  // Drive everything but accuracy to zero, then pull accuracy back down. There
+  // is no proportion left to preserve, so the remainder must split evenly
+  // rather than vanishing and leaving a budget that totals 40.
+  let weights: Record<string, number> = {
+    accuracy: 100,
+    latency: 0,
+    cost: 0,
+    privacy: 0,
+  };
+  weights = rebalance(weights, "accuracy", 40);
+
+  const total = PRIORITIES.reduce(
+    (sum: number, key: string) => sum + weights[key],
+    0,
+  );
+  assert.ok(Math.abs(total - 100) < 1e-9, `budget totalled ${total}`);
+  assert.ok(weights.latency > 0, "latency stayed at zero");
+});
+
+test("privacy weighting puts an on-device model first", async () => {
+  const { isDevice, modelsForPlatform } = await loadCatalog();
+  const { buildPool, rankModels, NO_REQUIREMENTS } = await loadScoring();
+
+  const pool = buildPool(modelsForPlatform("macos"), "english", NO_REQUIREMENTS);
+  const ranked = rankModels(pool, {
+    weights: { accuracy: 25, latency: 15, cost: 10, privacy: 50 },
+    measured: {},
+  });
+
+  assert.ok(ranked.length > 0, "no models ranked");
+  assert.ok(
+    isDevice(ranked[0].model),
+    `privacy-first ranked ${ranked[0].model.name}, which is not on-device`,
+  );
+});
+
+test("accuracy weighting puts the lowest error rate first", async () => {
+  const { modelsForPlatform } = await loadCatalog();
+  const { buildPool, rankModels, NO_REQUIREMENTS } = await loadScoring();
+
+  const pool = buildPool(modelsForPlatform("macos"), "english", NO_REQUIREMENTS);
+  const ranked = rankModels(pool, {
+    weights: { accuracy: 100, latency: 0, cost: 0, privacy: 0 },
+    measured: {},
+  });
+
+  const lowestWer = Math.min(
+    ...pool
+      .map((model: { wer: number | null }) => model.wer)
+      .filter((wer: number | null): wer is number => wer !== null),
+  );
+  assert.equal(
+    ranked[0].model.wer,
+    lowestWer,
+    `accuracy-first ranked ${ranked[0].model.name} above the ${lowestWer}% model`,
+  );
+});
+
+test("a measured timing beats the published speed factor", async () => {
+  const { CLOUD_MODELS } = await loadCatalog();
+  const { estimateSeconds } = await loadScoring();
+
+  const model = CLOUD_MODELS.find(
+    (entry: { sttProvider: string; speedFactor: number | null }) =>
+      entry.sttProvider === "deepgram" && entry.speedFactor !== null,
+  );
+  assert.ok(model, "no benchmarked Deepgram model to test with");
+
+  const published = estimateSeconds(model, {});
+  assert.equal(published.isMeasured, false);
+
+  // A model-level key wins over its provider-level one.
+  const measured = estimateSeconds(model, {
+    deepgram: 900,
+    [`deepgram:${model.modelId}`]: 400,
+  });
+  assert.equal(measured.isMeasured, true);
+  assert.equal(measured.seconds, 0.4);
+});
+
+test("requirements filter the pool rather than reordering it", async () => {
+  const { modelsForPlatform } = await loadCatalog();
+  const { buildPool } = await loadScoring();
+
+  const macos = modelsForPlatform("macos");
+  const all = buildPool(macos, "english", {
+    streaming: false,
+    customVocabulary: false,
+    stableOnly: false,
+  });
+  const stable = buildPool(macos, "english", {
+    streaming: false,
+    customVocabulary: false,
+    stableOnly: true,
+  });
+
+  assert.ok(stable.length < all.length, "no preview models were filtered out");
+  assert.ok(
+    stable.every(
+      (model: { placement: string; preview?: boolean }) =>
+        model.placement === "device" || model.preview === false,
+    ),
+    "a preview model survived the stable-only filter",
+  );
+});


### PR DESCRIPTION
Adds an English-only page at `/en/choosing-a-model` that ranks the speech-to-text models we actually ship, and links it from the navbar.

## What it does

The reader splits a fixed **100 points** across accuracy, speed, cost and privacy. The sliders steal from each other, so you physically cannot rate everything important — which is closer to how the trade-off really works. Every model gets a 0-1 sub-score on each of the four; its rank is the weighted sum.

Cloud and on-device models sit in **one** ranking, each badged, because they are different bargains rather than different tiers. On-device costs nothing per minute and never transmits audio, and pays for that at the top of the accuracy table. Turn the privacy slider up and the ranking moves to on-device, which is the honest answer to that question.

Filters: platform (macOS/Windows), language breadth, live streaming, custom vocabulary, no-preview-models.

## Where the numbers come from

| | Source |
|---|---|
| Accuracy | [Artificial Analysis leaderboard](https://artificialanalysis.ai/speech-to-text/non-streaming), credited and linked on-page |
| Cost | `creditsPerMinute` from `cloud-stt-catalog.json` — what the app actually charges |
| Speed | Our own measured p50 from the `/latency` samples, falling back to the published speed factor |
| Privacy | Where the audio goes: on-device / BYOK / cloud-tier |

Three honesty details worth reviewing:

- **23 of 26** cloud models have a published WER. The other three are marked `not benchmarked` and score **neutrally** rather than carrying a number I invented.
- Open-weights local models (Whisper, Parakeet) inherit the figure the leaderboard measured for **those same weight files**, marked `same weights`. Accuracy travels with the weights; throughput does not, so those rows never borrow a speed figure.
- The remaining local models fall back to the app's own 1-5 accuracy rating, marked `app rating`. Without that fallback, an unbenchmarked Whisper Tiny scores like a frontier model purely for being free and private — it won the balanced preset before I added it.

## Region

Reuses the existing `/api/geo/nearest-region` endpoint, so the speed numbers shown are the ones that visitor would actually get. Nothing is stored; a manual pick always wins; off our edge it falls back to the busiest measured region.

## Structure

- `lib/choosing-a-model/catalog.ts` — mirrors two sources that live outside the Next.js build root (the shared STT catalog, and the macOS/Windows on-device registries). Same arrangement as `lib/latency/providers.ts`, and the new test reads the real catalog as data and **fails when this copy drifts**.
- `lib/choosing-a-model/scoring.ts` — a pure function of the models it is handed, with no runtime dependency on the catalog, so the ranking is testable against a fixture.
- `src/content/choosing-a-model.ts` — server-only; folds the latency matrix into per-region timings. Never throws: a database blip costs the page its measured timings, not its ranking.

English-only with a hardcoded navbar label, following the `/latency` precedent — the page is mostly numbers, and 40 translated copies of them buy nothing. Happy to localise it if you'd rather.

## Testing

- 9 new tests pass, including the catalog drift guard, the "budget always totals 100" invariant, and the priority-ordering assertions.
- Verified rendering against a dev server: `/en/choosing-a-model` returns 200 with correct content; `/ja/choosing-a-model` serves not-found, matching `/latency`.
- `tsc --noEmit` adds **no** new errors.

⚠️ **Pre-existing breakage, not from this PR:** `next build` currently fails on `CustomersClient.tsx` importing `keepPreviousData`, which the installed `@tanstack/react-query` doesn't export, and ESLint can't resolve `@eslint/js`. Both look like stale `node_modules` on `main`. CI may be red for those reasons.

Not done: I haven't clicked through the sliders in a real browser, only asserted the ranking in tests and checked the server-rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Buw9nVWVqtrbhFSu8EvN48
