### PR TITLE
Fix Linux installation guide link

### DIFF
--- a/nextjs/app/[locale]/download/page.tsx
+++ b/nextjs/app/[locale]/download/page.tsx
@@ -395,7 +395,7 @@ sudo usermod -aG hyperwhisper-input "$USER"`}
                 <Button
                   as="a"
                   className="mt-4 bg-gray-800 text-gray-200"
-                  href="https://help.hyperwhisper.com/linux-installation"
+                  href="https://www.hyperwhisper.com/docs/linux-installation"
                   rel="noreferrer"
                   target="_blank"
                   variant="flat"


### PR DESCRIPTION
The Linux download page linked to the undeployed `help.hyperwhisper.com` hostname. Point it to the verified live guide at `https://www.hyperwhisper.com/docs/linux-installation`.\n\nVerified with targeted ESLint (0 errors), `git diff --check`, and an HTTP 200 probe of the destination.