### PR TITLE
fix(auth): close open redirect via tab/CR/LF in returnTo

### DIFF
--- a/nextjs/src/lib/license-key-redirect.ts
+++ b/nextjs/src/lib/license-key-redirect.ts
@@ -5,18 +5,27 @@ export const DEFAULT_LICENSE_KEY_REDIRECT = "/en/user/dashboard";
  * otherwise returns `fallback`. Rejects protocol-relative ("//evil.com") and
  * backslash ("/\\evil.com") prefixes that satisfy a naive `startsWith("/")`
  * check but resolve to an attacker-controlled origin, preventing open redirects.
+ *
+ * Tab, CR and LF are removed before the prefix checks. The URL parser strips
+ * them, so "/\t/evil.com" passes a `startsWith("//")` guard and only becomes
+ * "//evil.com" once the browser resolves it.
  */
 export function sanitizeReturnTo(
   returnTo: string | null | undefined,
   fallback: string,
 ) {
+  if (!returnTo) {
+    return fallback;
+  }
+
+  const candidate = returnTo.replace(/[\t\r\n]/g, "");
+
   if (
-    returnTo &&
-    returnTo.startsWith("/") &&
-    !returnTo.startsWith("//") &&
-    !returnTo.startsWith("/\\")
+    candidate.startsWith("/") &&
+    !candidate.startsWith("//") &&
+    !candidate.startsWith("/\\")
   ) {
-    return returnTo;
+    return candidate;
   }
 
   return fallback;

--- a/nextjs/tests/license-key-redirect.test.ts
+++ b/nextjs/tests/license-key-redirect.test.ts
@@ -64,3 +64,41 @@ test("sanitizeReturnTo blocks protocol-relative and backslash open redirects", (
   assert.equal(sanitizeReturnTo("/\\evil.com", fallback), fallback);
   assert.equal(sanitizeReturnTo("https://evil.com", fallback), fallback);
 });
+
+test("sanitizeReturnTo blocks tab/CR/LF smuggled past the prefix checks", () => {
+  const fallback = "/en/user/dashboard";
+  assert.equal(sanitizeReturnTo("/\t/evil.com", fallback), fallback);
+  assert.equal(sanitizeReturnTo("/\n/evil.com", fallback), fallback);
+  assert.equal(sanitizeReturnTo("/\r/evil.com", fallback), fallback);
+  assert.equal(sanitizeReturnTo("/\t\t//evil.com", fallback), fallback);
+  assert.equal(sanitizeReturnTo("/\t\\evil.com", fallback), fallback);
+  assert.equal(sanitizeReturnTo("/\r\n/evil.com", fallback), fallback);
+  assert.equal(sanitizeLicenseKeyRedirect("/\t/evil.com"), DEFAULT_LICENSE_KEY_REDIRECT);
+});
+
+test("every sanitized target resolves to the same origin", () => {
+  const origin = "https://hyperwhisper.com";
+  const hostile = [
+    "/\t/evil.com",
+    "/\n/evil.com",
+    "/\r/evil.com",
+    "/\t\t//evil.com",
+    "/\t\\evil.com",
+    "//evil.com",
+    "/\\evil.com",
+    "https://evil.com",
+  ];
+
+  for (const target of hostile) {
+    const resolved = new URL(sanitizeLicenseKeyRedirect(target), origin);
+    assert.equal(resolved.origin, origin, `${JSON.stringify(target)} escaped the origin`);
+  }
+});
+
+test("sanitizeReturnTo still accepts ordinary paths with query and hash", () => {
+  const fallback = "/en/user/dashboard";
+  assert.equal(
+    sanitizeReturnTo("/en/user/dashboard?tab=credits#usage", fallback),
+    "/en/user/dashboard?tab=credits#usage",
+  );
+});


### PR DESCRIPTION
Closes an open redirect in the license-key sign-in flow.

`sanitizeReturnTo` rejected `//evil.com` and `/\evil.com`, but not `/<TAB>/evil.com`. The URL parser strips tab, CR and LF, so that input passed the `startsWith("//")` guard and only collapsed to `//evil.com` once the browser resolved it.

Before:

```
"/\t/evil.com"  -> passes the guard -> browser resolves: https://evil.com/
"/\n/evil.com"  -> passes the guard -> browser resolves: https://evil.com/
"/\r/evil.com"  -> passes the guard -> browser resolves: https://evil.com/
```

The one caller, `auth-license-key-plugin.ts:84`, returns the value straight to the client as `{ redirect: ... }`, so this reached the browser unchanged.

The fix strips those three characters before the prefix checks and returns the cleaned string, so nothing smuggled through reaches the caller.

Tests assert the resolved origin via `new URL()` against a real base rather than inspecting the raw string, covering tab, LF, CR, repeated tabs, the `/\t\\` variant and the existing protocol-relative cases. Ordinary paths with a query and fragment still pass through. 8/8 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KU3oKNzKJGFQzeyJ2K6ipD