### PR TITLE
Stop /latency drawing retired Chirp 3 rows

### DIFF
--- a/nextjs/lib/latency/providers.ts
+++ b/nextjs/lib/latency/providers.ts
@@ -179,6 +179,30 @@ export const KNOWN_PROVIDERS: readonly string[] = STT_CATALOG.map(
   (entry) => entry.sttProvider,
 );
 
+/**
+ * Providers the page no longer draws, even though the window still holds their
+ * rows.
+ *
+ * This is NOT the same as "absent from STT_CATALOG". An unmapped provider
+ * renders under its raw backend id on purpose — that is how something added to
+ * the edge service shows up here immediately, looking unfinished rather than
+ * being silently dropped (see the file header). A RETIRED provider is the
+ * opposite case: the apps dropped it, no client can select it any more, and its
+ * stored rows are history. Drawing it invites a visitor to shop for a provider
+ * their app does not offer, and a raw id like `google-chirp` reads as a row
+ * someone forgot to finish rather than one deliberately left behind.
+ *
+ * Nothing is deleted. The rows stay for the retention the privacy page states,
+ * WINDOW_DAYS ages them out of the aggregate on its own, and this list only
+ * stops them being drawn in the meantime. Ingest already refuses new rows for
+ * them, because KNOWN_PROVIDERS is derived from the catalog above.
+ *
+ *  - `google-chirp` — Google Cloud Speech-to-Text V2 Chirp 3. Replaced by
+ *    geminiTranscribe as the Google HyperWhisper Cloud tier at catalog v8
+ *    (2026-08-27); the app's picker has not offered it since.
+ */
+export const RETIRED_PROVIDERS: readonly string[] = ["google-chirp"];
+
 /** The name the app's Provider dropdown shows for a vendor key. */
 export function vendorDisplayName(vendorKey: string): string {
   const entry = STT_CATALOG.find((candidate) => candidate.vendor === vendorKey);

--- a/nextjs/src/content/latency.ts
+++ b/nextjs/src/content/latency.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { and, eq, gte, sql } from "drizzle-orm";
+import { and, eq, gte, notInArray, sql } from "drizzle-orm";
 
 import { db } from "@/src/db";
 import { sttLatencySamples } from "@/src/db/schema/stt-latency-samples";
@@ -15,6 +15,7 @@ import {
   type LatencyVendorRow,
 } from "@/lib/latency/types";
 import {
+  RETIRED_PROVIDERS,
   STT_CATALOG,
   isDefaultModel,
   modelDisplayName,
@@ -174,6 +175,17 @@ async function queryLatencyMatrix(bucket: DurationBucket): Promise<LatencyMatrix
       and(
         gte(sttLatencySamples.createdAt, since),
         eq(sttLatencySamples.durationBucket, bucket),
+        // Dropped at the scan, not after the aggregate. `google-chirp` falls
+        // through VENDOR_EXPR's else arm to a vendor row of its own, so today
+        // dropping it later would work — but a provider retired while still
+        // mapped to a live vendor would already have moved that vendor's
+        // percentile, and percentiles do not come apart again. Filtering at the
+        // source is correct for both, and keeps the scan on the same index.
+        // `notInArray` is guarded because drizzle renders an empty one as a
+        // contradiction, which would blank the whole page.
+        ...(RETIRED_PROVIDERS.length > 0
+          ? [notInArray(sttLatencySamples.provider, [...RETIRED_PROVIDERS])]
+          : []),
       ),
     )
     .as("attempt");

--- a/nextjs/tests/latency-report-validation.test.ts
+++ b/nextjs/tests/latency-report-validation.test.ts
@@ -118,6 +118,38 @@ test("accepts every provider the page can display", async () => {
   }
 });
 
+test("a retired provider is never also a live one", async () => {
+  const { KNOWN_PROVIDERS, RETIRED_PROVIDERS } = await loadProviders();
+
+  // RETIRED_PROVIDERS is applied as a NOT IN against the whole scan, so an id
+  // that appears in both lists would silently blank a provider the apps still
+  // offer — the page would draw nothing for it and say nothing about why. The
+  // two lists are maintained by hand at opposite ends of a provider's life, so
+  // this is the only thing stopping a retirement being written against the
+  // wrong id.
+  for (const provider of RETIRED_PROVIDERS) {
+    assert.ok(
+      !KNOWN_PROVIDERS.includes(provider),
+      `${provider} is retired but still in the catalog mirror`,
+    );
+  }
+});
+
+test("chirp_3 is retired, so ingest refuses it and the page hides its history", async () => {
+  const { validateSample } = await load();
+  const { RETIRED_PROVIDERS } = await loadProviders();
+
+  // Chirp 3 stopped being selectable at catalog v8 (2026-08-27), but the sweep
+  // that filled this page ran before that, so the 90-day window still holds its
+  // rows. Both halves have to hold: no new rows arrive, and the old ones are
+  // not drawn.
+  assert.ok(RETIRED_PROVIDERS.includes("google-chirp"));
+  assert.deepEqual(
+    validateSample(goodSample({ provider: "google-chirp" })),
+    { reason: "unknown provider" },
+  );
+});
+
 type CatalogFile = {
   providers: {
     sttProvider: string;


### PR DESCRIPTION
## What

The `/latency` table still shows a `google-chirp` / `chirp_3` row, printed under its raw backend id. Chirp 3 stopped being selectable at **catalog v8 (2026-08-27)**, when `geminiTranscribe` replaced it as the Google HyperWhisper Cloud tier — so the row advertises a provider no client can pick, and the raw id reads as a row someone forgot to finish.

## Why it is still there

The rows are real: the August sweep filled them, and `WINDOW_DAYS` is 90, so they would sit on the page until mid-November. Ingest already refuses new ones — `KNOWN_PROVIDERS` derives from the catalog mirror, and the mirror lost the entry with the retirement.

## The change

Adds `RETIRED_PROVIDERS` and drops those rows at the scan.

This is deliberately **not** the same rule as "absent from `STT_CATALOG`". That file renders an unmapped provider under its raw id on purpose, so something added to the edge service shows up here immediately rather than being silently dropped. A retirement is the opposite case, and it needs saying out loud — otherwise the next reader takes the filter for the unknown-provider rule and deletes one of them.

**Nothing is deleted.** The privacy page states a 1-year retention, so the rows stay and the 90-day window ages them out of the aggregate on its own.

Filtered at the scan rather than after the aggregate: `google-chirp` happens to own its vendor row today, but a provider retired while still mapped to a live vendor would already have moved that vendor's percentile, and percentiles do not come apart again.

## Tests

Two added, 29/29 pass:

- a retired id is never also a live one — the filter is a `NOT IN` over the whole scan, so a typo there blanks a working provider silently
- `chirp_3` is refused at ingest *and* hidden on the page

`tsc --noEmit` clean for every latency file. The 3 remaining repo-wide errors are pre-existing, in `TRPCProvider.tsx` and `CustomersClient.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hQrUG6BFrQqR69RbUyvTU