### PR TITLE
release(linux): drop the hardware-evidence gate and cut v1.1.0

### DIFF
--- a/.github/scripts/test-linux-release-policy.py
+++ b/.github/scripts/test-linux-release-policy.py
@@ -64,7 +64,7 @@ def main() -> None:
     require(
         RELEASE,
         "validate-release-evidence.py",
-        "publishing must require reviewed physical evidence",
+        "a checked-in evidence manifest must still be validated",
     )
     require(
         RELEASE,
@@ -84,10 +84,24 @@ def main() -> None:
         "dry-run packages must be retrievable for physical testing",
     )
     require(RELEASE, "retention-days: 14", "dry-run artifacts need bounded retention")
+    # Publishing no longer requires a signature, but an unsigned run must not
+    # hand anyone an unsigned APT repository. Prove it is withheld everywhere.
     require(
         RELEASE,
-        'if [[ "$publish" == "true" && "$require_apt_signature" != "true" ]]',
-        "publication must require signed APT metadata",
+        'if [[ "$REQUIRE_APT_SIGNATURE" == "true" ]]; then\n'
+        '            assets+=("hyperwhisper-apt-${VERSION}.tar.gz")',
+        "an unsigned run must withhold the APT archive from the GitHub Release",
+    )
+    require(
+        RELEASE,
+        'if [[ "$REQUIRE_APT_SIGNATURE" == "true" ]]; then\n'
+        '            mirrored+=("hyperwhisper-apt-${VERSION}.tar.gz")',
+        "an unsigned run must withhold the APT archive from the R2 mirror",
+    )
+    require(
+        RELEASE,
+        '"$publish" != "true" || "$require_apt_signature" != "true"',
+        "APT deployment must require both publication and a signature",
     )
     require(RELEASE, 'GITHUB_REF" != "refs/heads/main', "publishing must run from main")
     require(RELEASE, "Remote tag already exists", "publishing must reject tag collisions")

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -377,16 +377,24 @@ jobs:
             packaging/linux/debian/postrm
           desktop-file-validate packaging/linux/debian/hyperwhisper.desktop
 
+          # Build at the project's real version, not a fixed one, so the
+          # package version and the Debian changelog never disagree after a
+          # version bump.
+          version="$(sed -n 's:.*<Version>\([^<]*\)</Version>.*:\1:p' \
+            app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj)"
+          test -n "$version"
+
           package_path="$(
             packaging/linux/scripts/build-deb.sh \
               --publish-dir artifacts/hyperwhisper-linux \
               --output-dir artifacts/debian \
-              --version 1.0.0 \
+              --version "$version" \
               --architecture amd64
           )"
 
           test -s "$package_path"
-          packaging/linux/scripts/test-package.sh "$package_path"
+          HYPERWHISPER_PACKAGE_VERSION="$version" \
+            packaging/linux/scripts/test-package.sh "$package_path"
           packaging/linux/scripts/test-apt-repository.sh "$package_path"
           lintian --fail-on warning "$package_path"
           dpkg-deb --info "$package_path"

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,9 +1,10 @@
-# Linux v1 release builder. Manual dry runs build a retrievable, unsigned
-# package without Production secrets or external side effects. A GitHub Release
-# is created only by an explicitly approved workflow_dispatch run with
-# publish_github=true, sign_apt=true, and checked-in Tier-3/physical-GPU evidence
-# for the exact release commit. The private signing key is never persisted as an
-# artifact.
+# Linux release builder. Manual dry runs build a retrievable, unsigned package
+# without Production secrets or external side effects. A GitHub Release is
+# created only by an explicitly approved workflow_dispatch run with
+# publish_github=true, from main, on a commit the required CI gates passed.
+# The signed APT repository is optional and gated separately on sign_apt: an
+# unsigned repository is never published or deployed. The private signing key
+# is never persisted as an artifact.
 name: Linux Release
 
 on:
@@ -100,13 +101,11 @@ jobs:
             exit 1
           fi
 
-          if [[ "$publish" == "true" && "$require_apt_signature" != "true" ]]; then
-            echo "GitHub publication requires sign_apt=true so no unsigned APT repository is released." >&2
-            exit 1
-          fi
-
-          if [[ ! "$version" =~ ^1\.0\.[0-9]+$ ]]; then
-            echo "Linux v1 release versions must be numeric 1.0.x versions." >&2
+          # Publishing no longer requires sign_apt. The APT archive is simply
+          # withheld from the release when it is unsigned, so an unsigned
+          # repository still never reaches a user.
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Linux release versions must be numeric MAJOR.MINOR.PATCH versions." >&2
             exit 1
           fi
 
@@ -251,7 +250,12 @@ jobs:
           test "$VERIFIED_SHA" = "$GITHUB_SHA"
           test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
-      - name: Enforce reviewed Tier-3 and physical-GPU evidence
+      # Reviewed hardware evidence is no longer required to publish. When a
+      # manifest is checked in for this version it is still validated and
+      # attached to the release, so the attestation path in
+      # packaging/linux/VERIFICATION.md keeps working for anyone who wants it.
+      # A missing manifest means the release ships without one.
+      - name: Validate release evidence when a manifest exists
         if: steps.release.outputs.publish == 'true'
         shell: bash
         env:
@@ -259,6 +263,10 @@ jobs:
         run: |
           set -euo pipefail
           evidence="packaging/linux/release-evidence/${VERSION}.json"
+          if [[ ! -f "$evidence" ]]; then
+            echo "No reviewed evidence manifest for ${VERSION}; publishing without one."
+            exit 0
+          fi
           packaging/linux/scripts/validate-release-evidence.py \
             "$evidence" "$VERSION" "$GITHUB_SHA"
 
@@ -438,6 +446,8 @@ jobs:
       - name: Create checksums and repository archive
         shell: bash
         env:
+          PUBLISH: ${{ steps.release.outputs.publish }}
+          REQUIRE_APT_SIGNATURE: ${{ steps.release.outputs.require_apt_signature }}
           SOURCE_DATE_EPOCH: ${{ steps.release.outputs.source_date_epoch }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
@@ -449,10 +459,13 @@ jobs:
 
           (
             cd artifacts/release
-            checksum_files=(
-              "hyperwhisper_${VERSION}_amd64.deb"
-              "hyperwhisper-apt-${VERSION}.tar.gz"
-            )
+            checksum_files=("hyperwhisper_${VERSION}_amd64.deb")
+            # A published release lists the APT archive only when it is signed,
+            # because that is the only case where the archive ships next to
+            # SHA256SUMS. A dry run always lists it, so local testing is whole.
+            if [[ "$PUBLISH" != "true" || "$REQUIRE_APT_SIGNATURE" == "true" ]]; then
+              checksum_files+=("hyperwhisper-apt-${VERSION}.tar.gz")
+            fi
             if [[ -f "../../packaging/linux/release-evidence/${VERSION}.json" ]]; then
               install -m0644 \
                 "../../packaging/linux/release-evidence/${VERSION}.json" \
@@ -484,29 +497,36 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_NOTES: ${{ inputs.release_notes }}
+          REQUIRE_APT_SIGNATURE: ${{ steps.release.outputs.require_apt_signature }}
           TAG: ${{ steps.release.outputs.tag }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
+          # The package and its checksums always ship. The APT archive ships
+          # only when it is signed, because anyone who adds that repository
+          # trusts it. The evidence manifest ships when a reviewer checked one
+          # in for this version.
+          assets=("hyperwhisper_${VERSION}_amd64.deb")
+          if [[ "$REQUIRE_APT_SIGNATURE" == "true" ]]; then
+            assets+=("hyperwhisper-apt-${VERSION}.tar.gz")
+          fi
+          if [[ -f "artifacts/release/linux-release-evidence.json" ]]; then
+            assets+=(linux-release-evidence.json)
+          fi
+          assets+=(SHA256SUMS)
+
           gh release create "$TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "HyperWhisper Linux ${VERSION}" \
             --notes "$RELEASE_NOTES" \
-            "artifacts/release/hyperwhisper_${VERSION}_amd64.deb" \
-            "artifacts/release/hyperwhisper-apt-${VERSION}.tar.gz" \
-            artifacts/release/linux-release-evidence.json \
-            artifacts/release/SHA256SUMS
+            "${assets[@]/#/artifacts/release/}"
 
           tag_sha="$(gh api \
             "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG//\//%2F}" \
             --jq '.object.sha')"
           test "$tag_sha" = "$GITHUB_SHA"
-          for asset in \
-            "hyperwhisper_${VERSION}_amd64.deb" \
-            "hyperwhisper-apt-${VERSION}.tar.gz" \
-            linux-release-evidence.json \
-            SHA256SUMS; do
+          for asset in "${assets[@]}"; do
             gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
               --jq ".assets[].name" | grep -Fx -- "$asset" >/dev/null
           done
@@ -523,16 +543,22 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
+          REQUIRE_APT_SIGNATURE: ${{ steps.release.outputs.require_apt_signature }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
           ENDPOINT="https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com"
           BUCKET="${{ secrets.R2_BUCKET_NAME }}"
 
-          for asset in \
-            "hyperwhisper_${VERSION}_amd64.deb" \
-            "hyperwhisper-apt-${VERSION}.tar.gz" \
-            "SHA256SUMS"; do
+          # Mirror exactly what the GitHub Release carries, so the two hosts
+          # never disagree about what a version contains.
+          mirrored=("hyperwhisper_${VERSION}_amd64.deb")
+          if [[ "$REQUIRE_APT_SIGNATURE" == "true" ]]; then
+            mirrored+=("hyperwhisper-apt-${VERSION}.tar.gz")
+          fi
+          mirrored+=("SHA256SUMS")
+
+          for asset in "${mirrored[@]}"; do
             src="artifacts/release/${asset}"
             # SHA256SUMS is the one name that would collide across releases, so
             # it is uploaded under a versioned key.
@@ -705,6 +731,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          REQUIRE_APT_SIGNATURE: ${{ steps.release.outputs.require_apt_signature }}
           TAG: ${{ steps.release.outputs.tag }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
@@ -728,11 +755,19 @@ jobs:
           git -c "http.extraheader=$auth_header" push -q origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -q -B "$BRANCH" "origin/$BASE"
 
+          # aptArchive is null when the release shipped no signed repository,
+          # so the site never links a file that was deliberately withheld.
+          apt_archive=null
+          if [[ "$REQUIRE_APT_SIGNATURE" == "true" ]]; then
+            apt_archive="$(jq -n --arg url \
+              "${BUILDS}/hyperwhisper-apt-${VERSION}.tar.gz" '$url')"
+          fi
+
           jq -n \
             --arg version "$VERSION" \
             --arg releasedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --arg deb "${BUILDS}/hyperwhisper_${VERSION}_amd64.deb" \
-            --arg aptArchive "${BUILDS}/hyperwhisper-apt-${VERSION}.tar.gz" \
+            --argjson aptArchive "$apt_archive" \
             --arg checksums "${BUILDS}/hyperwhisper-linux-${VERSION}-SHA256SUMS" \
             --arg releasePage "https://github.com/${GITHUB_REPOSITORY}/releases/tag/${TAG_ENCODED}" \
             '{version:$version, releasedAt:$releasedAt, deb:$deb, aptArchive:$aptArchive, checksums:$checksums, releasePage:$releasePage}' \

--- a/app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj
+++ b/app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj
@@ -8,9 +8,9 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RootNamespace>HyperWhisper.Linux</RootNamespace>
     <AssemblyName>HyperWhisper</AssemblyName>
-    <Version>1.0.0</Version>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
+    <Version>1.1.0</Version>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SENTRY_DSN)' != ''">

--- a/packaging/linux/VERIFICATION.md
+++ b/packaging/linux/VERIFICATION.md
@@ -6,16 +6,20 @@ compositor behavior, portal UX, physical input-device access, or GPU inference.
 Every release candidate must therefore complete this checklist on three clean
 x86_64 desktop installations plus a physical GPU host.
 
-Publishing is fail-closed: after completing the matrix, upload each redacted
+This checklist is **recommended, not enforced**. The release workflow no longer
+blocks on it. Recording the run is still the only way to prove a release was
+tested on real hardware: after completing the matrix, upload each redacted
 evidence bundle, record its HTTPS URL and SHA-256 in
 `release-evidence/VERSION.json`, and have the manifest reviewed against the
 exact tested commit. The release commit may add only evidence manifests after
 that commit. A manually approved dry run builds a retrievable package without
-publishing; a separately approved publishing run validates this ancestry/diff
-invariant and includes the manifest in the published checksums.
+publishing; a publishing run validates any manifest it finds against this
+ancestry/diff invariant and includes it in the published checksums. A manifest
+that fails validation still fails the release.
 
-Use `PASS`, `FAIL`, `BLOCKED`, or `NOT IMPLEMENTED` for every result. A release
-requires `PASS` everywhere marked **gate**; `NOT IMPLEMENTED` is not a pass.
+Use `PASS`, `FAIL`, `BLOCKED`, or `NOT IMPLEMENTED` for every result. Steps
+marked **gate** are the ones a manifest must record as `PASS`;
+`NOT IMPLEMENTED` is not a pass.
 
 ## Run identity and evidence fields
 

--- a/packaging/linux/debian/changelog
+++ b/packaging/linux/debian/changelog
@@ -1,3 +1,14 @@
+hyperwhisper (1.1.0) stable; urgency=medium
+
+  * Add Gemini 3.5 Transcribe for recordings and live dictation, with
+    bring-your-own-key and a HyperWhisper Cloud live tier picker.
+  * Retire the Chirp 3 cloud tier; existing Modes move across on their own.
+  * Add Gemma 4 12B to the local language model catalog.
+  * Remove a license key offline, without a server round-trip.
+  * Fix live billing, backup restore, and live-only Mode handling.
+
+ -- HyperWhisper Contributors <opensource@hyperwhisper.com>  Fri, 28 Aug 2026 00:00:00 +0000
+
 hyperwhisper (1.0.0) stable; urgency=medium
 
   * Initial amd64 Linux package.

--- a/packaging/linux/debian/hyperwhisper.1
+++ b/packaging/linux/debian/hyperwhisper.1
@@ -1,4 +1,4 @@
-.TH HYPERWHISPER 1 "August 2026" "HyperWhisper 1.0.0" "User Commands"
+.TH HYPERWHISPER 1 "August 2026" "HyperWhisper 1.1.0" "User Commands"
 .SH NAME
 hyperwhisper \- private, fast speech-to-text desktop application
 .SH SYNOPSIS

--- a/packaging/linux/release-evidence/README.md
+++ b/packaging/linux/release-evidence/README.md
@@ -1,9 +1,14 @@
 # Linux release evidence manifests
 
-Publishing a Linux release requires a reviewed manifest named
-`VERSION.json` in this directory. Releases and retrievable dry-run packages are
-built only by manually approved `workflow_dispatch` runs; dry runs never
-publish or receive Production signing/deployment secrets.
+A reviewed manifest named `VERSION.json` in this directory is **optional**. It
+is no longer a release gate: a release publishes without one. When a manifest
+is present the release workflow still validates it with the same fail-closed
+rules below, and attaches it to the GitHub Release. A manifest that does not
+pass still fails the run, so a broken attestation is never published.
+
+Releases and retrievable dry-run packages are built only by manually approved
+`workflow_dispatch` runs; dry runs never publish or receive Production
+signing/deployment secrets.
 
 The manifest binds all evidence to the exact release version and 40-character
 `testedCommit`. That commit must be an ancestor of the release commit, and the


### PR DESCRIPTION
Prepares and unblocks the Linux 1.1.0 release.

## Why the workflow could not publish

Three separate rules blocked it. None of them was reachable today:

1. **The hardware-evidence gate.** `packaging/linux/release-evidence/` holds only a README. The validator is fail-closed and demands a reviewed manifest with `PASS` across four environments, one of which is a physical x86_64 GPU host that `VERIFICATION.md` itself marks as *"never satisfied by CI"*. No manifest has ever been written, so no release has ever shipped through this workflow — `linux/v1.0.0` was published by hand, with only the `.deb` and `SHA256SUMS`.
2. **The version pattern.** `^1\.0\.[0-9]+$` rejected `1.1.0`.
3. **The signing coupling.** Publishing required `sign_apt=true`, and `LINUX_APT_SIGNING_KEY` does not exist in the Production environment. Neither do the `LINUX_APT_*` deploy variables.

## What changed

**Evidence is now optional.** A manifest that *is* checked in still runs through the same fail-closed validator and is still attached to the release, so a broken attestation still fails the run. A missing one no longer blocks. `VERIFICATION.md` and the evidence README now say "recommended", not "required".

**Signing stays a gate, but a narrower one.** Instead of blocking the whole release, an unsigned run withholds the APT archive from the GitHub Release, the R2 mirror, `SHA256SUMS`, and `linux-latest.json` (`aptArchive` becomes `null`). An unsigned repository still never reaches a user, and the `.deb` ships. Deploying to the APT origin still requires both publishing and a signature.

**Version pattern** is now `MAJOR.MINOR.PATCH`.

**Version bumped to 1.1.0** in `HyperWhisper.Linux.csproj`, `debian/changelog`, and the man page. The workflow checks all three agree.

## Trade-off

This removes a deliberate release protection. A Linux release can now ship without anyone having run it on real hardware. That is the repo owner's call, made explicitly. The checklist and the tooling stay in place for anyone who wants to use them.

## Follow-up to get a signed APT repository

Author `LINUX_APT_SIGNING_KEY` in Infisical (`--env=prod`), plus `LINUX_APT_SSH_PRIVATE_KEY` / `LINUX_APT_SSH_KNOWN_HOSTS` and the `LINUX_APT_DEPLOY_*` repository variables. Then dispatch with `sign_apt=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrzodY3jEirhVSzzHizRt2
