### PR TITLE
fix(macos): History rows all show the newest transcript while recording

### DIFF
--- a/app/macos/hyperwhisper/Views/HistoryView.swift
+++ b/app/macos/hyperwhisper/Views/HistoryView.swift
@@ -301,16 +301,36 @@ private final class HistoryViewModel: ObservableObject {
         }
     }
     @Published private(set) var sections: [HistorySectionSnapshot] = []
-    /// Identity key of the query whose results are currently in `sections`,
-    /// updated atomically with them. The List's `.id` must key off this — not
-    /// the live `searchText`, which changes on every keystroke, ~180ms before
-    /// the debounced results land. Keying off the live text rebuilds the list
-    /// too early (while it still shows the old result set) and then lets
-    /// SwiftUI diff two unrelated result sets inside one NSTableView when the
-    /// results do arrive — which mis-reuses cells: stale row content under new
-    /// section headers and selection tags (the row/detail mismatch bug).
-    /// Excludes fetchLimit so pagination doesn't rebuild the list.
-    @Published private(set) var appliedQueryKey: String = ""
+    /// Identity of the NSTableView-backed List, updated atomically with
+    /// `sections`. The List's `.id` keys off this so the table is REBUILT (not
+    /// diffed) on the two transitions where diffing mis-reuses row views:
+    ///
+    /// 1. The query changed (`queryKey`). Keyed off the query that PRODUCED the
+    ///    current sections — not the live `searchText`, which changes on every
+    ///    keystroke, ~180ms before the debounced results land. Keying off the
+    ///    live text rebuilds too early (while the old result set is still
+    ///    showing) and then lets SwiftUI diff two unrelated result sets inside
+    ///    one NSTableView: stale row content under new section headers and
+    ///    selection tags (the row/detail mismatch bug).
+    /// 2. The newest row changed (`newestRow`). A recording inserts a
+    ///    "processing" row at index 0 and then rewrites it in place a moment
+    ///    later on completion (text, status, duration), with a save — and a
+    ///    reload here — for each step. Under that insert-then-update churn the
+    ///    sidebar List reuses one row view for every row, so the whole day
+    ///    section renders the newest snapshot's preview/time/duration until
+    ///    the view is recreated (the "every row shows the same result until I
+    ///    leave History and come back" bug). Rebuilding on a newest-row change
+    ///    is cheap: the new row is at the top, so the scroll reset is what the
+    ///    user wants anyway.
+    ///
+    /// Excludes fetchLimit, and pagination only appends below the newest row,
+    /// so loading more never rebuilds the list.
+    @Published private(set) var listIdentity = ListIdentity(queryKey: "", newestRow: nil)
+
+    struct ListIdentity: Hashable {
+        let queryKey: String
+        let newestRow: HistoryItemSnapshot?
+    }
     @Published private(set) var loadedObjectIDs: Set<NSManagedObjectID> = []
     @Published private(set) var hasMoreResults: Bool = false
     @Published private(set) var availableModes: [Mode] = []
@@ -422,7 +442,10 @@ private final class HistoryViewModel: ObservableObject {
         // so the result always belongs to the newest applied query — no
         // staleness guard needed.
         sections = result.sections
-        appliedQueryKey = "\(query.searchText)|\(query.dateFilter)"
+        listIdentity = ListIdentity(
+            queryKey: "\(query.searchText)|\(query.dateFilter)",
+            newestRow: result.sections.first?.items.first
+        )
         loadedObjectIDs = result.objectIDs
         hasMoreResults = result.hasMoreResults
         isLoading = false
@@ -586,13 +609,11 @@ private struct HistoryScreen: View, Equatable {
                 }
             }
             .listStyle(.sidebar)
-            // Cheap insurance: rebuild the NSTableView-backed List when the query
-            // changes rather than diffing rows across unrelated result sets.
-            // Keyed off the query that PRODUCED the current sections (set
-            // atomically with them), not the live searchText — see
-            // appliedQueryKey for why keystroke-time rebuilds don't protect
-            // the dangerous transition.
-            .id(viewModel.appliedQueryKey)
+            // Rebuild the NSTableView-backed List (instead of diffing rows in
+            // place) when the query changes or when the newest row changes —
+            // the two transitions where in-place diffing mis-reuses row views.
+            // See ListIdentity for both failure modes.
+            .id(viewModel.listIdentity)
             .background(
                 Group {
                     Button("") {


### PR DESCRIPTION
## Problem

With History open during a recording, every row in the Today section shows the newest transcript's preview, time and duration. The row count is right; only the content is wrong. Switching to another page and back fixes it.

## Cause

A recording writes its transcript in steps: insert a "processing" row at the top, then rewrite that same row on completion. Each save re-queries History and replaces the sections array. Under that insert-then-update churn the NSTableView-backed sidebar `List` diffs rows in place and reuses one row view for every row. Leaving and returning creates a fresh `List`, which is why the rows come back correct.

#40 already rebuilt the `List` (via `.id`) when the search text or date filter changed, for the same row-reuse fault. It did not cover a new row at the top.

## Fix

`HistoryViewModel.appliedQueryKey` becomes `listIdentity`, a `Hashable` value of the applied query key plus the newest row's snapshot. The `List` keys its `.id` off it, so a new top row, or a rewrite of the top row, rebuilds the table instead of diffing it.

- Pagination only appends below the newest row, so load-more still never rebuilds.
- Side effect: when a new recording lands, the list scrolls to the top. The new row is at the top, so that is where the user wants to be.

## Verification

- `HistoryView.swift` compiles clean in a local `xcodebuild` (the link step on my Mac fails on a stale Rust core static library that lacks the new `HwLiveSession` symbols; that is a local artifact, unrelated to this change).
- Not reproduced live: screen capture and the app's local API were unavailable from this session. Manual check: open History, dictate twice; the Today rows must keep their own text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WTh2f7ebdUb8vCS6ntETfw
