### PR TITLE
feat(linux,web): put the current Linux version on the download page

### DIFF
--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -37,6 +37,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write   # the website version file lands via an auto-merged PR
 
 concurrency:
   group: linux-release
@@ -690,6 +691,80 @@ jobs:
             END { exit(found ? 0 : 1) }
           ' "${RUNNER_TEMP}/Packages"
           echo "Signed APT repository deployed and read back from $origin"
+
+      # The website's Linux download button reads this file. macOS and Windows
+      # land their appcast the same way — a commit on the base branch through an
+      # auto-merged PR — so the mechanism matches even though the format does
+      # not: Linux updates through apt, not Sparkle, so a Sparkle appcast here
+      # would be a costume.
+      #
+      # It runs last, after both the GitHub Release and the APT repository are
+      # live, so the site never advertises a version that is not fully shipped.
+      - name: Publish the Linux version to the website
+        if: steps.release.outputs.publish == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          BASE="${GITHUB_REF_NAME}"
+          BRANCH="release/linux-v${VERSION}-site"
+          TAG_ENCODED="${TAG//\//%2F}"
+          BUILDS="https://builds.hyperwhisper.com"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # The checkout step deliberately strips the token from the remote URL.
+          # Authenticate the push with a header instead of putting it back, so
+          # the credential never lands in .git/config.
+          auth_header="authorization: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
+
+          git -c "http.extraheader=$auth_header" fetch -q --no-tags origin "$BASE"
+
+          # Clear any stale branch left behind by a failed run.
+          git -c "http.extraheader=$auth_header" push -q origin --delete "$BRANCH" 2>/dev/null || true
+          git checkout -q -B "$BRANCH" "origin/$BASE"
+
+          jq -n \
+            --arg version "$VERSION" \
+            --arg releasedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg deb "${BUILDS}/hyperwhisper_${VERSION}_amd64.deb" \
+            --arg aptArchive "${BUILDS}/hyperwhisper-apt-${VERSION}.tar.gz" \
+            --arg checksums "${BUILDS}/hyperwhisper-linux-${VERSION}-SHA256SUMS" \
+            --arg releasePage "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_ENCODED}" \
+            '{version:$version, releasedAt:$releasedAt, deb:$deb, aptArchive:$aptArchive, checksums:$checksums, releasePage:$releasePage}' \
+            > nextjs/public/linux-latest.json
+
+          git add nextjs/public/linux-latest.json
+          if git diff --cached --quiet; then
+            echo "linux-latest.json is already current; nothing to publish."
+            exit 0
+          fi
+
+          git commit -q -m "release: Linux v${VERSION} — publish the version to the website"
+          git -c "http.extraheader=$auth_header" push -q -u origin "$BRANCH"
+
+          gh pr create --base "$BASE" --head "$BRANCH" \
+            --title "release: Linux v${VERSION} — website version file" \
+            --body "Automated release commit from linux-release.yml."
+
+          # A brand-new PR can take a moment to report as mergeable.
+          for i in 1 2 3 4 5; do
+            if gh pr merge "$BRANCH" --squash --delete-branch; then
+              break
+            fi
+            if [ "$i" = 5 ]; then
+              echo "::error::The website version file did not merge after 5 attempts. The release itself shipped correctly; merge release/linux-v${VERSION}-site by hand to update the download page."
+              exit 1
+            fi
+            echo "merge attempt $i failed, retrying..."
+            sleep 5
+          done
+
+          echo "The website now advertises Linux v${VERSION}."
 
       - name: Report dry-run artifacts
         if: steps.release.outputs.publish != 'true'

--- a/nextjs/app/[locale]/download/page.tsx
+++ b/nextjs/app/[locale]/download/page.tsx
@@ -9,6 +9,26 @@ import { useTranslations } from "next-intl";
 
 type Platform = "mac" | "windows" | "linux";
 
+/**
+ * Shape of /linux-latest.json, written by linux-release.yml on every published
+ * Linux release. Linux updates through apt rather than Sparkle, so it has no
+ * appcast; this file is the one thing the site needs from a release.
+ */
+type LinuxLatest = {
+  version: string;
+  releasedAt: string;
+  deb: string;
+  aptArchive: string | null;
+  checksums: string;
+  releasePage: string;
+};
+
+// Used only if /linux-latest.json cannot be read. It points at the releases
+// list rather than a pinned version, so a stale build can never advertise a
+// version number that has been superseded.
+const LINUX_RELEASES_URL =
+  "https://github.com/ray-amjad/hyperwhisper-app/releases?q=linux";
+
 export default function DownloadPage() {
   const t = useTranslations("downloadPage");
   const searchParams = useSearchParams();
@@ -24,6 +44,7 @@ export default function DownloadPage() {
     linux: { url: null, countdown: 5, started: false },
   });
   const [copied, setCopied] = useState(false);
+  const [linuxLatest, setLinuxLatest] = useState<LinuxLatest | null>(null);
 
   const currentState = downloadState[selectedPlatform];
 
@@ -60,6 +81,28 @@ export default function DownloadPage() {
     }
     // macOS is default, no change needed
   }, [searchParams]);
+
+  // Read the current Linux version once the user is on the Linux tab. A failure
+  // is not an error state: the button falls back to the releases list, so the
+  // page stays useful if the file is missing or the fetch is blocked.
+  useEffect(() => {
+    if (selectedPlatform !== "linux" || linuxLatest) return;
+
+    let cancelled = false;
+
+    fetch("/linux-latest.json")
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data: LinuxLatest | null) => {
+        if (!cancelled && data?.version && data?.deb) setLinuxLatest(data);
+      })
+      .catch(() => {
+        // Fall back to LINUX_RELEASES_URL below.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedPlatform, linuxLatest]);
 
   // Fetch the macOS download URL on mount (but don't trigger download yet).
   useEffect(() => {
@@ -273,17 +316,29 @@ export default function DownloadPage() {
               </Button>
             </div>
           ) : selectedPlatform === "linux" ? (
-            <Button
-              as="a"
-              className="bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold hover:from-purple-500 hover:to-blue-500 transition-all hover:shadow-lg px-8"
-              href="https://github.com/ray-amjad/hyperwhisper-app/releases/tag/linux%2Fv1.0.0"
-              rel="noreferrer"
-              size="lg"
-              startContent={<Download className="w-5 h-5" />}
-              target="_blank"
-            >
-              Download Linux v1.0.0
-            </Button>
+            <div className="flex flex-col items-center gap-3">
+              <Button
+                as="a"
+                className="bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold hover:from-purple-500 hover:to-blue-500 transition-all hover:shadow-lg px-8"
+                href={linuxLatest?.deb ?? LINUX_RELEASES_URL}
+                rel="noreferrer"
+                size="lg"
+                startContent={<Download className="w-5 h-5" />}
+                target="_blank"
+              >
+                {linuxLatest
+                  ? `Download Linux v${linuxLatest.version}`
+                  : "Download Linux"}
+              </Button>
+              <a
+                className="text-sm text-gray-400 underline hover:text-gray-200"
+                href={linuxLatest?.releasePage ?? LINUX_RELEASES_URL}
+                rel="noreferrer"
+                target="_blank"
+              >
+                Checksums and release notes
+              </a>
+            </div>
           ) : (
             <Button
               className="bg-gradient-to-r from-purple-600 to-blue-600 text-white font-semibold hover:from-purple-500 hover:to-blue-500 transition-all hover:shadow-lg px-8"
@@ -366,11 +421,12 @@ export default function DownloadPage() {
                 </div>
                 <p className="text-sm text-gray-400 mb-4">
                   Linux v1 targets Ubuntu 22.04+ and Debian 12+ on amd64.
-                  Replace VERSION with the version you downloaded.
+                  {!linuxLatest &&
+                    " Replace VERSION with the version you downloaded."}
                 </p>
                 <div className="rounded-lg border border-gray-700 bg-gray-800/80 p-3 overflow-x-auto">
                   <code className="text-sm font-mono text-gray-200 whitespace-pre">
-                    {`sudo apt install ./hyperwhisper_VERSION_amd64.deb
+                    {`sudo apt install ./hyperwhisper_${linuxLatest?.version ?? "VERSION"}_amd64.deb
 sudo usermod -aG hyperwhisper-input "$USER"`}
                   </code>
                 </div>

--- a/nextjs/public/linux-latest.json
+++ b/nextjs/public/linux-latest.json
@@ -1,0 +1,8 @@
+{
+  "version": "1.0.0",
+  "releasedAt": "2026-08-24T03:50:01Z",
+  "deb": "https://github.com/ray-amjad/hyperwhisper-app/releases/download/linux%2Fv1.0.0/hyperwhisper_1.0.0_amd64.deb",
+  "aptArchive": null,
+  "checksums": "https://github.com/ray-amjad/hyperwhisper-app/releases/download/linux%2Fv1.0.0/SHA256SUMS",
+  "releasePage": "https://github.com/ray-amjad/hyperwhisper-app/releases/tag/linux%2Fv1.0.0"
+}


### PR DESCRIPTION
Stacked on #344 — both PRs touch `linux-release.yml`. GitHub retargets this to `main` when #344 merges.

## The problem

The site never learned about Linux releases. Nothing is broken; the wiring never existed.

- `nextjs/app/[locale]/download/page.tsx` hardcoded `releases/tag/linux%2Fv1.0.0` with literal button text `Download Linux v1.0.0`.
- `linux-release.yml` never touched `nextjs/`. macOS and Windows both land an appcast there.

Only one Linux release exists, so the hardcode is not yet wrong. It goes stale the moment v1.0.1 is cut.

## The workflow side

`linux-release.yml` now writes `nextjs/public/linux-latest.json` and lands it on the base branch through an auto-merged PR — the same mechanism macOS and Windows use.

The **format** is deliberately not the same. Linux updates through `apt`, not Sparkle, so a Sparkle appcast here would be a costume. A small JSON file is what the site actually needs, and it is less code on both ends.

Two details worth review:

- The step runs **last**, after both the GitHub Release and the APT repository are live, so the site never advertises a version that is not fully shipped. If its PR fails to merge, the error says the release shipped and only the site commit needs a hand — the release is not rolled back.
- The push authenticates with an `http.extraheader` rather than writing the token back into the remote URL, so the credential never lands in `.git/config`.

## The page side

- The button reads the file and links straight to the `.deb` on `builds.hyperwhisper.com`.
- A secondary link goes to the GitHub Release for checksums and notes.
- The install snippet substitutes the real version instead of telling the reader to replace `VERSION` by hand.
- If the file cannot be read, the button falls back to the **releases list**, not a pinned version — a stale build can never advertise a superseded version number.

## One thing to know about the seed

`linux-latest.json` ships pointing at the v1.0.0 **GitHub** assets, not R2. The R2 mirror in #344 only covers releases from the next one onward, so pointing it at `builds.hyperwhisper.com` today would 404. The first Linux release after this merges rewrites the file with R2 URLs.

## Verification

`actionlint` is clean on `linux-release.yml`. `tsc --noEmit` reports no errors in the changed page; the three it does report are pre-existing react-query / tRPC version mismatches in `CustomersClient.tsx` and `TRPCProvider.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrzodY3jEirhVSzzHizRt2