### PR TITLE
ci(linux): cache the end-to-end Whisper model and retry the download

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -307,14 +307,36 @@ jobs:
           python3 .github/scripts/test-dotnet-coverage-policy.py
           app/linux/scripts/run-dotnet-coverage.sh
 
+      # The model is immutable and its digest is pinned below, so a cache hit is
+      # always the same bytes. Caching matters because linux-release.yml gates
+      # on this job: a Hugging Face rate limit on one anonymous download used to
+      # fail a release with nothing wrong in the tree.
+      - name: Restore the end-to-end Whisper model
+        id: whisper-model
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/ggml-tiny.en.bin
+          key: whisper-ggml-tiny-en-921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f
+
+      - name: Download the end-to-end Whisper model
+        if: steps.whisper-model.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Hugging Face answers 429 to anonymous downloads under load, and curl
+          # treats that code as retryable once --retry is set.
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-delay 10 \
+            https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin \
+            --output "${RUNNER_TEMP}/ggml-tiny.en.bin"
+
       - name: Verify live PipeWire microphone transcription
         shell: bash
         run: |
           set -euo pipefail
           model_path="${RUNNER_TEMP}/ggml-tiny.en.bin"
-          curl --fail --silent --show-error --location \
-            https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en.bin \
-            --output "$model_path"
+          # Checked on every run, not only after a download, so a truncated or
+          # corrupt cache entry fails here instead of as a transcription bug.
           echo "921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f  $model_path" \
             | sha256sum --check --strict
           HW_E2E_WHISPER_MODEL="$model_path" \


### PR DESCRIPTION
The Linux 1.1.0 release failed on this, with nothing wrong in the tree:

```
curl: (22) The requested URL returned error: 429
```

The `Verify live PipeWire microphone transcription` step downloaded
`ggml-tiny.en.bin` from Hugging Face on every run, with one attempt and no
retry. Hugging Face rate-limits anonymous downloads. `--fail` turns the 429
into exit 22, the job fails, and `linux-release.yml` skips the release job
because of `needs: quality-gates`.

So a third party rate limiter can fail a release. macOS and Windows have no
equivalent dependency.

## What changed

1. **Cache the model** with `actions/cache@v4`, keyed on the SHA-256 that was
   already pinned in the step. The file is immutable, so a hit is always the
   same bytes and the network is skipped entirely.
2. **Retry on a cold cache** with `--retry 5 --retry-delay 10`. curl treats
   429 as retryable once `--retry` is set.
3. **Move the checksum into the test step**, so it runs on a cache hit too. A
   truncated cache entry now fails on the digest rather than surfacing later
   as a transcription failure.

## Scope

CI only. No user-facing code. `.github/scripts/test-linux-release-policy.py`
still finds every fragment it asserts on, including `run-virtual-mic-e2e.sh`.

Validated locally with `actionlint` (clean) and a YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QrzodY3jEirhVSzzHizRt2
