### PR TITLE
chore: remove dead env vars and disambiguate the two Upstash pairs

### DIFF
--- a/hyperwhisper-cloud/.env.example
+++ b/hyperwhisper-cloud/.env.example
@@ -5,12 +5,15 @@ ELEVENLABS_API_KEY=your_elevenlabs_api_key
 XAI_API_KEY=your_xai_api_key
 META_MODEL_API_KEY=your_meta_model_api_key
 
-# Upstash Redis (for rate limiting and credits)
+# Upstash Redis (rate limiting and credits) — THIS SERVICE'S pair. Named
+# WITHOUT the `_REST_` infix the Next.js site uses, which is
+# UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN (see nextjs/.env.example).
+# Both services talk to Upstash over the same REST protocol and the same
+# @upstash/redis client; only the variable names differ. Never cross-wire them.
 UPSTASH_REDIS_URL=https://your-redis.upstash.io
 UPSTASH_REDIS_TOKEN=your_upstash_token
 
 # License Validation
-POLAR_API_KEY=your_polar_api_key
 NEXTJS_LICENSE_API_URL=https://hyperwhisper.com/api/license/validate
 
 # Local development

--- a/hyperwhisper-cloud/src/lib/redis.ts
+++ b/hyperwhisper-cloud/src/lib/redis.ts
@@ -15,6 +15,14 @@ export type { CachedLicense, RedisStore, RedisStoreFactory } from './redis-core'
 // Initialize Redis client (lazy initialization for testing without Redis)
 let _redis: Redis | null = null;
 
+// This is the transcription service's Upstash pair, named WITHOUT the
+// `_REST_` infix the Next.js site uses. That site reads
+// UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN in
+// `nextjs/lib/clients/redis.ts`. Both go through the same @upstash/redis
+// client over the same REST protocol, so a cross-wired value fails silently
+// as a cache that answers the wrong service's keys rather than as a
+// connection error. Keep the two name pairs distinct, and check which
+// service you are in before you touch either one.
 function getRedis(): Redis {
   if (!_redis) {
     const url = process.env.UPSTASH_REDIS_URL;

--- a/nextjs/.env.example
+++ b/nextjs/.env.example
@@ -4,10 +4,6 @@ NEXT_PUBLIC_SITE_URL="http://localhost:3000"
 # Stripe (for billing)
 STRIPE_SECRET_KEY="sk_test_your_stripe_secret_key_here"
 STRIPE_WEBHOOK_SECRET="whsec_your_stripe_webhook_secret_here"
-STRIPE_LICENSE_PRODUCT_ID="prod_your_stripe_license_product_id_here"
-STRIPE_CREDITS_PRODUCT_5="prod_fake5dollarproductxxxxxxxxxxx"
-STRIPE_CREDITS_PRODUCT_10="prod_fake10dollarproductxxxxxxxxxx"
-STRIPE_CREDITS_PRODUCT_20="prod_fake20dollarproductxxxxxxxxxx"
 
 # Internal API secret (shared with Agentic Coding School for license grants)
 HYPERWHISPER_INTERNAL_SECRET="your_internal_shared_secret_here"
@@ -17,12 +13,13 @@ HYPERWHISPER_INTERNAL_SECRET="your_internal_shared_secret_here"
 # latency-retention prune 401s forever.
 CRON_SECRET="your_vercel_cron_secret_here"
 
-# Cloudflare Worker Configuration
-NEXT_PUBLIC_CLOUDFLARE_WORKER_URL="https://transcribe-dev-v1.hyperwhisper.com"
-
 # Resend Email Service
 RESEND_API_KEY="your_resend_api_key_here"
 
-# Upstash Redis
+# Upstash Redis — THIS SITE'S pair. The `_REST_` infix is the whole
+# difference from the Fly transcription service's pair, which is named
+# UPSTASH_REDIS_URL / UPSTASH_REDIS_TOKEN (see hyperwhisper-cloud/.env.example).
+# Both services talk to Upstash over the same REST protocol and the same
+# @upstash/redis client; only the variable names differ. Never cross-wire them.
 UPSTASH_REDIS_REST_URL="https://fake-redis.upstash.io"
 UPSTASH_REDIS_REST_TOKEN="fake_upstash_token"

--- a/nextjs/lib/clients/redis.ts
+++ b/nextjs/lib/clients/redis.ts
@@ -1,5 +1,14 @@
 import { Redis } from "@upstash/redis";
 
+// This is the Next.js site's Upstash pair, and the `_REST_` infix in the two
+// variable names is the only thing that separates it from the Fly
+// transcription service's pair. That service reads UPSTASH_REDIS_URL /
+// UPSTASH_REDIS_TOKEN in `hyperwhisper-cloud/src/lib/redis.ts` — no infix.
+// Both go through the same @upstash/redis client over the same REST
+// protocol, so a cross-wired value fails silently as a cache that answers
+// the wrong service's keys rather than as a connection error. Keep the two
+// name pairs distinct, and check which service you are in before you touch
+// either one.
 const redis = new Redis({
   url: process.env.UPSTASH_REDIS_REST_URL!,
   token: process.env.UPSTASH_REDIS_REST_TOKEN!,

--- a/nextjs/src/env/schema.mjs
+++ b/nextjs/src/env/schema.mjs
@@ -19,9 +19,6 @@ export const serverSchema = z.object({
   // Resend Email
   RESEND_API_KEY: z.string(),
 
-  // HyperWhisper Cloud API (for CF Workers to call credits endpoints)
-  HYPERWHISPER_CLOUD_API_KEY: z.string().optional(),
-
   // Shared secret for internal license endpoints (Agentic Coding School calls
   // /api/internal/grant-license and /api/internal/licenses-for-email with it)
   HYPERWHISPER_INTERNAL_SECRET: z.string().optional(),
@@ -78,9 +75,6 @@ export const serverEnv = {
   // Resend Email
   RESEND_API_KEY: process.env.RESEND_API_KEY,
 
-  // HyperWhisper Cloud API (for CF Workers to call credits endpoints)
-  HYPERWHISPER_CLOUD_API_KEY: process.env.HYPERWHISPER_CLOUD_API_KEY,
-
   // Shared secret for internal license endpoints (Agentic Coding School calls
   // /api/internal/grant-license and /api/internal/licenses-for-email with it)
   HYPERWHISPER_INTERNAL_SECRET: process.env.HYPERWHISPER_INTERNAL_SECRET,
@@ -112,7 +106,6 @@ export const serverEnv = {
 export const clientSchema = z.object({
   NEXT_PUBLIC_ENVIRONMENT: z.enum(["development", "test", "production"]).optional(),
   NEXT_PUBLIC_SITE_URL: z.string().url().optional(),
-  NEXT_PUBLIC_CLOUDFLARE_WORKER_URL: z.string().url(),
   NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
   NEXT_PUBLIC_POSTHOG_HOST: z.string().url().optional(),
 });
@@ -126,7 +119,6 @@ export const clientSchema = z.object({
 export const clientEnv = {
   NEXT_PUBLIC_ENVIRONMENT: process.env.NEXT_PUBLIC_ENVIRONMENT,
   NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,
-  NEXT_PUBLIC_CLOUDFLARE_WORKER_URL: process.env.NEXT_PUBLIC_CLOUDFLARE_WORKER_URL,
   NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
   NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 };


### PR DESCRIPTION
## What

An audit of all 74 Infisical secrets against the code found **8 names that nothing reads**. Six are Infisical-only and get deleted there. This PR removes the two that also live in the repo, plus a third that never had a secret behind it.

### Removed

| Name | Why |
|---|---|
| `NEXT_PUBLIC_CLOUDFLARE_WORKER_URL` | No code reads it. Its value still pointed at `transcribe-dev-v1` while the apps call `transcribe-prod-v2`. |
| `HYPERWHISPER_CLOUD_API_KEY` | Declared in `schema.mjs` only, read nowhere, never present in Infisical. |
| `POLAR_API_KEY` | Left in `hyperwhisper-cloud/.env.example` after the Polar integration was removed. |

**There is no Cloudflare Worker in the stack at all.** No `wrangler` config exists anywhere, and `transcribe-prod-v2.hyperwhisper.com` is a CNAME to `hyperwhisper-transcribe.fly.dev`. Cloudflare is used only for **R2** release artifacts, so `CLOUDFLARE_ACCOUNT_ID`, the R2 keys, and `R2_BUCKET_NAME` all stay.

The worker URL had to leave `clientSchema` in this same commit: it was declared **required** (`z.string().url()`, not `.optional()`), so deleting the secret without this change would have failed the next production build.

### Upstash disambiguation

Two pairs exist because two services each have their own database:

| Pair | Service | Client |
|---|---|---|
| `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` | Next.js site on Vercel | `nextjs/lib/clients/redis.ts` |
| `UPSTASH_REDIS_URL` / `UPSTASH_REDIS_TOKEN` | Fly transcription service | `hyperwhisper-cloud/src/lib/redis.ts` |

Both go through the same `@upstash/redis` client over the same REST protocol, so the `_REST_` infix is the only signal telling them apart. A cross-wired value fails **silently** — as a cache serving the wrong service's keys, not as a connection error. Both clients and both `.env.example` files now state which pair is which and why.

No rename here: renaming would need a coordinated Infisical + Vercel + Fly change and a deploy of both services. Say the word and it can follow.

## Follow-up outside this PR

Delete these 6 from Infisical `prod` (they exist nowhere in the code):

```
infisical secrets delete STRIPE_LICENSE_PRODUCT_ID STRIPE_CREDITS_PRODUCT_5 \
  STRIPE_CREDITS_PRODUCT_10 STRIPE_CREDITS_PRODUCT_20 CLOUDFLARE_WORKER_URL \
  FAKE_LICENSE_KEY --env=prod --path=/ --type=shared
```

Then delete `NEXT_PUBLIC_CLOUDFLARE_WORKER_URL` **after this merges**, never before.

Kept deliberately, despite reading as unused: `ACCESS_TOKEN` and `AXIOM_TOKEN` are live Fly secrets on `hyperwhisper-log-shipper`; `BETTER_AUTH_SECRET` is read by the library itself; the 8 `ASC_*` / `IOS_*` names are used by the private iOS repo. `RESEND_API_KEY` is load-bearing — magic-link sign-in depends on it.

## Testing

- `npx tsc --noEmit` in `nextjs`: **3 errors before, 3 errors after** — the same pre-existing `@tanstack/react-query` / tRPC version mismatches. No regression.
- `tsc --noEmit` in `hyperwhisper-cloud`: clean.
- Grepped the whole tree, the private iOS repo, all workflows, and both Fly apps for every removed name: no remaining references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GLzasoVuLh524EWbvDexj5