### PR TITLE
Surface Linux availability across website and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # HyperWhisper
 
-**Fast, private speech-to-text for macOS, Windows, and iOS.**
+**Fast, private speech-to-text for macOS, Windows, and Linux.**
 
 Press a key, speak, and your words appear as text in any app — transcribed
 on-device by default, with an optional hosted Cloud for the highest-accuracy
@@ -31,7 +31,7 @@ schemas — open-sourced under **Apache-2.0**.
 ## Fully open source — including the backend
 
 Everything in HyperWhisper is open source under **Apache-2.0** — the macOS,
-Windows, and iOS apps, the marketing/license website, the docs, the shared
+Windows, Linux, and iOS apps, the marketing/license website, the docs, the shared
 schemas, **and the Fly.io transcription backend**
 ([`hyperwhisper-cloud/`](https://github.com/ray-amjad/hyperwhisper-app/tree/main/hyperwhisper-cloud)). Nothing is
 closed source. **Local transcription runs entirely on your machine** with no
@@ -56,6 +56,7 @@ in this repo.
 |---|---|
 | `app/macos` | macOS app (Swift / SwiftUI) |
 | `app/windows` | Windows app (C# / WPF / .NET 10) |
+| `app/linux` | Linux app (C# / Avalonia / .NET 10) |
 | `app/ios` | iOS app *(work in progress; not built here)* |
 | `hyperwhisper-cloud` | Fly.io edge transcription service |
 | `nextjs` | Marketing & account website (Next.js) |
@@ -85,6 +86,10 @@ Each app has its own setup; see the per-directory `AGENTS.md` for details.
   Dependencies resolve via Swift Package Manager. Requires macOS 14+.
 - **Windows** — `dotnet run -c Debug` from `app/windows/HyperWhisper/`. Requires
   the .NET 10 SDK on Windows. See `app/windows/AGENTS.md` for installer builds.
+- **Linux** —
+  `dotnet build app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj -c Release`.
+  Requires the .NET 10 SDK. Run `app/linux/scripts/run-ui-smoke.sh` for the
+  headless UI smoke test; see `packaging/linux/README.md` for Debian packaging.
 - **Web** — `npm install && npm run dev` in `nextjs/`. Local builds use
   `SKIP_ENV_VALIDATION=1 npm run build`.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Each app has its own setup; see the per-directory `AGENTS.md` for details.
 - **Linux** —
   `dotnet build app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj -c Release`.
   Requires the .NET 10 SDK. Run `app/linux/scripts/run-ui-smoke.sh` for the
-  headless UI smoke test; see `packaging/linux/README.md` for Debian packaging.
+  headless UI smoke test; see `packaging/linux/README.md` for Debian packaging,
+  or download [Linux v1.0.0](https://github.com/ray-amjad/hyperwhisper-app/releases/tag/linux%2Fv1.0.0).
 - **Web** — `npm install && npm run dev` in `nextjs/`. Local builds use
   `SKIP_ENV_VALIDATION=1 npm run build`.
 

--- a/mintlify-help/linux-installation.mdx
+++ b/mintlify-help/linux-installation.mdx
@@ -19,9 +19,8 @@ matrix.
 ## Install the Debian package
 
 <Info>
-  The Linux app and its packaging are available in source now. The public v1
-  Debian package will appear on GitHub Releases after the supported desktop and
-  GPU matrix is validated on physical hardware.
+  Linux v1.0.0 passed the automated build, package, UI-smoke, and integration
+  gates. The expanded physical GNOME, KDE, and GPU matrix is planned for v1.1.0.
 </Info>
 
 Download `hyperwhisper_VERSION_amd64.deb` from the

--- a/mintlify-help/linux-installation.mdx
+++ b/mintlify-help/linux-installation.mdx
@@ -18,6 +18,12 @@ matrix.
 
 ## Install the Debian package
 
+<Info>
+  The Linux app and its packaging are available in source now. The public v1
+  Debian package will appear on GitHub Releases after the supported desktop and
+  GPU matrix is validated on physical hardware.
+</Info>
+
 Download `hyperwhisper_VERSION_amd64.deb` from the
 [Linux releases](https://github.com/ray-amjad/hyperwhisper-app/releases), then
 run this command from the directory containing the file:

--- a/mintlify-help/storage-settings.mdx
+++ b/mintlify-help/storage-settings.mdx
@@ -69,11 +69,6 @@ HyperWhisper always records to WAV and always transcribes the WAV file. The conv
   <Tab title="Windows">
     The toggle is on for a new installation. On an installation that is older than this setting, the toggle is off until you turn it on.
   </Tab>
-  <Tab title="Linux">
-    Turn on **Automatically delete old transcripts and app-owned audio**, then choose 1 to 365 days. Cleanup runs at startup, once per hour, and when you click **Delete now**. The button applies the configured age cutoff; it does not delete recent items.
-
-    Linux deletes only regular files inside its fixed XDG recordings folder. Imported source files and symbolic-link targets are retained.
-  </Tab>
 </Tabs>
 
 ---
@@ -104,6 +99,11 @@ This card deletes the recordings that are older than an age that you set. Automa
     A line below the box shows the time of the last cleanup and the number of transcripts that it deleted.
 
     The **Delete Now** button runs the same cleanup immediately. A confirmation dialog opens first. HyperWhisper then shows the number of deleted transcripts. macOS has no equivalent button.
+  </Tab>
+  <Tab title="Linux">
+    Turn on **Automatically delete old transcripts and app-owned audio**, then choose 1 to 365 days. Cleanup runs at startup, once per hour, and when you click **Delete now**. The button applies the configured age cutoff; it does not delete recent items.
+
+    Linux deletes only regular files inside its fixed XDG recordings folder. Imported source files and symbolic-link targets are retained.
   </Tab>
 </Tabs>
 

--- a/mintlify-help/system-requirements.mdx
+++ b/mintlify-help/system-requirements.mdx
@@ -68,13 +68,13 @@ HyperWhisper runs natively on macOS, Windows, and Linux. Select your platform be
     - **Ubuntu 22.04 or later**, or **Debian 12 or later**
     - x86_64 / amd64 processor (ARM64 is not supported in Linux v1)
     - glibc 2.35 or later
-    - GNOME or KDE Plasma for the verified desktop experience
+    - GNOME or KDE Plasma, the targeted Linux v1 desktops
     - A Vulkan-capable GPU is recommended for local Whisper models
     - ~300 MB free disk for the app, plus space for each local model
 
-    The release package is a self-contained `.deb`; you do not need to install
+    Linux v1 is packaged as a self-contained `.deb`; you do not need to install
     .NET separately. Other Debian-based distributions may satisfy its
-    dependencies, but they are outside the release verification matrix.
+    dependencies, but they are outside the supported v1 matrix.
 
     Whisper uses Vulkan on supported NVIDIA, AMD, and Intel GPUs and falls back
     to the CPU. Local Gemma post-processing uses CUDA 12 on supported NVIDIA

--- a/mintlify-help/updates.mdx
+++ b/mintlify-help/updates.mdx
@@ -1,9 +1,11 @@
 ---
 title: App Updates
-description: How HyperWhisper updates itself on macOS and Windows, and how to check for updates manually.
+description: How HyperWhisper updates on macOS, Windows, and Linux, and how to check for updates manually.
 ---
 
-HyperWhisper checks for updates automatically. You install a new version with one click. You do not need to watch the version numbers yourself.
+HyperWhisper checks for updates automatically on macOS and Windows. Linux uses
+your distribution's package tools so the app never changes system packages by
+itself.
 
 <Tabs>
   <Tab title="macOS">
@@ -35,6 +37,15 @@ HyperWhisper checks for updates automatically. You install a new version with on
     ## Turn off automatic checks
 
     To stop the automatic check in the background, go to **Settings → General**. Then turn off **Auto update**. You can still start a manual check at any time with **Check for Updates**.
+  </Tab>
+  <Tab title="Linux">
+    Open **About**, then click **Refresh package status**. HyperWhisper compares
+    the installed package with your distribution's cached package metadata. It
+    does not refresh repositories or install packages itself.
+
+    Refresh metadata and install an available version with your distribution's
+    normal software updater. For a directly downloaded Debian package, download
+    the newer `.deb` and run `sudo apt install ./hyperwhisper_VERSION_amd64.deb`.
   </Tab>
 </Tabs>
 

--- a/nextjs/app/[locale]/download/page.tsx
+++ b/nextjs/app/[locale]/download/page.tsx
@@ -276,13 +276,13 @@ export default function DownloadPage() {
             <Button
               as="a"
               className="bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold hover:from-purple-500 hover:to-blue-500 transition-all hover:shadow-lg px-8"
-              href="https://github.com/ray-amjad/hyperwhisper-app/releases"
+              href="https://github.com/ray-amjad/hyperwhisper-app/tree/main/app/linux"
               rel="noreferrer"
               size="lg"
               startContent={<Download className="w-5 h-5" />}
               target="_blank"
             >
-              View Linux releases
+              View Linux source
             </Button>
           ) : (
             <Button
@@ -365,8 +365,13 @@ export default function DownloadPage() {
                   </h2>
                 </div>
                 <p className="text-sm text-gray-400 mb-4">
-                  Ubuntu 22.04+ and Debian 12+ on amd64 are the verified release
-                  floor. Replace VERSION with the version you downloaded.
+                  Linux v1 targets Ubuntu 22.04+ and Debian 12+ on amd64.
+                  Replace VERSION with the version you downloaded.
+                </p>
+                <p className="text-sm text-amber-300/90 mb-4">
+                  The Linux app is available from source now. The public v1
+                  Debian package will appear on GitHub Releases after the
+                  supported physical hardware matrix is validated.
                 </p>
                 <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-3 overflow-x-auto">
                   <code className="text-sm font-mono text-gray-200 whitespace-pre">

--- a/nextjs/app/[locale]/download/page.tsx
+++ b/nextjs/app/[locale]/download/page.tsx
@@ -276,13 +276,13 @@ export default function DownloadPage() {
             <Button
               as="a"
               className="bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold hover:from-purple-500 hover:to-blue-500 transition-all hover:shadow-lg px-8"
-              href="https://github.com/ray-amjad/hyperwhisper-app/tree/main/app/linux"
+              href="https://github.com/ray-amjad/hyperwhisper-app/releases/tag/linux%2Fv1.0.0"
               rel="noreferrer"
               size="lg"
               startContent={<Download className="w-5 h-5" />}
               target="_blank"
             >
-              View Linux source
+              Download Linux v1.0.0
             </Button>
           ) : (
             <Button
@@ -367,11 +367,6 @@ export default function DownloadPage() {
                 <p className="text-sm text-gray-400 mb-4">
                   Linux v1 targets Ubuntu 22.04+ and Debian 12+ on amd64.
                   Replace VERSION with the version you downloaded.
-                </p>
-                <p className="text-sm text-amber-300/90 mb-4">
-                  The Linux app is available from source now. The public v1
-                  Debian package will appear on GitHub Releases after the
-                  supported physical hardware matrix is validated.
                 </p>
                 <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-3 overflow-x-auto">
                   <code className="text-sm font-mono text-gray-200 whitespace-pre">

--- a/nextjs/app/[locale]/layout.tsx
+++ b/nextjs/app/[locale]/layout.tsx
@@ -71,6 +71,7 @@ export async function generateMetadata({ params }: Props) {
       "AI transcription",
       "macOS app",
       "Windows app",
+      "Linux app",
       "whisper AI",
       "dictation software",
       "voice typing",

--- a/nextjs/app/[locale]/open-source/page.tsx
+++ b/nextjs/app/[locale]/open-source/page.tsx
@@ -39,9 +39,9 @@ export default function OpenSourcePage() {
         <p>
           An app that listens to your microphone should be something you can
           verify, not just trust. So we opened everything up. You can read every
-          line of HyperWhisper — the macOS and Windows apps, and the Cloud
-          transcription backend — see exactly where your audio goes, and know
-          you&apos;ll never be locked in. The whole project lives on{" "}
+          line of HyperWhisper — the macOS, Windows, and Linux apps, and the
+          Cloud transcription backend — see exactly where your audio goes, and
+          know you&apos;ll never be locked in. The whole project lives on{" "}
           <a href={GITHUB_URL} target="_blank" rel="noopener noreferrer">
             GitHub
           </a>{" "}

--- a/nextjs/app/sitemap.ts
+++ b/nextjs/app/sitemap.ts
@@ -13,6 +13,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "", // home page
     "/about",
     "/blog",
+    "/download",
     "/pricing",
     "/docs",
     "/support",

--- a/nextjs/components/landing/HeroSection.tsx
+++ b/nextjs/components/landing/HeroSection.tsx
@@ -80,6 +80,9 @@ export default function HeroSection() {
             <div className="px-3 py-1 bg-gray-800 rounded-lg border border-gray-700 flex items-center gap-2">
               <span className="text-sm text-gray-300">{t("windows")}</span>
             </div>
+            <div className="px-3 py-1 bg-gray-800 rounded-lg border border-gray-700 flex items-center gap-2">
+              <span className="text-sm text-gray-300">{t("linux")}</span>
+            </div>
           </div>
         </div>
       </m.div>

--- a/nextjs/messages/ar.json
+++ b/nextjs/messages/ar.json
@@ -29,7 +29,8 @@
     "demoCta": "شاهد العرض",
     "availableOn": "متاح على",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "مصمم للمحترفين",

--- a/nextjs/messages/bg.json
+++ b/nextjs/messages/bg.json
@@ -29,7 +29,8 @@
     "demoCta": "Гледайте демо",
     "availableOn": "Налично за",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Създадено за професионалисти",

--- a/nextjs/messages/ca.json
+++ b/nextjs/messages/ca.json
@@ -29,7 +29,8 @@
     "demoCta": "Mira la demo",
     "availableOn": "Disponible a",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Creat per a professionals",

--- a/nextjs/messages/cs.json
+++ b/nextjs/messages/cs.json
@@ -29,7 +29,8 @@
     "demoCta": "Podívat se na demo",
     "availableOn": "Dostupné pro",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Vytvořeno pro profesionály",

--- a/nextjs/messages/da.json
+++ b/nextjs/messages/da.json
@@ -29,7 +29,8 @@
     "demoCta": "Se demo",
     "availableOn": "Tilgængelig på",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Bygget til professionelle",

--- a/nextjs/messages/de.json
+++ b/nextjs/messages/de.json
@@ -29,7 +29,8 @@
     "demoCta": "Demo ansehen",
     "availableOn": "Verfügbar für",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Für Profis entwickelt",

--- a/nextjs/messages/el.json
+++ b/nextjs/messages/el.json
@@ -29,7 +29,8 @@
     "demoCta": "Δείτε demo",
     "availableOn": "Διαθέσιμο σε",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Φτιαγμένο για επαγγελματίες",

--- a/nextjs/messages/en.json
+++ b/nextjs/messages/en.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "title": "HyperWhisper - AI Voice Transcription for macOS & Windows",
-    "description": "Write 5x faster with AI-powered voice transcription. HyperWhisper transcribes your voice with incredible accuracy on macOS and Windows. Speak naturally and watch your words appear instantly."
+    "title": "HyperWhisper - AI Voice Transcription for macOS, Windows & Linux",
+    "description": "Write 5x faster with AI-powered voice transcription. HyperWhisper transcribes your voice with incredible accuracy on macOS, Windows, and Linux. Speak naturally and watch your words appear instantly."
   },
   "navbar": {
     "features": "Features",
@@ -29,7 +29,8 @@
     "demoCta": "Watch demo",
     "availableOn": "Available on",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Built for professionals",
@@ -164,7 +165,7 @@
       },
       "offline": {
         "question": "Can I use it without internet?",
-        "answer": "Absolutely. HyperWhisper can be used entirely offline on your Mac or Windows PC using local AI models - no internet required. For users who want maximum accuracy and speed, we also offer optional cloud processing via various cloud providers."
+        "answer": "Absolutely. HyperWhisper can be used entirely offline on macOS, Windows, or Linux using local AI models - no internet required. For users who want maximum accuracy and speed, we also offer optional cloud processing via various cloud providers."
       },
       "apiKey": {
         "question": "Do I need to pay for API access?",
@@ -179,12 +180,12 @@
         "answer": "For offline transcription, we offer multiple sizes of the Whisper model (made by OpenAI, supporting 99+ languages). We also offer NVidia's Parakeet models (supporting 25+ languages).\n      \n      For offline post-processing, we offer multiple sizes of the Gemma 3 model (made by Google)."
       },
       "compatibility": {
-        "question": "Does it work with all Mac and Windows apps?",
+        "question": "Does it work with all my apps?",
         "answer": "Yes, it works everywhere you can type. Whether you're composing emails, writing documents, coding, or chatting. Just hit the shortcut, speak, and watch your words appear instantly."
       },
       "privacy": {
         "question": "How is my privacy protected?",
-        "answer": "When using local mode, no data ever leaves your Mac or Windows PC.\n\nWhen using cloud transcription, your data is sent to the cloud provider you choose (e.g., OpenAI, Groq, xAI Grok, Deepgram, AssemblyAI, ElevenLabs, Mistral, Soniox, or Google Gemini).\n\nYou can verify this yourself with a network inspector such as [Proxyman](https://proxyman.io) or a network monitor like [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html), or by reading the [source code on GitHub](https://github.com/ray-amjad/hyperwhisper-app).\n\nFor a full breakdown of where audio goes and how to opt your own API keys out of model training, see our [Data Privacy guide](https://hyperwhisper.com/docs/data-privacy)."
+        "answer": "When using local mode, no data ever leaves your macOS, Windows, or Linux device.\n\nWhen using cloud transcription, your data is sent to the cloud provider you choose (e.g., OpenAI, Groq, xAI Grok, Deepgram, AssemblyAI, ElevenLabs, Mistral, Soniox, or Google Gemini).\n\nYou can verify this yourself with a network inspector such as [Proxyman](https://proxyman.io) or a network monitor like [Little Snitch](https://www.obdev.at/products/littlesnitch/index.html), or by reading the [source code on GitHub](https://github.com/ray-amjad/hyperwhisper-app).\n\nFor a full breakdown of where audio goes and how to opt your own API keys out of model training, see our [Data Privacy guide](https://hyperwhisper.com/docs/data-privacy)."
       },
       "cloud": {
         "question": "What is HyperWhisper Cloud?",
@@ -216,7 +217,7 @@
       },
       "requirements": {
         "question": "What are the system requirements?",
-        "answer": "For Mac: macOS 14 or newer, both Apple Silicon and Intel supported. For Windows: Windows 10/11, x64 or ARM64. 8GB RAM recommended for optimal performance."
+        "answer": "Mac: macOS 14+ on Apple Silicon or Intel. Windows: Windows 10/11 on x64 or ARM64. Linux v1: Ubuntu 22.04+ or Debian 12+ on amd64. 8GB RAM recommended for optimal performance."
       },
       "madeBy": {
         "question": "Who was this made by?",
@@ -291,7 +292,7 @@
     "loading": "Loading..."
   },
   "footer": {
-    "tagline": "Write 5x faster with AI-powered voice transcription for macOS & Windows.",
+    "tagline": "Write 5x faster with AI-powered voice transcription for macOS, Windows & Linux.",
     "product": "Product",
     "resources": "Resources",
     "company": "Company",

--- a/nextjs/messages/es.json
+++ b/nextjs/messages/es.json
@@ -29,7 +29,8 @@
     "demoCta": "Ver demo",
     "availableOn": "Disponible en",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Hecho para profesionales",

--- a/nextjs/messages/et.json
+++ b/nextjs/messages/et.json
@@ -29,7 +29,8 @@
     "demoCta": "Vaata demot",
     "availableOn": "Saadaval",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Loodud professionaalidele",

--- a/nextjs/messages/fi.json
+++ b/nextjs/messages/fi.json
@@ -29,7 +29,8 @@
     "demoCta": "Katso demo",
     "availableOn": "Saatavilla",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Rakennettu ammattilaisille",

--- a/nextjs/messages/fr.json
+++ b/nextjs/messages/fr.json
@@ -29,7 +29,8 @@
     "demoCta": "Voir la démo",
     "availableOn": "Disponible sur",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Conçu pour les professionnels",

--- a/nextjs/messages/he.json
+++ b/nextjs/messages/he.json
@@ -29,7 +29,8 @@
     "demoCta": "לצפות בדמו",
     "availableOn": "זמין עבור",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "נבנה לאנשי מקצוע",

--- a/nextjs/messages/hi.json
+++ b/nextjs/messages/hi.json
@@ -29,7 +29,8 @@
     "demoCta": "डेमो देखें",
     "availableOn": "उपलब्ध है",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "प्रोफेशनल्स के लिए बनाया गया",

--- a/nextjs/messages/hr.json
+++ b/nextjs/messages/hr.json
@@ -29,7 +29,8 @@
     "demoCta": "Pogledaj demo",
     "availableOn": "Dostupno na",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Stvoreno za profesionalce",

--- a/nextjs/messages/hu.json
+++ b/nextjs/messages/hu.json
@@ -29,7 +29,8 @@
     "demoCta": "Demó megtekintése",
     "availableOn": "Elérhető",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Profiknak tervezve",

--- a/nextjs/messages/id.json
+++ b/nextjs/messages/id.json
@@ -29,7 +29,8 @@
     "demoCta": "Lihat demo",
     "availableOn": "Tersedia di",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Dibuat untuk profesional",

--- a/nextjs/messages/is.json
+++ b/nextjs/messages/is.json
@@ -29,7 +29,8 @@
     "demoCta": "Sjá kynningu",
     "availableOn": "Í boði fyrir",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Byggt fyrir fagfólk",

--- a/nextjs/messages/it.json
+++ b/nextjs/messages/it.json
@@ -29,7 +29,8 @@
     "demoCta": "Guarda la demo",
     "availableOn": "Disponibile su",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Progettato per professionisti",

--- a/nextjs/messages/ja.json
+++ b/nextjs/messages/ja.json
@@ -29,7 +29,8 @@
     "demoCta": "デモ動画を見る",
     "availableOn": "対応OS",
     "macos": "macOS 14以降",
-    "windows": "Windows 10以降"
+    "windows": "Windows 10以降",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "プロフェッショナルのために",

--- a/nextjs/messages/ko.json
+++ b/nextjs/messages/ko.json
@@ -29,7 +29,8 @@
     "demoCta": "데모 보기",
     "availableOn": "지원 플랫폼",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "전문가를 위해 설계됨",

--- a/nextjs/messages/lt.json
+++ b/nextjs/messages/lt.json
@@ -29,7 +29,8 @@
     "demoCta": "Žiūrėti demonstraciją",
     "availableOn": "Prieinama",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Sukurta profesionalams",

--- a/nextjs/messages/lv.json
+++ b/nextjs/messages/lv.json
@@ -29,7 +29,8 @@
     "demoCta": "Skatīties demo",
     "availableOn": "Pieejams",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Radīts profesionāļiem",

--- a/nextjs/messages/ms.json
+++ b/nextjs/messages/ms.json
@@ -29,7 +29,8 @@
     "demoCta": "Tonton demo",
     "availableOn": "Tersedia di",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Dibina untuk profesional",

--- a/nextjs/messages/nb.json
+++ b/nextjs/messages/nb.json
@@ -29,7 +29,8 @@
     "demoCta": "Se demo",
     "availableOn": "Tilgjengelig på",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Bygget for profesjonelle",

--- a/nextjs/messages/nl.json
+++ b/nextjs/messages/nl.json
@@ -29,7 +29,8 @@
     "demoCta": "Demo bekijken",
     "availableOn": "Beschikbaar op",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Gemaakt voor professionals",

--- a/nextjs/messages/pl.json
+++ b/nextjs/messages/pl.json
@@ -29,7 +29,8 @@
     "demoCta": "Zobacz demo",
     "availableOn": "Dostępne na",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Stworzone dla profesjonalistów",

--- a/nextjs/messages/pt.json
+++ b/nextjs/messages/pt.json
@@ -29,7 +29,8 @@
     "demoCta": "Ver demonstração",
     "availableOn": "Disponível em",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Feito para profissionais",

--- a/nextjs/messages/ro.json
+++ b/nextjs/messages/ro.json
@@ -29,7 +29,8 @@
     "demoCta": "Vezi demo",
     "availableOn": "Disponibil pe",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Creat pentru profesioniști",

--- a/nextjs/messages/ru.json
+++ b/nextjs/messages/ru.json
@@ -29,7 +29,8 @@
     "demoCta": "Смотреть демо",
     "availableOn": "Доступно на",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Создано для профессионалов",

--- a/nextjs/messages/sk.json
+++ b/nextjs/messages/sk.json
@@ -29,7 +29,8 @@
     "demoCta": "Pozrieť demo",
     "availableOn": "Dostupné na",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Vytvorené pre profesionálov",

--- a/nextjs/messages/sl.json
+++ b/nextjs/messages/sl.json
@@ -29,7 +29,8 @@
     "demoCta": "Poglej demo",
     "availableOn": "Na voljo za",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Ustvarjeno za profesionalce",

--- a/nextjs/messages/sr.json
+++ b/nextjs/messages/sr.json
@@ -29,7 +29,8 @@
     "demoCta": "Pogledaj demo",
     "availableOn": "Dostupno na",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Napravljeno za profesionalce",

--- a/nextjs/messages/sv.json
+++ b/nextjs/messages/sv.json
@@ -29,7 +29,8 @@
     "demoCta": "Se demo",
     "availableOn": "Finns för",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Byggd för proffs",

--- a/nextjs/messages/th.json
+++ b/nextjs/messages/th.json
@@ -29,7 +29,8 @@
     "demoCta": "ดูเดโม",
     "availableOn": "พร้อมใช้งานบน",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "สร้างมาเพื่อมืออาชีพ",

--- a/nextjs/messages/tr.json
+++ b/nextjs/messages/tr.json
@@ -29,7 +29,8 @@
     "demoCta": "Demoyu izle",
     "availableOn": "Kullanılabildiği platformlar",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Profesyoneller için geliştirildi",

--- a/nextjs/messages/uk.json
+++ b/nextjs/messages/uk.json
@@ -29,7 +29,8 @@
     "demoCta": "Дивитись демо",
     "availableOn": "Доступно на",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Створено для професіоналів",

--- a/nextjs/messages/vi.json
+++ b/nextjs/messages/vi.json
@@ -29,7 +29,8 @@
     "demoCta": "Xem demo",
     "availableOn": "Có trên",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "Xây dựng cho chuyên gia",

--- a/nextjs/messages/zh-Hant.json
+++ b/nextjs/messages/zh-Hant.json
@@ -29,7 +29,8 @@
     "demoCta": "觀看示範",
     "availableOn": "適用於",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "為專業人士打造",

--- a/nextjs/messages/zh.json
+++ b/nextjs/messages/zh.json
@@ -29,7 +29,8 @@
     "demoCta": "观看演示",
     "availableOn": "适用于",
     "macos": "macOS 14+",
-    "windows": "Windows 10+"
+    "windows": "Windows 10+",
+    "linux": "Linux (amd64)"
   },
   "features": {
     "title": "为专业人士打造",


### PR DESCRIPTION
## Summary

- add Linux to the homepage platform badges, English SEO/FAQ/footer copy, open-source page, and sitemap
- expose the Linux badge in all 40 locale message catalogs
- document the Linux source tree and build path in the repository README
- add accurate package-update guidance and fix the misplaced Linux storage-cleanup instructions
- keep the Linux download page honest while physical hardware validation is pending: source is available now, and the public `.deb` remains gated

## Verification

- `node --import tsx --test tests/*.test.ts` (94/94)
- targeted ESLint (0 errors; pre-existing warnings only)
- `SKIP_ENV_VALIDATION=1` production build with `.env.example` (941/941 pages)
- local production server: HTTP 200 for `/en`, `/en/download?platform=linux`, `/ja/download?platform=linux`, and `/sitemap.xml`
- all 40 locale JSON files parsed and contain `hero.linux`
- Mintlify navigation paths validated
- `git diff --check`

## Release status

The hosted `v1.0.0` Linux build-only workflow is running separately. This PR intentionally does not claim that the public signed Debian release has passed the physical desktop/GPU evidence gate.
