### PR TITLE
release(linux): bump version to 1.12.0, in step with Windows

### DIFF
--- a/app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj
+++ b/app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj
@@ -13,9 +13,9 @@
          Linux About page read "Version 1.1.0" and looked like a truncated minor field. Nothing
          generates these three lines, so they are hand-maintained: change them with the Windows
          ones, never on their own. -->
-    <Version>1.11.0</Version>
-    <AssemblyVersion>1.11.0.0</AssemblyVersion>
-    <FileVersion>1.11.0.0</FileVersion>
+    <Version>1.12.0</Version>
+    <AssemblyVersion>1.12.0.0</AssemblyVersion>
+    <FileVersion>1.12.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(SENTRY_DSN)' != ''">

--- a/packaging/linux/debian/changelog
+++ b/packaging/linux/debian/changelog
@@ -1,3 +1,15 @@
+hyperwhisper (1.12.0) stable; urgency=medium
+
+  * Rebuild the Linux onboarding and app UI on the Windows design, and fix
+    the onboarding overlay getting stuck.
+  * Add Microsoft MAI-Transcribe-2 and Meta Muse Voice Transcribe as
+    HyperWhisper Cloud transcription options.
+  * Improve live-dictation accuracy with a shared word-agreement engine.
+  * Fix HyperWhisper Cloud transcription retries running past the
+    expected wait time, and /health reporting a failing provider as healthy.
+
+ -- HyperWhisper Contributors <opensource@hyperwhisper.com>  Mon, 07 Sep 2026 03:43:35 +0000
+
 hyperwhisper (1.1.0) stable; urgency=medium
 
   * Add Gemini 3.5 Transcribe for recordings and live dictation, with


### PR DESCRIPTION
Prepares the Linux 1.12.0 release: syncs `app/linux/HyperWhisper.Linux/HyperWhisper.Linux.csproj` Version/AssemblyVersion/FileVersion with the Windows 1.12.0 csproj (per the existing drift-prevention comment on that field), and adds the matching Debian changelog entry that `linux-release.yml` validates against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)