### PR TITLE
ci(release): fail fast when the R2 upload credentials are rejected

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -50,6 +50,37 @@ jobs:
           fetch-depth: 0
 
       # ----------------------------------------------------------------
+      # 1b. Verify the R2 credentials before anything expensive runs
+      # ----------------------------------------------------------------
+      - name: Verify Cloudflare R2 credentials
+        if: ${{ inputs.skip_upload != true }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          ENDPOINT="https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+          BUCKET="${{ secrets.R2_BUCKET_NAME }}"
+          PROBE="_ci-preflight/macos-${{ github.run_id }}-${{ github.run_attempt }}.txt"
+
+          which aws || brew install awscli
+
+          # Round-trip a throwaway object rather than calling head-bucket: an
+          # expired or read-only token still passes a read probe and then fails
+          # the real upload after the archive, notarization and stapling have
+          # already burned ~13 minutes. Fail here instead, at ~40 seconds.
+          echo "r2-preflight" > "$RUNNER_TEMP/r2-preflight.txt"
+          if ! aws s3 cp "$RUNNER_TEMP/r2-preflight.txt" "s3://$BUCKET/$PROBE" --endpoint-url "$ENDPOINT"; then
+            echo "::error::Cloudflare R2 rejected the upload credentials. Create a new R2 API token with Object Read & Write on the builds bucket, write CLOUDFLARE_R2_ACCESS_KEY_ID and CLOUDFLARE_R2_SECRET_ACCESS_KEY to Infisical (--env=prod), wait for the sync, then re-run. Never edit the GitHub secret directly: the next sync overwrites it."
+            exit 1
+          fi
+
+          # Best-effort tidy-up. A token with write but not delete is still fine
+          # for a release, so a failure here must not fail the run.
+          aws s3 rm "s3://$BUCKET/$PROBE" --endpoint-url "$ENDPOINT" || true
+          echo "R2 credentials accepted."
+
+      # ----------------------------------------------------------------
       # 2. Select Xcode version
       # ----------------------------------------------------------------
       - name: Select Xcode 26.3

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -124,6 +124,41 @@ jobs:
           Write-Host "Preflight passed for Windows $ver"
 
       # ----------------------------------------------------------------
+      # 1b. Verify the R2 credentials before anything expensive runs
+      # ----------------------------------------------------------------
+      - name: Verify Cloudflare R2 credentials
+        if: ${{ inputs.skip_upload != true }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+        run: |
+          $ErrorActionPreference = "Stop"
+          $endpoint = "https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+          $bucket = "${{ secrets.R2_BUCKET_NAME }}"
+          $probe = "_ci-preflight/windows-${{ github.run_id }}-${{ github.run_attempt }}.txt"
+
+          choco install awscli -y --no-progress
+
+          # Round-trip a throwaway object rather than calling head-bucket: an
+          # expired or read-only token still passes a read probe and then fails
+          # the real upload after both installers are built and signed.
+          $probeFile = Join-Path $env:RUNNER_TEMP "r2-preflight.txt"
+          Set-Content -Path $probeFile -Value "r2-preflight"
+
+          & aws s3 cp $probeFile "s3://$bucket/$probe" --endpoint-url $endpoint
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::Cloudflare R2 rejected the upload credentials. Create a new R2 API token with Object Read & Write on the builds bucket, write CLOUDFLARE_R2_ACCESS_KEY_ID and CLOUDFLARE_R2_SECRET_ACCESS_KEY to Infisical (--env=prod), wait for the sync, then re-run. Never edit the GitHub secret directly: the next sync overwrites it."
+            throw "R2 credential preflight failed"
+          }
+
+          # Best-effort tidy-up. A token with write but not delete is still fine
+          # for a release, so a failure here must not fail the run.
+          & aws s3 rm "s3://$bucket/$probe" --endpoint-url $endpoint
+          $LASTEXITCODE = 0
+          Write-Host "R2 credentials accepted."
+
+      # ----------------------------------------------------------------
       # 2. Setup .NET 10 SDK
       # ----------------------------------------------------------------
       - name: Setup .NET 10 SDK
@@ -537,10 +572,6 @@ jobs:
       # ----------------------------------------------------------------
       # 10. Upload to Cloudflare R2
       # ----------------------------------------------------------------
-      - name: Install AWS CLI
-        if: ${{ inputs.skip_upload != true }}
-        run: choco install awscli -y --no-progress
-
       - name: Upload installers to Cloudflare R2
         if: ${{ inputs.skip_upload != true }}
         env:


### PR DESCRIPTION
## Why

The 2.45.0 macOS release archived, notarized, stapled and Sparkle-signed a DMG, then failed on the very last step that could still lose work:

```
An error occurred (Unauthorized) when calling the CreateMultipartUpload operation
```

Thirteen minutes of build, discarded. The synced secret values had not changed since the previous good release, so the token had been revoked at the Cloudflare end.

## What

Both release workflows now round-trip a throwaway object into the builds bucket before anything expensive runs — macOS right after checkout, Windows right after the existing input preflight. Failure aborts at roughly 40 seconds.

- A **write** probe, not `head-bucket`. An expired or read-only token still passes a read probe and then fails the real upload after the build is spent.
- The error message names the fix, so the next person does not rediscover it: rotate in Cloudflare, author in Infisical `--env=prod`, never edit the GitHub secret directly.
- The delete afterwards is best-effort. A token with write but no delete can still ship a release, so a failure there must not fail the run.
- Both steps carry the same `skip_upload != true` guard as the upload they protect, so dry runs are unaffected.

Also drops the Windows `Install AWS CLI` step — the preflight installs it under the identical condition.

## Scope

Only the two workflows that actually write to R2. The build/test CI workflows do not touch R2, so a credential probe there would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrzodY3jEirhVSzzHizRt2